### PR TITLE
Clear URL hash on reinstall so stale windows don't reopen

### DIFF
--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -582,7 +582,7 @@ export class OsApiClass implements OsApi {
 						this.fs.reinstallOS().then(() => {
 							clearAllPreferences();
 							saveWindows([]);
-							window.location.reload();
+							window.location.replace(window.location.pathname);
 						});
 					}
 				}


### PR DESCRIPTION
## Summary

- The hash routing effect writes the active window ID to the URL (e.g. `#about-terminal`)
- `window.location.reload()` preserves the hash
- On boot, the hash routing code reopens that window — so About Terminal (or any focused window) survives a reinstall
- Fix: use `location.replace(pathname)` to strip the hash and reload cleanly

## Test plan

- [x] Type check clean
- [ ] Manual: open About Terminal, reinstall OS, verify it doesn't reappear