### PR TITLE
Computer Store + My Shelf: three-state ownership model

### DIFF
--- a/src/lib/apps/computer-store/AisleView.svelte
+++ b/src/lib/apps/computer-store/AisleView.svelte
@@ -1,0 +1,525 @@
+<script lang="ts">
+	import ShelfHTML from './ShelfHTML.svelte';
+	import BackWallHTML from './BackWallHTML.svelte';
+	import CounterScene from './CounterScene.svelte';
+	import Hotspot from './Hotspot.svelte';
+	import { CATEGORIES, shelfLineup } from './store-data';
+
+	let { onenter }: { onenter: (view: string) => void } = $props();
+
+	let hot = $state<string | null>(null);
+
+	const shelfT = {
+		games: { scale: 1.0, tilt: 20, x: 12, y: 110 },
+		ent: { scale: 1.0, tilt: -22, x: 0, y: 80 },
+		business: { scale: 1.0, tilt: 0, x: 186, y: 97 },
+		counter: { scale: 1.0, tilt: 0, x: 380, y: 56 }
+	};
+
+	const G = shelfT.games;
+	const E = shelfT.ent;
+	const B = shelfT.business;
+	const C = shelfT.counter;
+
+	const ceilPerspXs = [40, 120, 200, 280, 360, 440, 520, 600, 680];
+	const floorPerspXs = [40, 120, 200, 280, 360, 440, 520, 600, 680];
+	const wallStripeXs = [80, 160, 240, 320, 400, 480, 560, 640];
+
+	const INK = '#0a0a0a';
+	const YELLOW = '#f9bd2b';
+	const ACCENT = '#f54e00';
+</script>
+
+<div class="aisle">
+	<svg
+		viewBox="0 0 720 522"
+		preserveAspectRatio="xMidYMid slice"
+		class="bg-svg"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<!-- PATTERN DEFINITIONS -->
+		<defs>
+			<pattern id="floorTile" x="0" y="0" width="28" height="28" patternUnits="userSpaceOnUse">
+				<rect width="28" height="28" fill="#cbd5cb" />
+				<rect x="0" y="0" width="14" height="14" fill="#b6c0b6" />
+				<rect x="14" y="14" width="14" height="14" fill="#b6c0b6" />
+				<rect x="13" y="0" width="1" height="28" fill="#9aa89a" />
+				<rect x="0" y="13" width="28" height="1" fill="#9aa89a" />
+			</pattern>
+			<pattern id="floorCarpet" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
+				<rect width="36" height="36" fill="#cbd5cb" />
+				<rect x="2" y="2" width="2" height="2" fill="#a8b3a8" />
+				<rect x="14" y="8" width="2" height="2" fill="#a8b3a8" />
+				<rect x="26" y="2" width="2" height="2" fill="#a8b3a8" />
+				<rect x="8" y="18" width="2" height="2" fill="#a8b3a8" />
+				<rect x="20" y="22" width="2" height="2" fill="#a8b3a8" />
+				<rect x="32" y="14" width="2" height="2" fill="#a8b3a8" />
+				<rect x="6" y="30" width="2" height="2" fill="#a8b3a8" />
+				<rect x="22" y="32" width="2" height="2" fill="#a8b3a8" />
+			</pattern>
+		</defs>
+
+		<!-- CEILING -->
+		<rect x="0" y="0" width="720" height="56" fill="#e8c897" />
+		{#each ceilPerspXs as cx (cx)}
+			<line
+				x1={cx}
+				y1="0"
+				x2={cx + (380 - cx) * (56 / 206)}
+				y2="56"
+				stroke="#bca270"
+				stroke-width="1"
+			/>
+		{/each}
+		{#each [14, 30, 44] as cy (cy)}
+			<line x1="0" y1={cy} x2="720" y2={cy} stroke="#bca270" stroke-width="1" />
+		{/each}
+		<line x1="0" y1="56" x2="720" y2="56" stroke={INK} stroke-width="2" />
+
+		<!-- FLUORESCENT LIGHTS -->
+		{#each [160, 360, 560] as lx (lx)}
+			<g>
+				<line x1={lx} y1="56" x2={lx} y2="74" stroke={INK} stroke-width="2" />
+				<rect
+					x={lx - 28}
+					y="74"
+					width="56"
+					height="8"
+					fill="#dcd6c8"
+					stroke={INK}
+					stroke-width="2"
+				/>
+				<rect x={lx - 24} y="76" width="48" height="4" fill="#fff9d6" />
+			</g>
+		{/each}
+
+		<!-- BACK WALL -->
+		<rect x="0" y="56" width="720" height="160" fill="#f5b34f" />
+		<!-- wall stripe trim -->
+		<rect x="0" y="200" width="720" height="6" fill={ACCENT} />
+		<line x1="0" y1="206" x2="720" y2="206" stroke={INK} stroke-width="2" />
+		<!-- wallpaper vertical stripes -->
+		{#each wallStripeXs as wx (wx)}
+			<line x1={wx} y1="56" x2={wx} y2="200" stroke="#e09f3f" stroke-width="1" />
+		{/each}
+
+		<!-- FLOOR -->
+		<rect x="0" y="206" width="720" height="316" fill="#cbd5cb" />
+		{#each floorPerspXs as fx (fx)}
+			<line x1={fx} y1="522" x2="380" y2="206" stroke="#9aa89a" stroke-width="1" />
+		{/each}
+		{#each [230, 260, 300, 350, 410, 478] as fy (fy)}
+			<line x1="0" y1={fy} x2="720" y2={fy} stroke="#9aa89a" stroke-width="1" />
+		{/each}
+
+		<!-- HANGING PROMO SIGNS -->
+		<g>
+			<line x1="80" y1="56" x2="80" y2="62" stroke={INK} stroke-width="2" />
+			<line x1="124" y1="56" x2="124" y2="62" stroke={INK} stroke-width="2" />
+			<polygon
+				points="48,62 156,62 162,76 156,90 48,90 42,76"
+				fill="#a6f000"
+				stroke={INK}
+				stroke-width="2"
+			/>
+			<text
+				x="102"
+				y="82"
+				font-family="'Press Start 2P', monospace"
+				font-size="12"
+				fill={INK}
+				text-anchor="middle"
+				letter-spacing="1.5"
+			>
+				&#x2605; SALE!
+			</text>
+		</g>
+		<g>
+			<line x1="600" y1="56" x2="600" y2="62" stroke={INK} stroke-width="2" />
+			<line x1="644" y1="56" x2="644" y2="62" stroke={INK} stroke-width="2" />
+			<polygon
+				points="568,62 676,62 682,76 676,90 568,90 562,76"
+				fill={YELLOW}
+				stroke={INK}
+				stroke-width="2"
+			/>
+			<text
+				x="622"
+				y="82"
+				font-family="'Press Start 2P', monospace"
+				font-size="11"
+				fill={INK}
+				text-anchor="middle"
+				letter-spacing="1"
+			>
+				&#x2605; NEW
+			</text>
+		</g>
+
+		<!-- SHOPPING BASKET -->
+		<g transform="translate(232 472)">
+			<rect x="-2" y="0" width="8" height="4" fill={INK} />
+			<rect x="22" y="0" width="8" height="4" fill={INK} />
+			<rect x="0" y="2" width="28" height="16" fill="#f9bd2b" stroke={INK} stroke-width="2" />
+			<rect x="3" y="5" width="22" height="11" fill={INK} />
+			<rect x="3" y="6" width="22" height="1" fill="#f9bd2b" />
+			<rect x="3" y="9" width="22" height="1" fill="#f9bd2b" />
+			<rect x="3" y="12" width="22" height="1" fill="#f9bd2b" />
+			<rect x="3" y="15" width="22" height="1" fill="#f9bd2b" />
+		</g>
+
+		<!-- RETRO COMPUTER SHELF (top) + PARTS SHELF (bottom) on back wall -->
+		<g>
+			<!-- TOP SHELF brackets -->
+			<rect x="304" y="150" width="3" height="6" fill="#7a4f2a" />
+			<rect x="416" y="150" width="3" height="6" fill="#7a4f2a" />
+			<rect x="527" y="150" width="3" height="6" fill="#7a4f2a" />
+			<!-- TOP SHELF plank -->
+			<rect x="298" y="148" width="240" height="5" fill="#a06a3a" stroke={INK} stroke-width="2" />
+			<!-- under-shelf shadow -->
+			<rect x="300" y="153" width="236" height="1" fill="rgba(0,0,0,0.18)" />
+
+			<!-- COMPUTER 1: COMMODORE 64 -->
+			<g transform="translate(304 120)">
+				<rect x="6" y="0" width="20" height="11" fill="#3a322a" stroke={INK} stroke-width="2" />
+				<rect x="8" y="2" width="16" height="7" fill="#1e3a4e" />
+				<rect x="9" y="3" width="3" height="1" fill="#a6c8f0" />
+				<rect x="9" y="5" width="7" height="1" fill="#a6c8f0" />
+				<rect x="9" y="7" width="4" height="1" fill="#a6c8f0" />
+				<rect x="14" y="11" width="4" height="2" fill="#3a322a" />
+				<rect x="0" y="14" width="32" height="14" fill="#d4cdb8" stroke={INK} stroke-width="2" />
+				<rect x="2" y="16" width="20" height="1" fill={INK} />
+				<rect x="2" y="18" width="20" height="1" fill={INK} />
+				<rect x="2" y="20" width="20" height="1" fill={INK} />
+				<rect x="2" y="22" width="20" height="1" fill={INK} />
+				<rect x="23" y="16" width="7" height="8" fill="#b88848" stroke={INK} stroke-width="0.5" />
+				<rect x="3" y="25" width="3" height="2" fill="#f54e00" />
+				<rect x="7" y="25" width="3" height="2" fill="#c92127" />
+				<rect x="11" y="25" width="3" height="2" fill="#5e3a8a" />
+			</g>
+
+			<!-- COMPUTER 2: MAC SE -->
+			<g transform="translate(348 120)">
+				<rect x="0" y="0" width="30" height="28" fill="#d4cdb8" stroke={INK} stroke-width="2" />
+				<rect x="1" y="1" width="28" height="2" fill="#e8e0c8" />
+				<rect x="4" y="4" width="22" height="13" fill={INK} />
+				<rect x="6" y="6" width="18" height="9" fill="#1e3a1e" />
+				<rect x="7" y="8" width="4" height="1" fill="#a6f000" />
+				<rect x="12" y="8" width="2" height="1" fill="#a6f000" />
+				<rect x="15" y="8" width="3" height="1" fill="#a6f000" />
+				<rect x="7" y="11" width="6" height="1" fill="#a6f000" />
+				<rect x="14" y="11" width="3" height="1" fill="#a6f000" />
+				<rect x="8" y="21" width="14" height="2" fill={INK} />
+				<rect x="3" y="20" width="1" height="1" fill="#a6f000" />
+				<rect x="3" y="21" width="1" height="1" fill="#f9bd2b" />
+				<rect x="3" y="22" width="1" height="1" fill="#f54e00" />
+				<rect x="3" y="23" width="1" height="1" fill="#c92127" />
+				<rect x="26" y="24" width="2" height="2" fill="#a6f000" />
+			</g>
+
+			<!-- COMPUTER 3: APPLE II -->
+			<g transform="translate(392 120)">
+				<rect x="5" y="0" width="20" height="12" fill="#888888" stroke={INK} stroke-width="2" />
+				<rect x="7" y="2" width="16" height="8" fill="#1e3a1e" />
+				<rect x="8" y="4" width="6" height="1" fill="#a6f000" />
+				<rect x="8" y="6" width="10" height="1" fill="#a6f000" />
+				<rect x="8" y="8" width="4" height="1" fill="#a6f000" />
+				<rect x="13" y="12" width="4" height="2" fill="#888888" />
+				<rect x="0" y="14" width="30" height="14" fill="#d4cdb8" stroke={INK} stroke-width="2" />
+				<rect x="2" y="16" width="20" height="10" fill="#c2b9a0" />
+				<rect x="4" y="18" width="16" height="1" fill={INK} />
+				<rect x="4" y="20" width="16" height="1" fill={INK} />
+				<rect x="4" y="22" width="16" height="1" fill={INK} />
+				<rect x="4" y="24" width="10" height="1" fill={INK} />
+				<rect x="23" y="16" width="5" height="1" fill="#a6f000" />
+				<rect x="23" y="17" width="5" height="1" fill="#f9bd2b" />
+				<rect x="23" y="18" width="5" height="1" fill="#f54e00" />
+				<rect x="23" y="19" width="5" height="1" fill="#c92127" />
+				<rect x="23" y="20" width="5" height="1" fill="#5e3a8a" />
+			</g>
+
+			<!-- COMPUTER 4: TRS-80 -->
+			<g transform="translate(440 118)">
+				<rect x="0" y="0" width="32" height="30" fill="#7a7a7a" stroke={INK} stroke-width="2" />
+				<rect x="1" y="1" width="30" height="2" fill="#9a9a9a" />
+				<rect x="3" y="3" width="26" height="14" fill={INK} />
+				<rect x="5" y="5" width="22" height="10" fill="#3a2818" />
+				<rect x="7" y="7" width="6" height="1" fill="#f9bd2b" />
+				<rect x="7" y="9" width="12" height="1" fill="#f9bd2b" />
+				<rect x="7" y="11" width="4" height="1" fill="#f9bd2b" />
+				<rect x="7" y="13" width="2" height="1" fill="#f9bd2b" />
+				<rect x="2" y="19" width="28" height="8" fill="#5a5a5a" />
+				<rect x="4" y="20" width="24" height="1" fill={INK} />
+				<rect x="4" y="22" width="24" height="1" fill={INK} />
+				<rect x="4" y="24" width="24" height="1" fill={INK} />
+				<rect x="4" y="27" width="8" height="2" fill={INK} />
+				<rect x="5" y="27" width="1" height="2" fill="#f9bd2b" />
+				<rect x="7" y="27" width="1" height="2" fill="#f9bd2b" />
+				<rect x="9" y="27" width="1" height="2" fill="#f9bd2b" />
+				<rect x="27" y="20" width="2" height="2" fill="#f54e00" />
+			</g>
+
+			<!-- COMPUTER 5: IBM PC -->
+			<g transform="translate(488 118)">
+				<rect x="5" y="0" width="22" height="14" fill="#3a322a" stroke={INK} stroke-width="2" />
+				<rect x="7" y="2" width="18" height="10" fill="#1e3a1e" />
+				<rect x="8" y="4" width="3" height="1" fill="#a6f000" />
+				<rect x="8" y="6" width="2" height="1" fill="#a6f000" />
+				<rect x="8" y="8" width="6" height="1" fill="#a6f000" />
+				<rect x="11" y="14" width="10" height="2" fill="#3a322a" />
+				<rect x="0" y="16" width="32" height="14" fill="#d4cdb8" stroke={INK} stroke-width="2" />
+				<rect x="1" y="17" width="30" height="2" fill="#e8e0c8" />
+				<rect x="3" y="20" width="14" height="3" fill={INK} />
+				<rect x="3" y="24" width="14" height="3" fill={INK} />
+				<rect x="20" y="21" width="9" height="3" fill="#5e3a8a" />
+				<rect x="21" y="22" width="2" height="1" fill="#ffffff" />
+				<rect x="24" y="22" width="2" height="1" fill="#ffffff" />
+				<rect x="27" y="22" width="2" height="1" fill="#ffffff" />
+				<rect x="27" y="26" width="2" height="2" fill="#a6f000" />
+			</g>
+
+			<!-- BOTTOM SHELF: random boxes of computer parts -->
+			<g>
+				<!-- shelf plank -->
+				<rect x="298" y="174" width="240" height="4" fill="#a06a3a" stroke={INK} stroke-width="2" />
+				<rect x="300" y="178" width="236" height="1" fill="rgba(0,0,0,0.18)" />
+
+				<!-- stack of floppy disks -->
+				<g transform="translate(306 156)">
+					<rect x="0" y="0" width="14" height="3" fill="#2a3a5a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="3" width="14" height="3" fill="#3a2818" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="6" width="14" height="3" fill="#5e3a8a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="9" width="14" height="3" fill="#c92127" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="12" width="14" height="3" fill="#2a5a2a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="15" width="14" height="3" fill="#3a2818" stroke={INK} stroke-width="0.5" />
+				</g>
+
+				<!-- CABLES box -->
+				<g transform="translate(326 160)">
+					<rect x="0" y="0" width="22" height="14" fill="#c8a06a" stroke={INK} stroke-width="1.5" />
+					<rect x="0" y="5" width="22" height="1" fill="#7a4f2a" />
+					<rect x="2" y="2" width="18" height="3" fill="#ffffff" />
+					<rect x="4" y="3" width="2" height="1" fill={INK} />
+					<rect x="7" y="3" width="2" height="1" fill={INK} />
+					<rect x="10" y="3" width="2" height="1" fill={INK} />
+					<rect x="13" y="3" width="2" height="1" fill={INK} />
+				</g>
+
+				<!-- RAM sticks standing up -->
+				<g transform="translate(354 156)">
+					<rect x="0" y="0" width="3" height="18" fill="#2a5a2a" stroke={INK} stroke-width="0.5" />
+					<rect x="4" y="0" width="3" height="18" fill="#2a5a2a" stroke={INK} stroke-width="0.5" />
+					<rect x="8" y="0" width="3" height="18" fill="#2a5a2a" stroke={INK} stroke-width="0.5" />
+					<rect x="12" y="0" width="3" height="18" fill="#2a5a2a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="16" width="15" height="2" fill="#f9bd2b" />
+				</g>
+
+				<!-- hard drive / power supply -->
+				<g transform="translate(376 160)">
+					<rect x="0" y="0" width="22" height="14" fill="#5a5a5a" stroke={INK} stroke-width="1.5" />
+					<rect x="1" y="1" width="20" height="3" fill="#3a3a3a" />
+					<rect x="2" y="6" width="18" height="1" fill="#3a3a3a" />
+					<rect x="2" y="9" width="18" height="1" fill="#3a3a3a" />
+					<rect x="2" y="12" width="6" height="1" fill="#3a3a3a" />
+					<rect x="18" y="12" width="2" height="1" fill="#a6f000" />
+				</g>
+
+				<!-- DRIVES box (tilted) -->
+				<g transform="translate(404 156) rotate(-4)">
+					<rect x="0" y="0" width="24" height="18" fill="#a88848" stroke={INK} stroke-width="1.5" />
+					<rect x="0" y="6" width="24" height="1" fill="#7a4f2a" />
+					<rect x="2" y="2" width="20" height="3" fill="#ffffff" />
+					<rect x="4" y="3" width="2" height="1" fill={INK} />
+					<rect x="7" y="3" width="2" height="1" fill={INK} />
+					<rect x="10" y="3" width="2" height="1" fill={INK} />
+					<rect x="13" y="3" width="2" height="1" fill={INK} />
+					<rect x="16" y="3" width="2" height="1" fill={INK} />
+					<rect x="0" y="10" width="24" height="1" fill="#d4c08a" />
+				</g>
+
+				<!-- CD/disk pile -->
+				<g transform="translate(434 162)">
+					<rect x="0" y="0" width="11" height="11" fill="#dcdcdc" stroke={INK} stroke-width="0.5" />
+					<rect x="2" y="2" width="7" height="7" fill="#1e3a4e" />
+					<rect x="4" y="4" width="3" height="3" fill={INK} />
+					<rect x="1" y="11" width="10" height="1" fill="#dcdcdc" stroke={INK} stroke-width="0.5" />
+				</g>
+
+				<!-- manuals stack -->
+				<g transform="translate(450 156)">
+					<rect x="0" y="0" width="20" height="3" fill="#c92127" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="3" width="20" height="3" fill="#2a3a8a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="6" width="20" height="3" fill="#5e3a8a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="9" width="20" height="3" fill="#2a5a2a" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="12" width="20" height="3" fill="#a04030" stroke={INK} stroke-width="0.5" />
+					<rect x="0" y="15" width="20" height="3" fill="#c92127" stroke={INK} stroke-width="0.5" />
+				</g>
+
+				<!-- PARTS box -->
+				<g transform="translate(478 160)">
+					<rect x="0" y="0" width="26" height="14" fill="#c8a06a" stroke={INK} stroke-width="1.5" />
+					<rect x="0" y="5" width="26" height="1" fill="#7a4f2a" />
+					<rect x="2" y="2" width="22" height="3" fill="#ffffff" />
+					<rect x="4" y="3" width="2" height="1" fill={INK} />
+					<rect x="7" y="3" width="2" height="1" fill={INK} />
+					<rect x="10" y="3" width="2" height="1" fill={INK} />
+					<rect x="13" y="3" width="2" height="1" fill={INK} />
+					<rect x="16" y="3" width="2" height="1" fill={INK} />
+					<rect x="19" y="3" width="2" height="1" fill={INK} />
+					<rect
+						x="13"
+						y="-3"
+						width="14"
+						height="5"
+						fill="#f9bd2b"
+						stroke={INK}
+						stroke-width="0.5"
+						transform="rotate(-6 20 0)"
+					/>
+				</g>
+
+				<!-- shelf-2 brackets -->
+				<rect x="304" y="178" width="3" height="3" fill="#7a4f2a" />
+				<rect x="416" y="178" width="3" height="3" fill="#7a4f2a" />
+				<rect x="527" y="178" width="3" height="3" fill="#7a4f2a" />
+			</g>
+		</g>
+
+		<!-- DOORMAT -->
+		<rect x="280" y="490" width="160" height="20" fill="#7a4f2a" stroke={INK} stroke-width="2" />
+		<text
+			x="360"
+			y="504"
+			font-family="'Press Start 2P', monospace"
+			font-size="9"
+			fill={YELLOW}
+			text-anchor="middle"
+		>
+			&#x25B8; WELCOME &#x25C2;
+		</text>
+	</svg>
+
+	<!-- SHELVES + BOXES (HTML overlay) -->
+	<ShelfHTML
+		side="left"
+		apps={shelfLineup('games', 6)}
+		label="GAMES"
+		color={CATEGORIES.games.color}
+		gap={G.x}
+		top={G.y}
+		width={232 * G.scale}
+		boxW={68 * G.scale}
+		boxH={96 * G.scale}
+		tilt={G.tilt}
+	/>
+	<ShelfHTML
+		side="right"
+		apps={shelfLineup('ent', 6)}
+		label="ENTERTAINMENT"
+		color={CATEGORIES.ent.color}
+		gap={E.x}
+		top={E.y}
+		width={184 * E.scale}
+		boxW={52 * E.scale}
+		boxH={76 * E.scale}
+		tilt={E.tilt}
+	/>
+	<BackWallHTML
+		apps={shelfLineup('business', 6)}
+		label="BUSINESS"
+		color={CATEGORIES.business.color}
+		left={B.x}
+		top={B.y}
+		width={108 * B.scale}
+		boxW={24 * B.scale}
+		boxH={30 * B.scale}
+		tilt={B.tilt}
+	/>
+	<CounterScene scale={C.scale} tilt={C.tilt} x={C.x} y={C.y} />
+
+	<!-- CLICKABLE HOTSPOTS -->
+	<Hotspot
+		id="games"
+		left="0%"
+		top="26%"
+		width="35%"
+		height="56%"
+		label="GAMES AISLE"
+		sublabel="Adventure · Puzzle · Card"
+		{hot}
+		onenter={() => (hot = 'games')}
+		onleave={() => (hot = null)}
+		onclick={() => onenter('games')}
+	/>
+	<Hotspot
+		id="ent"
+		left="74%"
+		top="21%"
+		width="26%"
+		height="56%"
+		label="ENTERTAINMENT"
+		sublabel="TV · Chat · Multimedia"
+		{hot}
+		onenter={() => (hot = 'ent')}
+		onleave={() => (hot = null)}
+		onclick={() => onenter('ent')}
+	/>
+	<Hotspot
+		id="business"
+		left="29%"
+		top="13%"
+		width="24%"
+		height="28%"
+		label="BUSINESS"
+		sublabel="Productivity · Tools"
+		{hot}
+		onenter={() => (hot = 'business')}
+		onleave={() => (hot = null)}
+		onclick={() => onenter('business')}
+	/>
+	<Hotspot
+		id="counter"
+		left="52%"
+		top="14%"
+		width="24%"
+		height="34%"
+		label="CHECKOUT"
+		sublabel="Take your cart up here"
+		{hot}
+		onenter={() => (hot = 'counter')}
+		onleave={() => (hot = null)}
+		onclick={() => onenter('counter')}
+	/>
+
+	<!-- Idle hint -->
+	<div class="idle-hint">click an aisle · step closer</div>
+</div>
+
+<style>
+	.aisle {
+		position: absolute;
+		inset: 0;
+		background: #f5b34f;
+		overflow: hidden;
+	}
+	.bg-svg {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+	}
+	.idle-hint {
+		position: absolute;
+		left: 50%;
+		bottom: 8px;
+		transform: translateX(-50%);
+		background: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 4px 10px;
+		font-family: 'VT323', monospace;
+		font-size: 14px;
+		letter-spacing: 0.02em;
+		white-space: nowrap;
+	}
+</style>

--- a/src/lib/apps/computer-store/AisleView.svelte
+++ b/src/lib/apps/computer-store/AisleView.svelte
@@ -3,23 +3,34 @@
 	import BackWallHTML from './BackWallHTML.svelte';
 	import CounterScene from './CounterScene.svelte';
 	import Hotspot from './Hotspot.svelte';
+	import ShelfTweaksPanel from './ShelfTweaksPanel.svelte';
 	import { CATEGORIES, shelfLineup } from './store-data';
 
-	let { onenter }: { onenter: (view: string) => void } = $props();
+	let {
+		onenter,
+		shelfT,
+		tweaksOpen = false,
+		onopentweaks,
+		onclosetweaks,
+		onupdatetweaks
+	}: {
+		onenter: (view: string) => void;
+		shelfT: Record<string, { scale: number; tilt: number; x: number; y: number }>;
+		tweaksOpen?: boolean;
+		onopentweaks?: () => void;
+		onclosetweaks?: () => void;
+		onupdatetweaks?: (
+			id: string,
+			patch: Partial<{ scale: number; tilt: number; x: number; y: number }>
+		) => void;
+	} = $props();
 
 	let hot = $state<string | null>(null);
 
-	const shelfT = {
-		games: { scale: 1.0, tilt: 20, x: 12, y: 110 },
-		ent: { scale: 1.0, tilt: -22, x: 0, y: 80 },
-		business: { scale: 1.0, tilt: 0, x: 186, y: 97 },
-		counter: { scale: 1.0, tilt: 0, x: 380, y: 56 }
-	};
-
-	const G = shelfT.games;
-	const E = shelfT.ent;
-	const B = shelfT.business;
-	const C = shelfT.counter;
+	const G = $derived(shelfT.games);
+	const E = $derived(shelfT.ent);
+	const B = $derived(shelfT.business);
+	const C = $derived(shelfT.counter);
 
 	const ceilPerspXs = [40, 120, 200, 280, 360, 440, 520, 600, 680];
 	const floorPerspXs = [40, 120, 200, 280, 360, 440, 520, 600, 680];
@@ -493,6 +504,16 @@
 
 	<!-- Idle hint -->
 	<div class="idle-hint">click an aisle · step closer</div>
+
+	{#if onopentweaks && onclosetweaks && onupdatetweaks}
+		<ShelfTweaksPanel
+			open={tweaksOpen}
+			onopen={onopentweaks}
+			onclose={onclosetweaks}
+			tweaks={shelfT}
+			onupdate={onupdatetweaks}
+		/>
+	{/if}
 </div>
 
 <style>

--- a/src/lib/apps/computer-store/BackWallHTML.svelte
+++ b/src/lib/apps/computer-store/BackWallHTML.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import MiniShelfBox from './MiniShelfBox.svelte';
+	import type { StoreApp } from './store-data';
+
+	let {
+		apps,
+		label,
+		color,
+		left = 220,
+		top = 114,
+		width = 108,
+		boxW = 24,
+		boxH = 30,
+		tilt = 0
+	}: {
+		apps: StoreApp[];
+		label: string;
+		color: string;
+		left?: number;
+		top?: number;
+		width?: number;
+		boxW?: number;
+		boxH?: number;
+		tilt?: number;
+	} = $props();
+
+	const top3 = $derived(apps.slice(0, 3));
+	const bottom3 = $derived(apps.slice(3, 6));
+	const headerFontSize = $derived(Math.max(6, Math.round(boxW * 0.3)));
+</script>
+
+<div
+	class="back-wall"
+	style:left="{left}px"
+	style:top="{top}px"
+	style:width="{width}px"
+	style:transform={tilt ? `perspective(1400px) rotateY(${tilt}deg)` : undefined}
+>
+	<div class="header" style:background={color} style:font-size="{headerFontSize}px">
+		{label}
+	</div>
+	<div class="body">
+		<div class="tier">
+			{#each top3 as app, i (i)}
+				<MiniShelfBox {app} w={boxW} h={boxH} />
+			{/each}
+		</div>
+		<div class="plank"></div>
+		<div class="tier">
+			{#each bottom3 as app, i (i)}
+				<MiniShelfBox {app} w={boxW} h={boxH} />
+			{/each}
+		</div>
+		<div class="plank bottom"></div>
+	</div>
+</div>
+
+<style>
+	.back-wall {
+		position: absolute;
+		display: flex;
+		flex-direction: column;
+		z-index: 2;
+		transform-origin: 50% 50%;
+	}
+	.header {
+		color: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 3px 4px;
+		font-family: 'Press Start 2P', monospace;
+		letter-spacing: 0.04em;
+		text-align: center;
+		white-space: nowrap;
+		flex-shrink: 0;
+		z-index: 2;
+	}
+	.body {
+		background: #a06a3a;
+		border: 2px solid #0a0a0a;
+		border-top: none;
+		box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.2);
+		padding: 4px 4px 0;
+		display: flex;
+		flex-direction: column;
+		position: relative;
+	}
+	.tier {
+		display: flex;
+		gap: 2px;
+		justify-content: center;
+		align-items: flex-end;
+	}
+	.plank {
+		height: 3px;
+		background: #7a4f2a;
+		border-top: 1px solid #0a0a0a;
+		border-bottom: 1px solid #0a0a0a;
+		margin: 3px -6px;
+	}
+	.plank.bottom {
+		margin-bottom: 0;
+	}
+</style>

--- a/src/lib/apps/computer-store/BoxDetailModal.svelte
+++ b/src/lib/apps/computer-store/BoxDetailModal.svelte
@@ -30,7 +30,13 @@
 		const boxKey = CAT_TO_BOX[catId];
 		return boxKey ? (CAT_COLORS[boxKey]?.band ?? INK) : INK;
 	});
+
+	function onkeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+	}
 </script>
+
+<svelte:window {onkeydown} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/apps/computer-store/BoxDetailModal.svelte
+++ b/src/lib/apps/computer-store/BoxDetailModal.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+	import SoftwareBox from './SoftwareBox.svelte';
+	import { type StoreApp, CATEGORIES, CAT_COLORS } from './store-data';
+
+	const INK = '#0a0a0a';
+
+	const CAT_TO_BOX: Record<string, string> = { games: 'GAMES', business: 'PROD', ent: 'ENT' };
+
+	let {
+		app,
+		owned = false,
+		inCart = false,
+		onclose,
+		onaddtocart,
+		onremovefromcart,
+		onreturn
+	}: {
+		app: StoreApp;
+		owned?: boolean;
+		inCart?: boolean;
+		onclose: () => void;
+		onaddtocart: () => void;
+		onremovefromcart: () => void;
+		onreturn: () => void;
+	} = $props();
+
+	const bandColor = $derived.by(() => {
+		const catId = Object.keys(CATEGORIES).find((k) => CATEGORIES[k].appIds.includes(app.id));
+		if (!catId) return INK;
+		const boxKey = CAT_TO_BOX[catId];
+		return boxKey ? (CAT_COLORS[boxKey]?.band ?? INK) : INK;
+	});
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="scrim" onclick={onclose}>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="modal" onclick={(e) => e.stopPropagation()}>
+		<!-- header -->
+		<div class="header">
+			<span>◂ YOU PICKED IT UP</span>
+			<button class="close-btn" onclick={onclose}>× PUT BACK</button>
+		</div>
+
+		<!-- body -->
+		<div class="body">
+			<div class="box-col">
+				<SoftwareBox {app} width={170} height={228} hoverable={false} lift />
+				<div class="price"><span class="price-label">$0.00</span></div>
+			</div>
+
+			<div class="info-col">
+				<div class="app-title">{app.title}</div>
+				<div class="publisher" style:color={bandColor}>{app.pub}</div>
+
+				<div class="back-copy">{app.back}</div>
+
+				<div class="section-header">WHAT'S INSIDE:</div>
+				<ul class="inside-list">
+					{#each app.inside as line, i (i)}
+						<li>▸ {line}</li>
+					{/each}
+				</ul>
+
+				<div class="section-header reqs-header">REQUIRES:</div>
+				<div class="reqs-text">{app.reqs}</div>
+			</div>
+		</div>
+
+		<!-- actions -->
+		<div class="actions">
+			{#if owned}
+				<div class="chip chip-owned">● ALREADY OWNED</div>
+				<button class="btn btn-warn" onclick={onreturn}>RETURN TO STORE</button>
+				<button class="btn btn-plain ml-auto" onclick={onclose}>◂ PUT BACK</button>
+			{:else if inCart}
+				<div class="chip chip-cart">● IN YOUR CART</div>
+				<button class="btn btn-warn" onclick={onremovefromcart}>TAKE OUT OF CART</button>
+				<button class="btn btn-plain ml-auto" onclick={onclose}>◂ PUT BACK</button>
+			{:else}
+				<button class="btn btn-primary" onclick={onaddtocart}>▸ ADD TO CART</button>
+				<button class="btn btn-plain ml-auto" onclick={onclose}>◂ PUT BACK ON SHELF</button>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.scrim {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.modal {
+		width: 560px;
+		max-width: 92%;
+		background: #ffffff;
+		border: 3px solid #0a0a0a;
+		box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.55);
+		display: flex;
+		flex-direction: column;
+		font-family: 'Pixelify Sans', sans-serif;
+	}
+
+	.header {
+		background: #0a0a0a;
+		color: #ffffff;
+		padding: 8px 12px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 10px;
+		letter-spacing: 0.04em;
+	}
+
+	.close-btn {
+		background: #ffffff;
+		color: #0a0a0a;
+		border: none;
+		font-family: inherit;
+		font-size: 10px;
+		padding: 3px 8px;
+		cursor: pointer;
+	}
+
+	.body {
+		display: flex;
+		padding: 18px;
+		gap: 18px;
+	}
+
+	.box-col {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.price {
+		font-family: 'VT323', monospace;
+		font-size: 13px;
+		color: rgba(0, 0, 0, 0.55);
+		text-align: center;
+	}
+
+	.price-label {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+	}
+
+	.info-col {
+		flex: 1;
+		min-width: 0;
+		font-family: 'VT323', monospace;
+		font-size: 16px;
+		line-height: 1.3;
+	}
+
+	.app-title {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 14px;
+		margin-bottom: 6px;
+	}
+
+	.publisher {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+		margin-bottom: 10px;
+		letter-spacing: 0.04em;
+	}
+
+	.back-copy {
+		background: #f7f4ec;
+		border-left: 4px solid #0a0a0a;
+		padding: 8px 12px;
+		margin-bottom: 14px;
+		font-size: 16px;
+		line-height: 1.35;
+	}
+
+	.section-header {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+		margin-bottom: 4px;
+		color: #0a0a0a;
+	}
+
+	.reqs-header {
+		margin-top: 10px;
+	}
+
+	.inside-list {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.inside-list li {
+		padding: 1px 0;
+	}
+
+	.reqs-text {
+		font-family: 'VT323', monospace;
+		font-size: 16px;
+	}
+
+	.actions {
+		padding: 12px 18px;
+		border-top: 2px solid #0a0a0a;
+		background: #f7f4ec;
+		display: flex;
+		gap: 10px;
+		align-items: center;
+		flex-wrap: wrap;
+	}
+
+	.chip {
+		border: 2px solid #0a0a0a;
+		padding: 5px 8px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+	}
+
+	.chip-owned {
+		background: #a6f000;
+	}
+
+	.chip-cart {
+		background: #f9bd2b;
+	}
+
+	.btn {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 10px;
+		letter-spacing: 0.04em;
+		padding: 8px 12px;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		cursor: pointer;
+	}
+
+	.btn-primary {
+		background: #f54e00;
+		color: #ffffff;
+	}
+
+	.btn-warn {
+		background: #f9bd2b;
+		color: #0a0a0a;
+	}
+
+	.btn-plain {
+		background: #ffffff;
+		color: #0a0a0a;
+	}
+
+	.ml-auto {
+		margin-left: auto;
+	}
+</style>

--- a/src/lib/apps/computer-store/CardboardBox.svelte
+++ b/src/lib/apps/computer-store/CardboardBox.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	let { w, h, shade = 'light' }: { w: number; h: number; shade?: 'light' | 'dark' } = $props();
+
+	const bg = $derived(shade === 'dark' ? '#a88848' : '#c8a06a');
+</script>
+
+<div class="cardboard" style:width="{w}px" style:height="{h}px" style:background={bg}>
+	<div class="tape"></div>
+	<div class="seam"></div>
+</div>
+
+<style>
+	.cardboard {
+		border: 2px solid #0a0a0a;
+		position: relative;
+		flex-shrink: 0;
+		box-shadow: 0 2px 0 rgba(0, 0, 0, 0.15);
+	}
+	.tape {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 40%;
+		height: 1px;
+		background: #7a4f2a;
+	}
+	.seam {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 50%;
+		width: 1px;
+		background: #7a4f2a;
+	}
+</style>

--- a/src/lib/apps/computer-store/CategoryCloseup.svelte
+++ b/src/lib/apps/computer-store/CategoryCloseup.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import SoftwareBox from './SoftwareBox.svelte';
+	import { CATEGORIES, APP_BY_ID, type StoreApp, type CategoryId } from './store-data';
+
+	let {
+		categoryId,
+		cart,
+		owned,
+		onpickup
+	}: {
+		categoryId: CategoryId;
+		cart: string[];
+		owned: string[];
+		onpickup: (app: StoreApp) => void;
+	} = $props();
+
+	const cat = $derived(CATEGORIES[categoryId]);
+	const apps = $derived(cat.appIds.map((id) => APP_BY_ID[id]));
+</script>
+
+<div class="closeup">
+	<div class="wall"></div>
+
+	<!-- Hanging aisle sign -->
+	<div class="sign-wrap">
+		<div class="cord left-cord"></div>
+		<div class="cord right-cord"></div>
+		<div class="sign" style:background={cat.color}>
+			AISLE &middot; {cat.label}
+			<div class="sign-tagline">{cat.tagline}</div>
+		</div>
+	</div>
+
+	<!-- Shelf and boxes -->
+	<div class="shelf-area">
+		<div class="boxes">
+			{#each apps as app (app.id)}
+				<SoftwareBox
+					{app}
+					onclick={() => onpickup(app)}
+					status={owned.includes(app.id)
+						? 'installed'
+						: cart.includes(app.id)
+							? 'in-cart'
+							: undefined}
+				/>
+			{/each}
+		</div>
+		<div class="shelf-plank"></div>
+		<div class="shelf-shadow"></div>
+
+		<!-- Manager's Special rail -->
+		<div class="mgr-special">
+			<span class="mgr-label">&#x2605; MGR. SPECIAL</span>
+			<span class="mgr-dash">&mdash;</span>
+			<span class="mgr-text">everything in this aisle is $0.00 (tips welcome)</span>
+		</div>
+	</div>
+</div>
+
+<style>
+	.closeup {
+		position: absolute;
+		inset: 0;
+		background: #f5b34f;
+		overflow: hidden;
+	}
+	.wall {
+		position: absolute;
+		inset: 0;
+		background: repeating-linear-gradient(90deg, #f5b34f 0 78px, #e8a73f 78px 80px);
+	}
+	.sign-wrap {
+		position: absolute;
+		left: 50%;
+		top: 14px;
+		transform: translateX(-50%);
+		z-index: 2;
+	}
+	.cord {
+		position: absolute;
+		top: -14px;
+		width: 2px;
+		height: 14px;
+		background: #0a0a0a;
+	}
+	.left-cord {
+		left: 20px;
+	}
+	.right-cord {
+		right: 20px;
+	}
+	.sign {
+		color: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		padding: 8px 22px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 12px;
+		letter-spacing: 0.06em;
+		text-align: center;
+		white-space: nowrap;
+	}
+	.sign-tagline {
+		font-family: 'VT323', monospace;
+		font-size: 13px;
+		color: rgba(255, 255, 255, 0.85);
+		margin-top: 4px;
+		letter-spacing: 0;
+		white-space: nowrap;
+	}
+	.shelf-area {
+		position: absolute;
+		left: 24px;
+		right: 24px;
+		bottom: 24px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+	.boxes {
+		display: flex;
+		align-items: flex-end;
+		gap: 18px;
+		margin-bottom: 0;
+	}
+	.shelf-plank {
+		width: 100%;
+		height: 14px;
+		background: #a06a3a;
+		border: 2px solid #0a0a0a;
+		box-shadow: 0 4px 0 #7a4f2a;
+		margin-top: 0;
+	}
+	.shelf-shadow {
+		width: 92%;
+		height: 6px;
+		background: rgba(0, 0, 0, 0.18);
+		margin-top: 10px;
+	}
+	.mgr-special {
+		margin-top: 10px;
+		background: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		padding: 6px 14px;
+		font-family: 'VT323', monospace;
+		font-size: 15px;
+		text-align: center;
+		max-width: 540px;
+	}
+	.mgr-label {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+		color: #f54e00;
+		letter-spacing: 0.04em;
+	}
+	.mgr-dash {
+		margin: 0 8px;
+	}
+</style>

--- a/src/lib/apps/computer-store/ComputerStoreWindow.svelte
+++ b/src/lib/apps/computer-store/ComputerStoreWindow.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	import type { TerminalFS } from '$lib/terminalos';
+	import type { OsApi } from '$lib/os/os-api';
+	import TopBar from './TopBar.svelte';
+	import AisleView from './AisleView.svelte';
+	import CategoryCloseup from './CategoryCloseup.svelte';
+	import CounterView from './CounterView.svelte';
+	import BoxDetailModal from './BoxDetailModal.svelte';
+	import ReceiptOverlay from './ReceiptOverlay.svelte';
+	import { CATEGORIES, APP_BY_ID, type StoreApp, type CategoryId } from './store-data';
+
+	let { os, fs }: { os: OsApi; fs: TerminalFS } = $props();
+
+	let view = $state<string>('aisle');
+	let cart = $state<string[]>([]);
+	let pickedUp = $state<StoreApp | null>(null);
+	let receipt = $state<{ items: string[] } | null>(null);
+	let tweaksOpen = $state(false);
+	let shelfT = $state({
+		games: { scale: 1.0, tilt: 20, x: 12, y: 110 },
+		ent: { scale: 1.0, tilt: -22, x: 0, y: 80 },
+		business: { scale: 1.0, tilt: 0, x: 186, y: 97 },
+		counter: { scale: 1.0, tilt: 0, x: 380, y: 56 }
+	});
+
+	const owned = $derived(fs.getOwnedApps());
+
+	const breadcrumb = $derived(
+		view === 'aisle'
+			? 'browse'
+			: view === 'counter'
+				? '▸ at the counter'
+				: `▸ ${CATEGORIES[view]?.label ?? ''} aisle`
+	);
+
+	function addToCart(id: string) {
+		if (!cart.includes(id)) cart = [...cart, id];
+	}
+
+	function removeFromCart(id: string) {
+		cart = cart.filter((x) => x !== id);
+	}
+
+	async function ringUp() {
+		if (cart.length === 0) return;
+		for (const id of cart) {
+			if (!fs.isAppOwned(id)) {
+				await fs.buyApp(id);
+			}
+		}
+		receipt = { items: [...cart] };
+		cart = [];
+		view = 'aisle';
+	}
+
+	async function returnToStore(id: string) {
+		await fs.returnApp(id);
+		pickedUp = null;
+	}
+</script>
+
+<div class="store-root">
+	<TopBar
+		{view}
+		{breadcrumb}
+		onback={view === 'aisle'
+			? null
+			: () => {
+					view = 'aisle';
+				}}
+		cartCount={cart.length}
+		oncart={() => {
+			view = 'counter';
+		}}
+	/>
+	<div class="store-body">
+		{#if view === 'aisle'}
+			<AisleView
+				onenter={(v) => {
+					view = v;
+				}}
+				{shelfT}
+				{tweaksOpen}
+				onopentweaks={() => {
+					tweaksOpen = true;
+				}}
+				onclosetweaks={() => {
+					tweaksOpen = false;
+				}}
+				onupdatetweaks={(id, patch) => {
+					const key = id as keyof typeof shelfT;
+					shelfT = { ...shelfT, [key]: { ...shelfT[key], ...patch } };
+				}}
+			/>
+		{/if}
+		{#if view === 'games' || view === 'business' || view === 'ent'}
+			<CategoryCloseup
+				categoryId={view as CategoryId}
+				{cart}
+				{owned}
+				onpickup={(app) => {
+					pickedUp = app;
+				}}
+			/>
+		{/if}
+		{#if view === 'counter'}
+			<CounterView {cart} onremove={removeFromCart} onringup={ringUp} />
+		{/if}
+		{#if pickedUp}
+			<BoxDetailModal
+				app={pickedUp}
+				owned={owned.includes(pickedUp.id)}
+				inCart={cart.includes(pickedUp.id)}
+				onclose={() => {
+					pickedUp = null;
+				}}
+				onaddtocart={() => {
+					addToCart(pickedUp!.id);
+					pickedUp = null;
+				}}
+				onremovefromcart={() => {
+					removeFromCart(pickedUp!.id);
+					pickedUp = null;
+				}}
+				onreturn={() => returnToStore(pickedUp!.id)}
+			/>
+		{/if}
+		{#if receipt}
+			<ReceiptOverlay
+				items={receipt.items}
+				onclose={() => {
+					receipt = null;
+				}}
+			/>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.store-root {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		overflow: hidden;
+		font-family: 'Pixelify Sans', sans-serif;
+		-webkit-font-smoothing: none;
+	}
+	.store-body {
+		position: relative;
+		flex: 1;
+		min-height: 0;
+		overflow: hidden;
+	}
+</style>

--- a/src/lib/apps/computer-store/ComputerStoreWindow.svelte
+++ b/src/lib/apps/computer-store/ComputerStoreWindow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { TerminalFS } from '$lib/terminalos';
+	import { getOwnedAppIds } from '$lib/terminalos';
 	import type { OsApi } from '$lib/os/os-api';
 	import TopBar from './TopBar.svelte';
 	import AisleView from './AisleView.svelte';
@@ -26,7 +27,7 @@
 	let ownedVersion = $state(0);
 	const owned = $derived.by(() => {
 		ownedVersion;
-		return fs.getOwnedApps();
+		return getOwnedAppIds(fs.getOwnedApps());
 	});
 
 	const breadcrumb = $derived(

--- a/src/lib/apps/computer-store/ComputerStoreWindow.svelte
+++ b/src/lib/apps/computer-store/ComputerStoreWindow.svelte
@@ -15,7 +15,7 @@
 	let view = $state<string>('aisle');
 	let cart = $state<string[]>([]);
 	let pickedUp = $state<StoreApp | null>(null);
-	let receipt = $state<{ items: string[] } | null>(null);
+	let receipt = $state<{ purchases: string[]; returns: string[] } | null>(null);
 	let tweaksOpen = $state(false);
 	let shelfT = $state({
 		games: { scale: 1.0, tilt: 20, x: 12, y: 110 },
@@ -62,7 +62,7 @@
 			}
 		}
 		ownedVersion++;
-		receipt = { items: [...cart] };
+		receipt = { purchases: [...cart], returns: [] };
 		cart = [];
 		view = 'aisle';
 	}
@@ -79,6 +79,8 @@
 		}
 		ownedVersion++;
 		pickedUp = null;
+		view = 'counter';
+		receipt = { purchases: [], returns: [id] };
 	}
 </script>
 
@@ -150,7 +152,8 @@
 		{/if}
 		{#if receipt}
 			<ReceiptOverlay
-				items={receipt.items}
+				purchases={receipt.purchases}
+				returns={receipt.returns}
 				onclose={() => {
 					receipt = null;
 				}}

--- a/src/lib/apps/computer-store/ComputerStoreWindow.svelte
+++ b/src/lib/apps/computer-store/ComputerStoreWindow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { type TerminalFS, getAppDef } from '$lib/terminalos';
+	import type { TerminalFS } from '$lib/terminalos';
 	import type { OsApi } from '$lib/os/os-api';
 	import TopBar from './TopBar.svelte';
 	import AisleView from './AisleView.svelte';
@@ -49,7 +49,6 @@
 		if (cart.length === 0) return;
 		for (const id of cart) {
 			if (!fs.isAppOwned(id)) {
-				if (!getAppDef(id)) continue;
 				const result = await fs.buyApp(id);
 				if (!result.ok) {
 					os.alert({

--- a/src/lib/apps/computer-store/ComputerStoreWindow.svelte
+++ b/src/lib/apps/computer-store/ComputerStoreWindow.svelte
@@ -154,6 +154,10 @@
 				onclose={() => {
 					receipt = null;
 				}}
+				onleave={() => {
+					receipt = null;
+					os.closeWindow('computer-store');
+				}}
 			/>
 		{/if}
 	</div>

--- a/src/lib/apps/computer-store/ComputerStoreWindow.svelte
+++ b/src/lib/apps/computer-store/ComputerStoreWindow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { TerminalFS } from '$lib/terminalos';
+	import { type TerminalFS, getAppDef } from '$lib/terminalos';
 	import type { OsApi } from '$lib/os/os-api';
 	import TopBar from './TopBar.svelte';
 	import AisleView from './AisleView.svelte';
@@ -23,7 +23,11 @@
 		counter: { scale: 1.0, tilt: 0, x: 380, y: 56 }
 	});
 
-	const owned = $derived(fs.getOwnedApps());
+	let ownedVersion = $state(0);
+	const owned = $derived.by(() => {
+		ownedVersion;
+		return fs.getOwnedApps();
+	});
 
 	const breadcrumb = $derived(
 		view === 'aisle'
@@ -45,16 +49,35 @@
 		if (cart.length === 0) return;
 		for (const id of cart) {
 			if (!fs.isAppOwned(id)) {
-				await fs.buyApp(id);
+				if (!getAppDef(id)) continue;
+				const result = await fs.buyApp(id);
+				if (!result.ok) {
+					os.alert({
+						title: 'Purchase Failed',
+						body: result.error.message,
+						buttons: [{ label: 'OK', primary: true }]
+					});
+					return;
+				}
 			}
 		}
+		ownedVersion++;
 		receipt = { items: [...cart] };
 		cart = [];
 		view = 'aisle';
 	}
 
 	async function returnToStore(id: string) {
-		await fs.returnApp(id);
+		const result = await fs.returnApp(id);
+		if (!result.ok) {
+			os.alert({
+				title: 'Return Failed',
+				body: result.error.message,
+				buttons: [{ label: 'OK', primary: true }]
+			});
+			return;
+		}
+		ownedVersion++;
 		pickedUp = null;
 	}
 </script>

--- a/src/lib/apps/computer-store/CounterScene.svelte
+++ b/src/lib/apps/computer-store/CounterScene.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	let {
+		scale = 1,
+		tilt = 0,
+		x = 380,
+		y = 56
+	}: {
+		scale?: number;
+		tilt?: number;
+		x?: number;
+		y?: number;
+	} = $props();
+
+	const W = 160;
+	const H = 216;
+</script>
+
+<div
+	class="counter-scene"
+	style:left="{x}px"
+	style:top="{y}px"
+	style:width="{W * scale}px"
+	style:height="{H * scale}px"
+	style:transform={tilt ? `perspective(1600px) rotateY(${tilt}deg)` : undefined}
+>
+	<svg
+		viewBox="0 0 {W} {H}"
+		width="100%"
+		height="100%"
+		shape-rendering="crispEdges"
+		style="overflow: visible"
+	>
+		<!-- CLERK — animated shuffle behind counter -->
+		<g>
+			<animateTransform
+				attributeName="transform"
+				type="translate"
+				calcMode="discrete"
+				values="32,68;40,67;48,68;56,67;64,68;72,67;80,68;88,67;96,68;88,67;80,68;72,67;64,68;56,67;48,68;40,67"
+				dur="10s"
+				repeatCount="indefinite"
+			/>
+			<!-- hair -->
+			<rect x="2" y="0" width="14" height="2" fill="#5a3a18" />
+			<rect x="0" y="2" width="18" height="3" fill="#5a3a18" />
+			<!-- face -->
+			<rect x="2" y="5" width="14" height="10" fill="#f0c89a" />
+			<rect x="0" y="5" width="2" height="6" fill="#5a3a18" />
+			<rect x="16" y="5" width="2" height="6" fill="#5a3a18" />
+			<!-- eyes -->
+			<rect x="4" y="8" width="3" height="2" fill="#ffffff" />
+			<rect x="11" y="8" width="3" height="2" fill="#ffffff" />
+			<rect x="5" y="8" width="2" height="2" fill="#0a0a0a" />
+			<rect x="12" y="8" width="2" height="2" fill="#0a0a0a" />
+			<!-- smile -->
+			<rect x="6" y="12" width="6" height="1" fill="#a04030" />
+			<!-- neck -->
+			<rect x="6" y="15" width="6" height="2" fill="#e0b888" />
+			<!-- shoulders -->
+			<rect x="-4" y="17" width="26" height="4" fill="#5e3a8a" />
+			<!-- vest body -->
+			<rect x="-2" y="21" width="22" height="44" fill="#5e3a8a" />
+			<!-- arms + hands -->
+			<rect
+				x="-4"
+				y="21"
+				width="3"
+				height="18"
+				fill="#5e3a8a"
+				stroke="#0a0a0a"
+				stroke-width="0.5"
+			/>
+			<rect x="-4" y="38" width="3" height="4" fill="#f0c89a" stroke="#0a0a0a" stroke-width="0.5" />
+			<rect
+				x="19"
+				y="21"
+				width="3"
+				height="18"
+				fill="#5e3a8a"
+				stroke="#0a0a0a"
+				stroke-width="0.5"
+			/>
+			<rect x="19" y="38" width="3" height="4" fill="#f0c89a" stroke="#0a0a0a" stroke-width="0.5" />
+			<!-- collar -->
+			<rect x="4" y="17" width="2" height="4" fill="#ffffff" />
+			<rect x="12" y="17" width="2" height="4" fill="#ffffff" />
+			<!-- tie -->
+			<rect x="8" y="17" width="2" height="12" fill="#f9bd2b" />
+			<rect x="7" y="24" width="4" height="6" fill="#f9bd2b" />
+			<!-- name badge -->
+			<rect x="1" y="26" width="6" height="3" fill="#ffffff" stroke="#0a0a0a" stroke-width="0.5" />
+			<rect x="2" y="27" width="4" height="1" fill="#0a0a0a" />
+		</g>
+
+		<!-- REGISTER -->
+		<rect x="28" y="102" width="38" height="22" fill="#dcd6c8" stroke="#0a0a0a" stroke-width="2" />
+		<rect x="32" y="105" width="30" height="7" fill="#a6f000" stroke="#0a0a0a" stroke-width="1" />
+		{#each [0, 1, 2] as c}
+			{#each [0, 1] as r}
+				<rect x={34 + c * 9} y={114 + r * 4} width="6" height="2" fill="#0a0a0a" />
+			{/each}
+		{/each}
+		<!-- receipt printer / scanner -->
+		<rect x="84" y="108" width="22" height="16" fill="#3a322a" stroke="#0a0a0a" stroke-width="2" />
+		<rect x="88" y="111" width="14" height="4" fill="#1ec8ff" />
+
+		<!-- COUNTER TOP -->
+		<rect x="0" y="124" width="156" height="40" fill="#a06a3a" stroke="#0a0a0a" stroke-width="2" />
+		{#each [20, 50, 90, 130] as lx}
+			<line x1={lx} y1="124" x2={lx} y2="164" stroke="#7a4f2a" stroke-width="1" />
+		{/each}
+
+		<!-- COUNTER BASE -->
+		<rect x="0" y="164" width="156" height="50" fill="#7a4f2a" stroke="#0a0a0a" stroke-width="2" />
+
+		<!-- CHECKOUT placard -->
+		<rect x="28" y="135" width="100" height="22" fill="#0a0a0a" stroke="#0a0a0a" stroke-width="2" />
+		<rect x="30" y="137" width="96" height="2" fill="rgba(255,255,255,0.15)" />
+		<text
+			x="78"
+			y="152"
+			font-family="'Press Start 2P', monospace"
+			font-size="10"
+			fill="#f9bd2b"
+			text-anchor="middle"
+			letter-spacing="1">CHECKOUT</text
+		>
+
+		<!-- NO RETURNS sign -->
+		<rect x="15" y="170" width="80" height="14" fill="#ffffff" stroke="#0a0a0a" stroke-width="1" />
+		<text
+			x="55"
+			y="181"
+			font-family="'Press Start 2P', monospace"
+			font-size="7"
+			fill="#0a0a0a"
+			text-anchor="middle">NO RETURNS</text
+		>
+	</svg>
+</div>
+
+<style>
+	.counter-scene {
+		position: absolute;
+		z-index: 4;
+		transform-origin: 50% 50%;
+	}
+</style>

--- a/src/lib/apps/computer-store/CounterView.svelte
+++ b/src/lib/apps/computer-store/CounterView.svelte
@@ -1,0 +1,434 @@
+<script lang="ts">
+	import SoftwareBox from './SoftwareBox.svelte';
+	import { APP_BY_ID } from './store-data';
+
+	let {
+		cart,
+		onremove,
+		onringup
+	}: {
+		cart: string[];
+		onremove: (id: string) => void;
+		onringup: () => void;
+	} = $props();
+</script>
+
+<div class="counter-view">
+	<!-- Wall -->
+	<div class="wall"></div>
+	<!-- Floor -->
+	<div class="floor"></div>
+	<!-- Floor-wall seam -->
+	<div class="seam"></div>
+
+	<!-- CHECKOUT sign overhead -->
+	<div class="sign-area">
+		<div class="sign-holder">
+			<div class="sign-cord sign-cord-left"></div>
+			<div class="sign-cord sign-cord-right"></div>
+			<div class="checkout-sign">
+				&#x2605; CHECKOUT &#x2605;
+				<div class="sign-sub">
+					now serving &middot; <span class="sign-you">&#x25CF; YOU</span>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<!-- RECEIPT panel -->
+	<div class="receipt">
+		<div class="receipt-header">RECEIPT</div>
+		<div class="receipt-body">
+			{#if cart.length === 0}
+				<div class="receipt-empty">no items yet.</div>
+			{:else}
+				{#each cart as id (id)}
+					<div class="receipt-line">
+						<span class="receipt-title">{APP_BY_ID[id].title}</span>
+						<span>$0.00</span>
+					</div>
+				{/each}
+			{/if}
+			<div class="receipt-total">
+				<span>TOTAL</span>
+				<span>$0.00</span>
+			</div>
+		</div>
+	</div>
+
+	<!-- Empty cart message -->
+	{#if cart.length === 0}
+		<div class="empty-msg">
+			cart is empty.<br />
+			<span class="empty-sub">grab something off a shelf.</span>
+		</div>
+	{/if}
+
+	<!-- CART ITEMS on counter -->
+	{#if cart.length > 0}
+		<div class="cart-items">
+			{#each cart as id (id)}
+				<div class="cart-item">
+					<button class="remove-btn" onclick={() => onremove(id)} title="remove">
+						&times; remove
+					</button>
+					<SoftwareBox app={APP_BY_ID[id]} width={60} height={82} hoverable={false} />
+				</div>
+			{/each}
+		</div>
+	{/if}
+
+	<!-- REGISTER -->
+	<div class="register">
+		<div class="register-display">
+			${(cart.length * 0).toFixed(2)}
+		</div>
+		<div class="register-keys">
+			{#each Array(12) as _, i (i)}
+				<div class="register-key"></div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- COUNTER bottom strip -->
+	<div class="counter-strip">
+		<!-- counter top -->
+		<div class="counter-top">
+			<div class="counter-top-grain"></div>
+		</div>
+		<!-- counter face -->
+		<div class="counter-face">
+			<div class="counter-face-grain"></div>
+			<div class="face-sign face-sign-returns">NO RETURNS</div>
+			<div class="face-sign face-sign-cash">CASH ONLY*</div>
+			<div class="face-disclaimer">* there is no cash. everything is free.</div>
+
+			<!-- RING ME UP button -->
+			<button
+				class="ring-btn"
+				class:ring-btn-active={cart.length > 0}
+				disabled={cart.length === 0}
+				onclick={cart.length > 0 ? onringup : undefined}
+			>
+				&#x25B8; RING ME UP
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.counter-view {
+		position: absolute;
+		inset: 0;
+		background: #f5b34f;
+		overflow: hidden;
+	}
+	.wall {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 220px;
+		background: #f5b34f;
+	}
+	.floor {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: 220px;
+		background: #cbd5cb;
+	}
+	.seam {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 220px;
+		height: 6px;
+		background: #f54e00;
+		border-top: 2px solid #0a0a0a;
+		border-bottom: 2px solid #0a0a0a;
+	}
+
+	/* CHECKOUT sign */
+	.sign-area {
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		height: 90px;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding-top: 8px;
+	}
+	.sign-holder {
+		position: relative;
+	}
+	.sign-cord {
+		position: absolute;
+		top: -8px;
+		width: 2px;
+		height: 14px;
+		background: #0a0a0a;
+	}
+	.sign-cord-left {
+		left: 20px;
+	}
+	.sign-cord-right {
+		right: 20px;
+	}
+	.checkout-sign {
+		background: #0a0a0a;
+		color: #f9bd2b;
+		border: 3px solid #0a0a0a;
+		box-shadow: 4px 4px 0 rgba(0, 0, 0, 0.45);
+		padding: 10px 28px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 16px;
+		letter-spacing: 0.08em;
+		text-align: center;
+		white-space: nowrap;
+	}
+	.sign-sub {
+		font-family: 'VT323', monospace;
+		font-size: 14px;
+		color: #ffffff;
+		margin-top: 6px;
+		letter-spacing: 0;
+	}
+	.sign-you {
+		color: #f54e00;
+	}
+
+	/* RECEIPT */
+	.receipt {
+		position: absolute;
+		left: 20px;
+		top: 100px;
+		width: 200px;
+		background: #fffceb;
+		border: 2px solid #0a0a0a;
+		box-shadow: 4px 4px 0 #0a0a0a;
+		font-family: 'VT323', monospace;
+		font-size: 15px;
+		background-image: repeating-linear-gradient(
+			0deg,
+			transparent 0 22px,
+			rgba(0, 0, 0, 0.05) 22px 23px
+		);
+		z-index: 3;
+	}
+	.receipt-header {
+		background: #0a0a0a;
+		color: #f9bd2b;
+		padding: 5px 8px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+		letter-spacing: 0.04em;
+	}
+	.receipt-body {
+		padding: 6px 8px;
+		max-height: 130px;
+		overflow-y: auto;
+	}
+	.receipt-empty {
+		color: rgba(10, 10, 10, 0.5);
+		font-style: italic;
+	}
+	.receipt-line {
+		display: flex;
+		justify-content: space-between;
+		border-bottom: 1px dotted rgba(0, 0, 0, 0.3);
+		padding: 1px 0;
+	}
+	.receipt-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.receipt-total {
+		display: flex;
+		justify-content: space-between;
+		margin-top: 8px;
+		padding-top: 5px;
+		border-top: 2px solid #0a0a0a;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+	}
+
+	/* Empty cart message */
+	.empty-msg {
+		position: absolute;
+		left: 50%;
+		top: 200px;
+		transform: translateX(-50%);
+		font-family: 'VT323', monospace;
+		font-size: 17px;
+		color: rgba(10, 10, 10, 0.7);
+		background: #ffffff;
+		border: 2px dashed #0a0a0a;
+		padding: 10px 14px;
+		text-align: center;
+		line-height: 1.3;
+		max-width: 280px;
+		z-index: 2;
+	}
+	.empty-sub {
+		opacity: 0.7;
+	}
+
+	/* Cart items */
+	.cart-items {
+		position: absolute;
+		left: 240px;
+		right: 180px;
+		top: 100px;
+		height: 202px;
+		display: flex;
+		align-items: flex-end;
+		gap: 8px;
+		padding: 0 4px 0 8px;
+		z-index: 2;
+	}
+	.cart-item {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+	.remove-btn {
+		background: transparent;
+		color: #0a0a0a;
+		border: none;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 7px;
+		cursor: pointer;
+		margin-bottom: 2px;
+		padding: 2px;
+	}
+
+	/* Register */
+	.register {
+		position: absolute;
+		right: 28px;
+		bottom: 200px;
+		width: 116px;
+		height: 108px;
+		background: #dcd6c8;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		z-index: 2;
+	}
+	.register-display {
+		position: absolute;
+		left: 8px;
+		top: 6px;
+		right: 8px;
+		height: 28px;
+		background: #a6f000;
+		border: 2px solid #0a0a0a;
+		font-family: 'VT323', monospace;
+		font-size: 18px;
+		text-align: right;
+		padding: 2px 6px;
+		color: #0a0a0a;
+	}
+	.register-keys {
+		position: absolute;
+		left: 8px;
+		top: 40px;
+		right: 8px;
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 3px;
+	}
+	.register-key {
+		aspect-ratio: 1 / 1;
+		background: #0a0a0a;
+	}
+
+	/* Counter strip */
+	.counter-strip {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 24px;
+		height: 196px;
+	}
+	.counter-top {
+		position: absolute;
+		left: 16px;
+		right: 16px;
+		top: 0;
+		height: 30px;
+		background: #a06a3a;
+		border: 2px solid #0a0a0a;
+		box-shadow: 0 4px 0 #7a4f2a;
+	}
+	.counter-top-grain {
+		position: absolute;
+		inset: 0;
+		background: repeating-linear-gradient(90deg, transparent 0 40px, rgba(0, 0, 0, 0.18) 40px 42px);
+	}
+	.counter-face {
+		position: absolute;
+		left: 16px;
+		right: 16px;
+		top: 30px;
+		bottom: 0;
+		background: #7a4f2a;
+		border: 2px solid #0a0a0a;
+		border-top: none;
+	}
+	.counter-face-grain {
+		position: absolute;
+		inset: 0;
+		background: repeating-linear-gradient(90deg, transparent 0 70px, rgba(0, 0, 0, 0.25) 70px 72px);
+	}
+	.face-sign {
+		position: absolute;
+		top: 14px;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 4px 8px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+	}
+	.face-sign-returns {
+		left: 12px;
+		background: #ffffff;
+		color: #0a0a0a;
+	}
+	.face-sign-cash {
+		left: 140px;
+		background: #f9bd2b;
+		color: #0a0a0a;
+	}
+	.face-disclaimer {
+		position: absolute;
+		left: 270px;
+		top: 18px;
+		font-family: 'VT323', monospace;
+		font-size: 14px;
+		color: rgba(255, 255, 255, 0.65);
+		white-space: nowrap;
+	}
+	.ring-btn {
+		position: absolute;
+		right: 18px;
+		bottom: 16px;
+		background: #888888;
+		color: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		padding: 12px 18px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 13px;
+		letter-spacing: 0.06em;
+		cursor: not-allowed;
+	}
+	.ring-btn-active {
+		background: #f54e00;
+		cursor: pointer;
+	}
+</style>

--- a/src/lib/apps/computer-store/Hotspot.svelte
+++ b/src/lib/apps/computer-store/Hotspot.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	let {
+		id,
+		left,
+		top,
+		width,
+		height,
+		label,
+		sublabel = '',
+		hot,
+		onenter,
+		onleave,
+		onclick
+	}: {
+		id: string;
+		left: string;
+		top: string;
+		width: string;
+		height: string;
+		label: string;
+		sublabel?: string;
+		hot: string | null;
+		onenter: () => void;
+		onleave: () => void;
+		onclick: () => void;
+	} = $props();
+
+	const isHot = $derived(hot === id);
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="hotspot"
+	class:active={isHot}
+	style:left
+	style:top
+	style:width
+	style:height
+	onmouseenter={onenter}
+	onmouseleave={onleave}
+	{onclick}
+>
+	{#if isHot}
+		<div class="tooltip">
+			<span class="tooltip-label">▸ {label}</span>
+			{#if sublabel}
+				<div class="tooltip-sub">{sublabel}</div>
+			{/if}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.hotspot {
+		position: absolute;
+		cursor: pointer;
+		outline: none;
+		background: transparent;
+		z-index: 5;
+	}
+	.hotspot.active {
+		outline: 3px dashed #f9bd2b;
+		outline-offset: -2px;
+		background: rgba(249, 189, 43, 0.1);
+	}
+	.tooltip {
+		position: absolute;
+		left: 50%;
+		top: -2px;
+		transform: translate(-50%, -100%);
+		background: #0a0a0a;
+		color: #f9bd2b;
+		border: 2px solid #f9bd2b;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		padding: 5px 9px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+		letter-spacing: 0.04em;
+		white-space: nowrap;
+		z-index: 6;
+	}
+	.tooltip-sub {
+		font-family: 'VT323', monospace;
+		font-size: 13px;
+		color: #ffffff;
+		margin-top: 2px;
+		letter-spacing: 0;
+	}
+</style>

--- a/src/lib/apps/computer-store/MiniShelfBox.svelte
+++ b/src/lib/apps/computer-store/MiniShelfBox.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import PixelIcon from './PixelIcon.svelte';
+	import type { StoreApp } from './store-data';
+	import { CAT_COLORS } from './store-data';
+
+	let { app, w = 52, h = 72 }: { app: StoreApp; w?: number; h?: number } = $props();
+
+	const cat = $derived(CAT_COLORS[app.cat] || CAT_COLORS.PROD);
+	const iconSize = $derived(Math.min(Math.floor(h * 0.5), w - 14));
+	const bandH = $derived(Math.max(10, Math.floor(h * 0.18)));
+	const bottomH = $derived(Math.max(6, Math.floor(h * 0.11)));
+
+	const stickerCfg = $derived.by(() => {
+		if (!app.sticker) return null;
+		const map: Record<string, { bg: string; fg: string; label: string }> = {
+			STAFF_PICK: { bg: '#f54e00', fg: '#ffffff', label: '★ STAFF' },
+			SALE: { bg: '#c92127', fg: '#ffffff', label: 'SALE!' },
+			NEW: { bg: '#f9bd2b', fg: '#0a0a0a', label: '★ NEW' }
+		};
+		return map[app.sticker] ?? null;
+	});
+</script>
+
+<div class="mini-box" style:width="{w}px" style:height="{h}px">
+	<div class="band" style:height="{bandH}px" style:background={cat.band}>
+		<div class="band-shine"></div>
+	</div>
+	<div class="splash" style:background={cat.splash}>
+		<PixelIcon name={app.icon} size={iconSize} />
+	</div>
+	<div class="trim" style:height="{bottomH}px" style:background={cat.trim}></div>
+	{#if stickerCfg}
+		<div
+			class="sticker"
+			style:background={stickerCfg.bg}
+			style:color={stickerCfg.fg}
+			style:font-size="{Math.max(4, Math.round(w * 0.13))}px"
+			style:padding="{Math.max(1, Math.round(w * 0.03))}px {Math.max(1, Math.round(w * 0.06))}px"
+			style:top="-{Math.max(2, Math.round(w * 0.1))}px"
+			style:right="-{Math.max(2, Math.round(w * 0.1))}px"
+		>
+			{stickerCfg.label}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.mini-box {
+		background: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 1px 2px 0 rgba(0, 0, 0, 0.4);
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 0;
+		font-family: 'Pixelify Sans', sans-serif;
+		position: relative;
+	}
+	.band {
+		border-bottom: 1px solid #0a0a0a;
+		position: relative;
+	}
+	.band-shine {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 2px;
+		background: rgba(255, 255, 255, 0.45);
+	}
+	.splash {
+		flex: 1;
+		display: grid;
+		place-items: center;
+		padding: 3px;
+		position: relative;
+	}
+	.sticker {
+		position: absolute;
+		transform: rotate(-10deg);
+		border: 1px solid #0a0a0a;
+		box-shadow: 1px 1px 0 #0a0a0a;
+		font-family: 'Press Start 2P', monospace;
+		letter-spacing: 0.04em;
+		white-space: nowrap;
+		z-index: 5;
+	}
+</style>

--- a/src/lib/apps/computer-store/PixelIcon.svelte
+++ b/src/lib/apps/computer-store/PixelIcon.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	let { name, size = 64 }: { name: string; size?: number } = $props();
+</script>
+
+<div class="pixel-icon" style:width="{size}px" style:height="{size}px">
+	{#if name === 'tetra'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="3" y="3" width="3" height="3" fill="#1ec8ff" stroke="#0a0a0a" />
+			<rect x="3" y="6" width="3" height="3" fill="#1ec8ff" stroke="#0a0a0a" />
+			<rect x="3" y="9" width="3" height="3" fill="#1ec8ff" stroke="#0a0a0a" />
+			<rect x="6" y="9" width="3" height="3" fill="#1ec8ff" stroke="#0a0a0a" />
+			<rect x="10" y="5" width="3" height="3" fill="#ff4ec8" stroke="#0a0a0a" />
+			<rect x="10" y="8" width="3" height="3" fill="#ff4ec8" stroke="#0a0a0a" />
+		</svg>
+	{:else if name === 'card'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="4" y="2" width="9" height="12" fill="#ffffff" stroke="#0a0a0a" />
+			<rect x="3" y="3" width="9" height="12" fill="#ffffff" stroke="#0a0a0a" />
+			<rect x="6" y="6" width="3" height="1" fill="#0a0a0a" />
+			<rect x="5" y="7" width="5" height="2" fill="#0a0a0a" />
+			<rect x="4" y="9" width="7" height="1" fill="#0a0a0a" />
+			<rect x="7" y="10" width="1" height="2" fill="#0a0a0a" />
+			<rect x="5" y="11" width="5" height="1" fill="#0a0a0a" />
+			<rect x="4" y="4" width="1" height="1" fill="#0a0a0a" />
+		</svg>
+	{:else if name === 'bomb'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="9" y="2" width="1" height="2" fill="#0a0a0a" />
+			<rect x="10" y="3" width="1" height="1" fill="#0a0a0a" />
+			<rect x="10" y="2" width="1" height="1" fill="#f9bd2b" />
+			<rect x="11" y="3" width="1" height="1" fill="#f54e00" />
+			<rect x="5" y="5" width="6" height="1" fill="#0a0a0a" />
+			<rect x="4" y="6" width="8" height="1" fill="#0a0a0a" />
+			<rect x="3" y="7" width="10" height="6" fill="#0a0a0a" />
+			<rect x="4" y="13" width="8" height="1" fill="#0a0a0a" />
+			<rect x="5" y="14" width="6" height="1" fill="#0a0a0a" />
+			<rect x="5" y="8" width="2" height="1" fill="#7a7a7a" />
+			<rect x="5" y="9" width="1" height="1" fill="#7a7a7a" />
+		</svg>
+	{:else if name === 'scroll'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="3" y="3" width="10" height="10" fill="#f0d8a0" stroke="#0a0a0a" />
+			<rect x="2" y="3" width="2" height="2" fill="#b88a3a" stroke="#0a0a0a" />
+			<rect x="2" y="11" width="2" height="2" fill="#b88a3a" stroke="#0a0a0a" />
+			<rect x="12" y="3" width="2" height="2" fill="#b88a3a" stroke="#0a0a0a" />
+			<rect x="12" y="11" width="2" height="2" fill="#b88a3a" stroke="#0a0a0a" />
+			<rect x="5" y="6" width="6" height="1" fill="#5a3820" />
+			<rect x="5" y="8" width="4" height="1" fill="#5a3820" />
+			<rect x="5" y="10" width="5" height="1" fill="#5a3820" />
+		</svg>
+	{:else if name === 'doc'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="3" y="2" width="10" height="12" fill="#ffffff" stroke="#0a0a0a" />
+			<polygon points="10,2 13,5 10,5" fill="#dcd6c8" stroke="#0a0a0a" />
+			<rect x="4" y="7" width="7" height="1" fill="#0a0a0a" />
+			<rect x="4" y="9" width="7" height="1" fill="#0a0a0a" />
+			<rect x="4" y="11" width="5" height="1" fill="#0a0a0a" />
+		</svg>
+	{:else if name === 'sticky'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="3" y="3" width="9" height="9" fill="#f6c542" stroke="#0a0a0a" />
+			<rect x="4" y="4" width="9" height="9" fill="#fff39a" stroke="#0a0a0a" />
+			<rect x="5" y="6" width="5" height="1" fill="#0a0a0a" />
+			<rect x="5" y="8" width="6" height="1" fill="#0a0a0a" />
+			<rect x="5" y="10" width="3" height="1" fill="#0a0a0a" />
+			<rect x="11" y="11" width="2" height="2" fill="#f6c542" />
+		</svg>
+	{:else if name === 'calc'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="3" y="2" width="10" height="12" fill="#dcd6c8" stroke="#0a0a0a" />
+			<rect x="4" y="3" width="8" height="3" fill="#a6f000" stroke="#0a0a0a" />
+			<rect x="9" y="4" width="2" height="1" fill="#0a0a0a" />
+			{#each [0, 1, 2] as r}{#each [0, 1, 2] as c}<rect
+						x={4 + c * 3}
+						y={7 + r * 2}
+						width="2"
+						height="1"
+						fill="#0a0a0a"
+					/>{/each}{/each}
+			<rect x="12" y="7" width="1" height="5" fill="#f54e00" stroke="#0a0a0a" />
+		</svg>
+	{:else if name === 'brush'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="1" y="7" width="7" height="6" fill="#f0c89a" stroke="#0a0a0a" />
+			<rect x="2" y="8" width="1" height="1" fill="#f54e00" />
+			<rect x="4" y="8" width="1" height="1" fill="#1ec8ff" />
+			<rect x="6" y="8" width="1" height="1" fill="#a6f000" />
+			<rect x="2" y="10" width="1" height="1" fill="#f9bd2b" />
+			<rect x="4" y="10" width="1" height="1" fill="#ff4ec8" />
+			<rect x="6" y="10" width="1" height="1" fill="#5a3a8a" />
+			<rect x="3" y="12" width="1" height="1" fill="#0a0a0a" />
+			<rect x="11" y="2" width="2" height="3" fill="#f54e00" stroke="#0a0a0a" />
+			<rect x="10" y="5" width="4" height="2" fill="#b88a3a" stroke="#0a0a0a" />
+			<rect x="9" y="7" width="2" height="2" fill="#7a4f2a" stroke="#0a0a0a" />
+			<rect x="8" y="9" width="2" height="2" fill="#7a4f2a" stroke="#0a0a0a" />
+		</svg>
+	{:else if name === 'tvguide'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="3" y="13" width="1" height="2" fill="#0a0a0a" />
+			<rect x="12" y="13" width="1" height="2" fill="#0a0a0a" />
+			<rect x="1" y="3" width="14" height="11" fill="#3a322a" stroke="#0a0a0a" />
+			<rect x="2" y="4" width="12" height="8" fill="#0000aa" stroke="#0a0a0a" />
+			<rect x="3" y="5" width="2" height="1" fill="#f9bd2b" />
+			<rect x="6" y="5" width="7" height="1" fill="#f9bd2b" />
+			<rect x="3" y="7" width="2" height="1" fill="#f9bd2b" />
+			<rect x="6" y="7" width="5" height="1" fill="#f9bd2b" />
+			<rect x="3" y="9" width="2" height="1" fill="#f9bd2b" />
+			<rect x="6" y="9" width="6" height="1" fill="#f9bd2b" />
+			<rect x="9" y="6" width="1" height="1" fill="#a6f000" />
+			<rect x="9" y="8" width="1" height="1" fill="#a6f000" />
+			<rect x="9" y="10" width="1" height="1" fill="#a6f000" />
+			<rect x="5" y="1" width="1" height="2" fill="#0a0a0a" />
+			<rect x="10" y="1" width="1" height="2" fill="#0a0a0a" />
+			<rect x="5" y="0" width="6" height="1" fill="#0a0a0a" />
+		</svg>
+	{:else if name === 'cb'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="2" y="2" width="11" height="8" fill="#ffffff" stroke="#0a0a0a" />
+			<rect x="3" y="10" width="3" height="2" fill="#ffffff" stroke="#0a0a0a" />
+			<rect x="4" y="11" width="1" height="1" fill="#ffffff" />
+			<rect x="3" y="10" width="3" height="1" fill="#ffffff" />
+			<rect x="4" y="4" width="1" height="4" fill="#0a0a0a" />
+			<rect x="5" y="4" width="2" height="1" fill="#0a0a0a" />
+			<rect x="5" y="7" width="2" height="1" fill="#0a0a0a" />
+			<rect x="8" y="4" width="1" height="4" fill="#0a0a0a" />
+			<rect x="9" y="4" width="2" height="1" fill="#0a0a0a" />
+			<rect x="9" y="6" width="2" height="1" fill="#0a0a0a" />
+			<rect x="9" y="7" width="2" height="1" fill="#0a0a0a" />
+			<rect x="11" y="5" width="1" height="1" fill="#0a0a0a" />
+			<rect x="11" y="7" width="1" height="1" fill="#0a0a0a" />
+		</svg>
+	{:else if name === 'camera'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="2" y="5" width="9" height="7" fill="#3a322a" stroke="#0a0a0a" />
+			<rect x="11" y="6" width="3" height="5" fill="#3a322a" stroke="#0a0a0a" />
+			<rect x="12" y="7" width="2" height="3" fill="#1ec8ff" stroke="#0a0a0a" />
+			<rect x="3" y="3" width="4" height="2" fill="#3a322a" stroke="#0a0a0a" />
+			<rect x="3" y="7" width="2" height="2" fill="#f54e00" stroke="#0a0a0a" />
+			<rect x="6" y="3" width="1" height="2" fill="#0a0a0a" />
+		</svg>
+	{:else if name === 'chart'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<rect x="2" y="3" width="1" height="11" fill="#0a0a0a" />
+			<rect x="2" y="13" width="12" height="1" fill="#0a0a0a" />
+			<rect x="4" y="10" width="2" height="3" fill="#1ec8ff" stroke="#0a0a0a" />
+			<rect x="7" y="7" width="2" height="6" fill="#a6f000" stroke="#0a0a0a" />
+			<rect x="10" y="5" width="2" height="8" fill="#f54e00" stroke="#0a0a0a" />
+			<rect x="13" y="4" width="1" height="1" fill="#f9bd2b" />
+		</svg>
+	{/if}
+</div>
+
+<style>
+	.pixel-icon {
+		display: block;
+	}
+	.pixel-icon svg {
+		width: 100%;
+		height: 100%;
+		display: block;
+		image-rendering: pixelated;
+	}
+</style>

--- a/src/lib/apps/computer-store/ReceiptOverlay.svelte
+++ b/src/lib/apps/computer-store/ReceiptOverlay.svelte
@@ -2,14 +2,20 @@
 	import { APP_BY_ID } from './store-data';
 
 	let {
-		items,
+		purchases = [],
+		returns = [],
 		onclose,
 		onleave
 	}: {
-		items: string[];
+		purchases?: string[];
+		returns?: string[];
 		onclose: () => void;
 		onleave: () => void;
 	} = $props();
+
+	const isReturn = $derived(returns.length > 0 && purchases.length === 0);
+	const hasReturns = $derived(returns.length > 0);
+	const hasPurchases = $derived(purchases.length > 0);
 
 	function onkeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape') onclose();
@@ -24,7 +30,7 @@
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div class="receipt" onclick={(e) => e.stopPropagation()}>
-		<div class="receipt-header">★ THANK YOU ★</div>
+		<div class="receipt-header">{isReturn ? '★ RETURN ★' : '★ THANK YOU ★'}</div>
 
 		<div class="receipt-body">
 			<div class="shop-name">
@@ -32,12 +38,22 @@
 				<div class="separator">─── ─── ─── ─── ───</div>
 			</div>
 
-			{#each items as id (id)}
-				<div class="line-item">
-					<span>{APP_BY_ID[id]?.title ?? id}</span>
-					<span>$0.00</span>
-				</div>
-			{/each}
+			{#if hasReturns}
+				{#each returns as id (id)}
+					<div class="line-item return">
+						<span>RETURN {APP_BY_ID[id]?.title ?? id}</span>
+						<span>-$0.00</span>
+					</div>
+				{/each}
+			{/if}
+			{#if hasPurchases}
+				{#each purchases as id (id)}
+					<div class="line-item">
+						<span>{APP_BY_ID[id]?.title ?? id}</span>
+						<span>$0.00</span>
+					</div>
+				{/each}
+			{/if}
 
 			<div class="total-row">
 				<span>TOTAL</span>
@@ -45,9 +61,14 @@
 			</div>
 
 			<div class="footer-text">
-				{items.length} item{items.length === 1 ? '' : 's'} on your shelf now.<br />
-				looks like you're developing quite a little software library.<br />
-				have fun.
+				{#if isReturn}
+					item returned to the shelf.<br />
+					no hard feelings.
+				{:else}
+					{purchases.length} item{purchases.length === 1 ? '' : 's'} on your shelf now.<br />
+					looks like you're developing quite a little software library.<br />
+					have fun.
+				{/if}
 			</div>
 		</div>
 
@@ -115,6 +136,10 @@
 	.line-item {
 		display: flex;
 		justify-content: space-between;
+	}
+	.line-item.return {
+		opacity: 0.65;
+		text-decoration: line-through;
 	}
 
 	.total-row {

--- a/src/lib/apps/computer-store/ReceiptOverlay.svelte
+++ b/src/lib/apps/computer-store/ReceiptOverlay.svelte
@@ -52,8 +52,8 @@
 		</div>
 
 		<div class="btn-row">
-			<button class="browse-btn" onclick={onclose}>◂ KEEP BROWSING</button>
-			<button class="leave-btn" onclick={onleave}>▸ LEAVE THE STORE</button>
+			<button class="btn" onclick={onclose}>◂ KEEP BROWSING</button>
+			<button class="btn primary" onclick={onleave}>▸ LEAVE THE STORE</button>
 		</div>
 	</div>
 </div>
@@ -135,27 +135,15 @@
 
 	.btn-row {
 		display: flex;
-		border-top: 2px solid #0a0a0a;
+		gap: 8px;
+		padding: 12px 18px;
+		border-top: 2px solid var(--ink, #0a0a0a);
 	}
-	.browse-btn {
+	.btn-row :global(.btn) {
 		flex: 1;
-		background: #ffffff;
-		color: #0a0a0a;
-		border: none;
-		border-right: 2px solid #0a0a0a;
-		padding: 10px 0;
-		font-family: 'Press Start 2P', monospace;
+		text-align: center;
 		font-size: 9px;
-		cursor: pointer;
-	}
-	.leave-btn {
-		flex: 1;
-		background: #f54e00;
-		color: #ffffff;
-		border: none;
-		padding: 10px 0;
 		font-family: 'Press Start 2P', monospace;
-		font-size: 9px;
-		cursor: pointer;
+		padding: 10px 8px;
 	}
 </style>

--- a/src/lib/apps/computer-store/ReceiptOverlay.svelte
+++ b/src/lib/apps/computer-store/ReceiptOverlay.svelte
@@ -3,10 +3,12 @@
 
 	let {
 		items,
-		onclose
+		onclose,
+		onleave
 	}: {
 		items: string[];
 		onclose: () => void;
+		onleave: () => void;
 	} = $props();
 
 	function onkeydown(e: KeyboardEvent) {
@@ -49,7 +51,10 @@
 			</div>
 		</div>
 
-		<button class="leave-btn" onclick={onclose}>▸ LEAVE THE STORE</button>
+		<div class="btn-row">
+			<button class="browse-btn" onclick={onclose}>◂ KEEP BROWSING</button>
+			<button class="leave-btn" onclick={onleave}>▸ LEAVE THE STORE</button>
+		</div>
 	</div>
 </div>
 
@@ -128,15 +133,29 @@
 		opacity: 0.75;
 	}
 
+	.btn-row {
+		display: flex;
+		border-top: 2px solid #0a0a0a;
+	}
+	.browse-btn {
+		flex: 1;
+		background: #ffffff;
+		color: #0a0a0a;
+		border: none;
+		border-right: 2px solid #0a0a0a;
+		padding: 10px 0;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+		cursor: pointer;
+	}
 	.leave-btn {
-		width: 100%;
+		flex: 1;
 		background: #f54e00;
 		color: #ffffff;
 		border: none;
-		border-top: 2px solid #0a0a0a;
 		padding: 10px 0;
 		font-family: 'Press Start 2P', monospace;
-		font-size: 10px;
+		font-size: 9px;
 		cursor: pointer;
 	}
 </style>

--- a/src/lib/apps/computer-store/ReceiptOverlay.svelte
+++ b/src/lib/apps/computer-store/ReceiptOverlay.svelte
@@ -8,7 +8,13 @@
 		items: string[];
 		onclose: () => void;
 	} = $props();
+
+	function onkeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') onclose();
+	}
 </script>
+
+<svelte:window {onkeydown} />
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/apps/computer-store/ReceiptOverlay.svelte
+++ b/src/lib/apps/computer-store/ReceiptOverlay.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { APP_BY_ID } from './store-data';
+
+	let {
+		items,
+		onclose
+	}: {
+		items: string[];
+		onclose: () => void;
+	} = $props();
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="scrim" onclick={onclose}>
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="receipt" onclick={(e) => e.stopPropagation()}>
+		<div class="receipt-header">★ THANK YOU ★</div>
+
+		<div class="receipt-body">
+			<div class="shop-name">
+				SOFTWARE SHOP
+				<div class="separator">─── ─── ─── ─── ───</div>
+			</div>
+
+			{#each items as id (id)}
+				<div class="line-item">
+					<span>{APP_BY_ID[id]?.title ?? id}</span>
+					<span>$0.00</span>
+				</div>
+			{/each}
+
+			<div class="total-row">
+				<span>TOTAL</span>
+				<span>$0.00</span>
+			</div>
+
+			<div class="footer-text">
+				{items.length} item{items.length === 1 ? '' : 's'} on your shelf now.<br />
+				looks like you're developing quite a little software library.<br />
+				have fun.
+			</div>
+		</div>
+
+		<button class="leave-btn" onclick={onclose}>▸ LEAVE THE STORE</button>
+	</div>
+</div>
+
+<style>
+	.scrim {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 100;
+	}
+
+	.receipt {
+		width: 280px;
+		background: #fffceb;
+		border: 2px solid #0a0a0a;
+		box-shadow: 5px 5px 0 rgba(0, 0, 0, 0.55);
+		font-family: 'VT323', monospace;
+		font-size: 16px;
+		background-image: repeating-linear-gradient(
+			0deg,
+			transparent 0 22px,
+			rgba(0, 0, 0, 0.05) 22px 23px
+		);
+	}
+
+	.receipt-header {
+		background: #0a0a0a;
+		color: #f9bd2b;
+		padding: 8px 12px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 10px;
+		letter-spacing: 0.04em;
+		text-align: center;
+	}
+
+	.receipt-body {
+		padding: 16px 18px;
+		line-height: 1.4;
+	}
+
+	.shop-name {
+		text-align: center;
+		margin-bottom: 8px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+	}
+
+	.separator {
+		font-family: 'VT323', monospace;
+		font-size: 13px;
+		margin-top: 4px;
+		opacity: 0.7;
+	}
+
+	.line-item {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.total-row {
+		border-top: 2px solid #0a0a0a;
+		margin: 8px 0;
+		padding-top: 6px;
+		display: flex;
+		justify-content: space-between;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+	}
+
+	.footer-text {
+		text-align: center;
+		margin-top: 10px;
+		opacity: 0.75;
+	}
+
+	.leave-btn {
+		width: 100%;
+		background: #f54e00;
+		color: #ffffff;
+		border: none;
+		border-top: 2px solid #0a0a0a;
+		padding: 10px 0;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 10px;
+		cursor: pointer;
+	}
+</style>

--- a/src/lib/apps/computer-store/ShelfHTML.svelte
+++ b/src/lib/apps/computer-store/ShelfHTML.svelte
@@ -1,0 +1,176 @@
+<script lang="ts">
+	import MiniShelfBox from './MiniShelfBox.svelte';
+	import CardboardBox from './CardboardBox.svelte';
+	import type { StoreApp } from './store-data';
+
+	let {
+		side,
+		apps,
+		label,
+		color,
+		gap = 0,
+		tilt = 0,
+		top = 110,
+		width = 184,
+		boxW = 52,
+		boxH = 76
+	}: {
+		side: 'left' | 'right';
+		apps: StoreApp[];
+		label: string;
+		color: string;
+		gap?: number;
+		tilt?: number;
+		top?: number;
+		width?: number;
+		boxW?: number;
+		boxH?: number;
+	} = $props();
+
+	const isLeft = $derived(side === 'left');
+	const top3 = $derived(apps.slice(0, 3));
+	const bottom3 = $derived(apps.slice(3, 6));
+	const headerFontSize = $derived(Math.max(11, Math.round(boxW * 0.22)));
+</script>
+
+<div
+	class="shelf"
+	class:left={isLeft}
+	class:right={!isLeft}
+	style:top="{top}px"
+	style:width="{width}px"
+	style:--gap="{gap}px"
+	style:transform={tilt ? `perspective(1600px) rotateY(${tilt}deg)` : undefined}
+	style:transform-origin={isLeft ? '0% 50%' : '100% 50%'}
+>
+	{#if tilt !== 0}
+		<div class="side-face" class:side-left={isLeft} class:side-right={!isLeft}>
+			<div class="side-tier-line" style:top="33%"></div>
+			<div class="side-tier-line" style:top="66%"></div>
+			<div class="side-grain"></div>
+		</div>
+	{/if}
+
+	<div class="cardboard-pile">
+		<CardboardBox w={Math.round(boxW * 0.7)} h={20} shade="light" />
+		<CardboardBox w={Math.round(boxW * 0.6)} h={28} shade="dark" />
+		<CardboardBox w={Math.round(boxW * 0.8)} h={16} shade="light" />
+		<CardboardBox w={Math.round(boxW * 0.65)} h={24} shade="dark" />
+	</div>
+
+	<div class="header" style:background={color} style:font-size="{headerFontSize}px">
+		{label}
+	</div>
+
+	<div class="shelf-body">
+		<div class="tier">
+			{#each top3 as app, i (i)}
+				<MiniShelfBox {app} w={boxW} h={boxH} />
+			{/each}
+		</div>
+		<div class="plank"></div>
+		<div class="tier">
+			{#each bottom3 as app, i (i)}
+				<MiniShelfBox {app} w={boxW} h={boxH} />
+			{/each}
+		</div>
+		<div class="plank bottom-plank"></div>
+	</div>
+</div>
+
+<style>
+	.shelf {
+		position: absolute;
+		display: flex;
+		flex-direction: column;
+		z-index: 3;
+		transform-style: preserve-3d;
+	}
+	.shelf.left {
+		left: var(--gap);
+	}
+	.shelf.right {
+		right: var(--gap);
+	}
+	.side-face {
+		position: absolute;
+		top: 30px;
+		bottom: 0;
+		width: 22px;
+		background: linear-gradient(180deg, #7a4f2a 0%, #6a4220 60%, #5a3818 100%);
+		border: 2px solid #0a0a0a;
+		backface-visibility: hidden;
+		z-index: 1;
+	}
+	.side-face.side-left {
+		left: 0;
+		transform-origin: 0% 50%;
+		transform: rotateY(-90deg);
+	}
+	.side-face.side-right {
+		right: 0;
+		transform-origin: 100% 50%;
+		transform: rotateY(90deg);
+	}
+	.side-tier-line {
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 2px;
+		background: #3a1f10;
+	}
+	.side-grain {
+		position: absolute;
+		inset: 0;
+		background: repeating-linear-gradient(0deg, transparent 0 6px, rgba(0, 0, 0, 0.12) 6px 7px);
+	}
+	.cardboard-pile {
+		height: 30px;
+		display: flex;
+		align-items: flex-end;
+		justify-content: center;
+		gap: 5px;
+		padding-left: 10px;
+		padding-right: 10px;
+		flex-shrink: 0;
+	}
+	.header {
+		color: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 7px 8px 6px;
+		font-family: 'Press Start 2P', monospace;
+		letter-spacing: 0.06em;
+		text-align: center;
+		flex-shrink: 0;
+		position: relative;
+		z-index: 2;
+	}
+	.shelf-body {
+		background: #a06a3a;
+		border: 2px solid #0a0a0a;
+		border-top: none;
+		box-shadow: 3px 4px 0 rgba(0, 0, 0, 0.2);
+		padding: 14px 6px 0;
+		display: flex;
+		flex-direction: column;
+		position: relative;
+	}
+	.tier {
+		display: flex;
+		gap: 6px;
+		justify-content: center;
+		align-items: flex-end;
+	}
+	.plank {
+		height: 6px;
+		background: #7a4f2a;
+		border-top: 2px solid #0a0a0a;
+		border-bottom: 2px solid #0a0a0a;
+		margin: 10px -8px;
+		box-shadow: 0 3px 0 rgba(0, 0, 0, 0.18);
+	}
+	.bottom-plank {
+		margin-bottom: 0;
+	}
+</style>

--- a/src/lib/apps/computer-store/ShelfTweaksPanel.svelte
+++ b/src/lib/apps/computer-store/ShelfTweaksPanel.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { CATEGORIES } from './store-data';
+
+	let {
+		open,
+		onopen,
+		onclose,
+		tweaks,
+		onupdate
+	}: {
+		open: boolean;
+		onopen: () => void;
+		onclose: () => void;
+		tweaks: Record<string, { scale: number; tilt: number; x: number; y: number }>;
+		onupdate: (
+			id: string,
+			patch: Partial<{ scale: number; tilt: number; x: number; y: number }>
+		) => void;
+	} = $props();
+
+	const INK = '#0a0a0a';
+	const PAPER = '#ffffff';
+	const YELLOW = '#f9bd2b';
+
+	let posX = $state<number | null>(null);
+	let posY = $state(8);
+
+	function onMouseDown(e: MouseEvent) {
+		const startX = e.clientX;
+		const startY = e.clientY;
+		const panel = (e.currentTarget as HTMLElement).parentElement!;
+		const r = panel.getBoundingClientRect();
+		const parentR = panel.offsetParent!.getBoundingClientRect();
+		const startLeft = r.left - parentR.left;
+		const startTop = r.top - parentR.top;
+
+		function onMove(ev: MouseEvent) {
+			posX = startLeft + (ev.clientX - startX);
+			posY = startTop + (ev.clientY - startY);
+		}
+		function onUp() {
+			window.removeEventListener('mousemove', onMove);
+			window.removeEventListener('mouseup', onUp);
+		}
+		window.addEventListener('mousemove', onMove);
+		window.addEventListener('mouseup', onUp);
+		e.preventDefault();
+	}
+
+	const rows = [
+		{ id: 'games', label: 'GAMES', color: CATEGORIES.games.color },
+		{ id: 'ent', label: 'ENT', color: CATEGORIES.ent.color },
+		{ id: 'business', label: 'BUSINESS', color: CATEGORIES.business.color },
+		{ id: 'counter', label: 'COUNTER', color: INK }
+	];
+</script>
+
+{#if !open}
+	<button class="toggle-btn" onclick={onopen}>▸ TWEAK SHELVES</button>
+{:else}
+	<div
+		class="panel"
+		style:top="{posY}px"
+		style:right={posX === null ? '8px' : 'auto'}
+		style:left={posX !== null ? `${posX}px` : 'auto'}
+	>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="header" onmousedown={onMouseDown}>
+			<span class="header-left">
+				<span class="drag-handle">⋮⋮</span>
+				SHELF TWEAKS
+			</span>
+			<button class="close-btn" onclick={onclose}>×</button>
+		</div>
+		{#each rows as row (row.id)}
+			{@const t = tweaks[row.id]}
+			<div class="section" style:border-top="1px solid {INK}">
+				<div class="section-label" style:background={row.color}>{row.label}</div>
+				{#each [{ key: 'scale', min: 0.4, max: 2.2, step: 0.01 }, { key: 'tilt', min: -45, max: 45, step: 0.5 }, { key: 'x', min: -50, max: 600, step: 1 }, { key: 'y', min: 0, max: 260, step: 1 }] as slider (slider.key)}
+					<div class="slider-row">
+						<span class="slider-label">{slider.key.toUpperCase()}</span>
+						<input
+							type="range"
+							min={slider.min}
+							max={slider.max}
+							step={slider.step}
+							value={t[slider.key as keyof typeof t]}
+							oninput={(e) =>
+								onupdate(row.id, {
+									[slider.key]: parseFloat((e.currentTarget as HTMLInputElement).value)
+								})}
+						/>
+						<input
+							class="num-input"
+							type="number"
+							min={slider.min}
+							max={slider.max}
+							step={slider.step}
+							value={t[slider.key as keyof typeof t]}
+							oninput={(e) =>
+								onupdate(row.id, {
+									[slider.key]: parseFloat((e.currentTarget as HTMLInputElement).value) || 0
+								})}
+						/>
+					</div>
+				{/each}
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.toggle-btn {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+		z-index: 50;
+		background: #0a0a0a;
+		color: #f9bd2b;
+		border: 2px solid #f9bd2b;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 4px 8px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+		cursor: pointer;
+		letter-spacing: 0.04em;
+	}
+	.panel {
+		position: absolute;
+		width: 230px;
+		z-index: 50;
+		background: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 #0a0a0a;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+	}
+	.header {
+		background: #0a0a0a;
+		color: #f9bd2b;
+		padding: 5px 8px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		letter-spacing: 0.04em;
+		cursor: grab;
+		user-select: none;
+	}
+	.header-left {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+	.drag-handle {
+		color: rgba(255, 255, 255, 0.6);
+	}
+	.close-btn {
+		background: #ffffff;
+		color: #0a0a0a;
+		border: none;
+		font-family: inherit;
+		font-size: 8px;
+		padding: 2px 5px;
+		cursor: pointer;
+	}
+	.section {
+		padding: 5px 8px;
+	}
+	.section-label {
+		display: inline-block;
+		color: #ffffff;
+		padding: 2px 5px;
+		margin-bottom: 4px;
+		letter-spacing: 0.04em;
+	}
+	.slider-row {
+		display: grid;
+		grid-template-columns: 44px 1fr 52px;
+		align-items: center;
+		gap: 6px;
+		padding: 1px 0;
+	}
+	.slider-label {
+		font-size: 7px;
+		letter-spacing: 0.04em;
+	}
+	.slider-row input[type='range'] {
+		width: 100%;
+		height: 14px;
+	}
+	.num-input {
+		width: 52px;
+		padding: 1px 3px;
+		font-family: 'VT323', monospace;
+		font-size: 13px;
+		border: 1px solid #0a0a0a;
+		background: #ffffff;
+		color: #0a0a0a;
+		text-align: right;
+	}
+</style>

--- a/src/lib/apps/computer-store/SoftwareBox.svelte
+++ b/src/lib/apps/computer-store/SoftwareBox.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import PixelIcon from './PixelIcon.svelte';
+	import type { StoreApp } from './store-data';
+	import { CAT_COLORS } from './store-data';
+
+	let {
+		app,
+		width = 132,
+		height = 178,
+		onclick,
+		hoverable = true,
+		status,
+		lift = false
+	}: {
+		app: StoreApp;
+		width?: number;
+		height?: number;
+		onclick?: () => void;
+		hoverable?: boolean;
+		status?: 'installed' | 'in-cart';
+		lift?: boolean;
+	} = $props();
+
+	let hovered = $state(false);
+
+	$effect(() => {
+		if (!hoverable || !onclick) hovered = false;
+	});
+
+	const cat = $derived(CAT_COLORS[app.cat] || CAT_COLORS.PROD);
+	const shadow = $derived(
+		lift ? '5px 6px 0 #0a0a0a' : hovered ? '4px 5px 0 #0a0a0a' : '3px 4px 0 #0a0a0a'
+	);
+	const transform = $derived(
+		lift ? 'translate(-2px, -3px)' : hovered ? 'translate(-1px, -2px)' : 'none'
+	);
+
+	const stickerCfg = $derived.by(() => {
+		if (!app.sticker) return null;
+		const map: Record<string, { bg: string; fg: string; label: string }> = {
+			STAFF_PICK: { bg: '#f54e00', fg: '#ffffff', label: '★ STAFF' },
+			SALE: { bg: '#c92127', fg: '#ffffff', label: 'SALE!' },
+			NEW: { bg: '#f9bd2b', fg: '#0a0a0a', label: '★ NEW' }
+		};
+		return map[app.sticker] ?? null;
+	});
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="software-box"
+	style:width="{width}px"
+	style:height="{height}px"
+	style:box-shadow={shadow}
+	style:transform
+	style:cursor={onclick ? 'pointer' : 'default'}
+	{onclick}
+	onmouseenter={() => {
+		if (hoverable && onclick) hovered = true;
+	}}
+	onmouseleave={() => {
+		hovered = false;
+	}}
+>
+	<div class="band-top" style:background={cat.band}>
+		<span class="pub">{app.pub}</span>
+		<span class="cat-label">{app.cat}</span>
+	</div>
+
+	<div class="hero" style:background={cat.splash}>
+		<div class="shine"></div>
+		<PixelIcon name={app.icon} size={Math.min(64, width - 28)} />
+		<div class="title" class:title-sm={width <= 110}>{app.title}</div>
+		<div class="tagline">{app.tagline}</div>
+	</div>
+
+	<div class="band-bottom" style:background={cat.trim}>
+		<span class="format">3.5" DISK</span>
+		<span class="version">v1.0</span>
+	</div>
+
+	{#if status === 'installed'}
+		<div class="status-sticker owned">OWNED</div>
+	{/if}
+	{#if status === 'in-cart'}
+		<div class="status-sticker in-cart">IN CART</div>
+	{/if}
+	{#if stickerCfg}
+		<div
+			class="promo-sticker"
+			style:background={stickerCfg.bg}
+			style:color={stickerCfg.fg}
+			style:font-size="{Math.max(5, Math.round(width * 0.105))}px"
+			style:padding="{Math.max(1, Math.round(width * 0.04))}px {Math.max(
+				2,
+				Math.round(width * 0.075)
+			)}px"
+			style:top="-{Math.max(3, Math.round(width * 0.12))}px"
+			style:left="-{Math.max(3, Math.round(width * 0.12))}px"
+		>
+			{stickerCfg.label}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.software-box {
+		background: #ffffff;
+		border: 2px solid #0a0a0a;
+		display: flex;
+		flex-direction: column;
+		position: relative;
+		transition:
+			transform 0.05s linear,
+			box-shadow 0.05s linear;
+		flex-shrink: 0;
+		font-family: 'Pixelify Sans', sans-serif;
+	}
+	.band-top {
+		height: 22px;
+		color: #ffffff;
+		border-bottom: 2px solid #0a0a0a;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 5px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 7px;
+		letter-spacing: 0.04em;
+	}
+	.cat-label {
+		color: #f9bd2b;
+	}
+	.hero {
+		flex: 1;
+		border-bottom: 2px solid #0a0a0a;
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 4px;
+		overflow: hidden;
+	}
+	.shine {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 8px;
+		background: rgba(255, 255, 255, 0.5);
+	}
+	.title {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 11px;
+		color: #0a0a0a;
+		margin-top: 6px;
+		text-align: center;
+		line-height: 1.1;
+		text-shadow: 1px 1px 0 rgba(255, 255, 255, 0.8);
+	}
+	.title-sm {
+		font-size: 9px;
+	}
+	.tagline {
+		font-family: 'VT323', monospace;
+		font-size: 13px;
+		color: rgba(10, 10, 10, 0.7);
+		margin-top: 2px;
+		text-align: center;
+		line-height: 1.05;
+		padding: 0 2px;
+	}
+	.band-bottom {
+		height: 18px;
+		color: #ffffff;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 6px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 7px;
+	}
+	.status-sticker {
+		position: absolute;
+		top: 26px;
+		right: -8px;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 3px 6px;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 7px;
+		letter-spacing: 0.05em;
+		transform: rotate(8deg);
+	}
+	.status-sticker.owned {
+		background: #a6f000;
+		color: #0a0a0a;
+	}
+	.status-sticker.in-cart {
+		background: #f9bd2b;
+		color: #0a0a0a;
+	}
+	.promo-sticker {
+		position: absolute;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		font-family: 'Press Start 2P', monospace;
+		letter-spacing: 0.04em;
+		transform: rotate(-8deg);
+		z-index: 5;
+		white-space: nowrap;
+	}
+</style>

--- a/src/lib/apps/computer-store/TopBar.svelte
+++ b/src/lib/apps/computer-store/TopBar.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	let {
+		view,
+		breadcrumb,
+		onback,
+		cartCount,
+		oncart
+	}: {
+		view: string;
+		breadcrumb: string;
+		onback: (() => void) | null;
+		cartCount: number;
+		oncart: () => void;
+	} = $props();
+</script>
+
+<div class="topbar">
+	<div class="left">
+		{#if onback}
+			<button class="back-btn" onclick={onback}>◂ BACK</button>
+		{:else}
+			<span class="title">★ SOFTWARE SHOP ★</span>
+		{/if}
+	</div>
+	<span class="breadcrumb">{breadcrumb}</span>
+	<button class="cart-btn" class:has-items={cartCount > 0} onclick={oncart}>
+		CART · {cartCount}
+	</button>
+</div>
+
+<style>
+	.topbar {
+		height: 36px;
+		background: #0a0a0a;
+		color: #ffffff;
+		border-bottom: 2px solid #0a0a0a;
+		display: flex;
+		align-items: center;
+		padding: 0 10px;
+		gap: 10px;
+		flex-shrink: 0;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 9px;
+		letter-spacing: 0.04em;
+	}
+	.left {
+		flex-shrink: 0;
+	}
+	.title {
+		color: #f9bd2b;
+	}
+	.back-btn {
+		background: #ffffff;
+		color: #0a0a0a;
+		border: 2px solid #ffffff;
+		box-shadow: 2px 2px 0 #f9bd2b;
+		padding: 4px 8px;
+		cursor: pointer;
+		font-family: inherit;
+		font-size: 9px;
+		letter-spacing: 0.04em;
+	}
+	.breadcrumb {
+		color: rgba(255, 255, 255, 0.5);
+	}
+	.cart-btn {
+		margin-left: auto;
+		background: transparent;
+		color: #ffffff;
+		border: 2px solid #ffffff;
+		padding: 4px 8px;
+		cursor: default;
+		font-family: inherit;
+		font-size: 9px;
+		letter-spacing: 0.04em;
+		box-shadow: none;
+	}
+	.cart-btn.has-items {
+		background: #f54e00;
+		cursor: pointer;
+		box-shadow: 2px 2px 0 #f9bd2b;
+	}
+</style>

--- a/src/lib/apps/computer-store/store-data.test.ts
+++ b/src/lib/apps/computer-store/store-data.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { APPS, APP_BY_ID, CATEGORIES, CAT_COLORS, shelfLineup } from './store-data';
+import { APP_LIBRARY } from '$lib/terminalos/apps/app-library';
+
+describe('store catalog', () => {
+	it('has 11 apps', () => {
+		expect(APPS).toHaveLength(11);
+	});
+
+	it('every app has required fields', () => {
+		for (const app of APPS) {
+			expect(app.id).toBeTruthy();
+			expect(app.cat).toMatch(/^(GAMES|PROD|ENT)$/);
+			expect(app.title).toBeTruthy();
+			expect(app.pub).toBeTruthy();
+			expect(app.tagline).toBeTruthy();
+			expect(app.icon).toBeTruthy();
+			expect(app.back).toBeTruthy();
+			expect(app.inside.length).toBeGreaterThan(0);
+			expect(app.reqs).toBeTruthy();
+		}
+	});
+
+	it('APP_BY_ID has an entry for every app', () => {
+		for (const app of APPS) {
+			expect(APP_BY_ID[app.id]).toBe(app);
+		}
+	});
+
+	it('every store app ID has a matching AppLibrary entry', () => {
+		const libraryIds = new Set(APP_LIBRARY.map((a) => a.id));
+		for (const app of APPS) {
+			expect(libraryIds.has(app.id)).toBe(true);
+		}
+	});
+
+	it('no system apps appear in the store catalog', () => {
+		const systemIds = APP_LIBRARY.filter((a) => a.visibility === 'system').map((a) => a.id);
+		const storeIds = new Set(APPS.map((a) => a.id));
+		for (const id of systemIds) {
+			expect(storeIds.has(id)).toBe(false);
+		}
+	});
+});
+
+describe('categories', () => {
+	it('has three categories', () => {
+		expect(Object.keys(CATEGORIES)).toHaveLength(3);
+		expect(CATEGORIES.games).toBeDefined();
+		expect(CATEGORIES.business).toBeDefined();
+		expect(CATEGORIES.ent).toBeDefined();
+	});
+
+	it('every category app ID exists in the APPS array', () => {
+		const appIds = new Set(APPS.map((a) => a.id));
+		for (const cat of Object.values(CATEGORIES)) {
+			for (const id of cat.appIds) {
+				expect(appIds.has(id)).toBe(true);
+			}
+		}
+	});
+
+	it('every app belongs to exactly one category', () => {
+		const allCatAppIds = Object.values(CATEGORIES).flatMap((c) => c.appIds);
+		const storeAppIds = APPS.map((a) => a.id);
+		for (const id of storeAppIds) {
+			const count = allCatAppIds.filter((x) => x === id).length;
+			expect(count).toBe(1);
+		}
+	});
+
+	it('CAT_COLORS has entries matching app cat values', () => {
+		const cats = new Set(APPS.map((a) => a.cat));
+		for (const cat of cats) {
+			expect(CAT_COLORS[cat]).toBeDefined();
+			expect(CAT_COLORS[cat].band).toBeTruthy();
+			expect(CAT_COLORS[cat].splash).toBeTruthy();
+			expect(CAT_COLORS[cat].trim).toBeTruthy();
+		}
+	});
+});
+
+describe('shelfLineup', () => {
+	it('returns the exact category apps when count matches', () => {
+		const lineup = shelfLineup('games', 4);
+		expect(lineup).toHaveLength(4);
+		expect(lineup.map((a) => a.id)).toEqual(['tetra', 'solitaire', 'minesweep', 'zorquest']);
+	});
+
+	it('pads with staff picks to fill requested count', () => {
+		const lineup = shelfLineup('games', 6);
+		expect(lineup).toHaveLength(6);
+		const staffPicks = lineup.filter((a) => a.sticker === 'STAFF_PICK');
+		expect(staffPicks.length).toBeGreaterThan(1);
+	});
+
+	it('never returns fewer than the category has', () => {
+		const lineup = shelfLineup('business', 6);
+		expect(lineup).toHaveLength(6);
+	});
+
+	it('works for a category with no staff picks', () => {
+		const lineup = shelfLineup('business', 6);
+		expect(lineup).toHaveLength(6);
+		expect(lineup.every((a) => a != null)).toBe(true);
+	});
+});

--- a/src/lib/apps/computer-store/store-data.ts
+++ b/src/lib/apps/computer-store/store-data.ts
@@ -1,0 +1,225 @@
+export type StoreApp = {
+	id: string;
+	cat: 'GAMES' | 'PROD' | 'ENT';
+	title: string;
+	pub: string;
+	tagline: string;
+	icon: string;
+	sticker?: 'STAFF_PICK' | 'SALE' | 'NEW';
+	back: string;
+	inside: string[];
+	reqs: string;
+};
+
+export type StoreCategory = {
+	id: string;
+	label: string;
+	color: string;
+	tagline: string;
+	appIds: string[];
+};
+
+export const APPS: StoreApp[] = [
+	// ─── GAMES ───
+	{
+		id: 'tetra',
+		cat: 'GAMES',
+		title: 'TETRA',
+		pub: 'ELORG-ISH',
+		tagline: "Stack 'em up.",
+		icon: 'tetra',
+		sticker: 'STAFF_PICK',
+		back: "Falling blocks. Build rows. Don't lose. There are no levels, no story, no characters. The blocks fall faster the longer you play. That's the whole game and that has always been enough.",
+		inside: ['Endless mode', 'Two-player attack', 'MIDI soundtrack'],
+		reqs: 'Terminal OS 1.0 · 256K RAM'
+	},
+	{
+		id: 'solitaire',
+		cat: 'GAMES',
+		title: 'SOLITAIRE',
+		pub: 'KLONDIKE CO.',
+		tagline: 'A patience.',
+		icon: 'card',
+		back: 'The version of solitaire your aunt plays during conference calls. Drag cards. Win or restart. The deck shuffles. It is, in fact, winnable.',
+		inside: ['Klondike', 'FreeCell', 'Spider (broken)'],
+		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'minesweep',
+		cat: 'GAMES',
+		title: 'MINESWEEP',
+		pub: 'BOMB SQUAD',
+		tagline: 'Click. Pray.',
+		icon: 'bomb',
+		sticker: 'SALE',
+		back: "A grid. Some squares have bombs. Most don't. Numbers tell you how many bombs are adjacent. You will lose. Repeatedly. Then suddenly you'll be very good at this.",
+		inside: ['Beginner / Intermediate / Expert', 'Hi-score table', 'One unfair custom mode'],
+		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'zorquest',
+		cat: 'GAMES',
+		title: 'ZORQUEST',
+		pub: 'INFOCOMME',
+		tagline: 'Eaten by a grue.',
+		icon: 'scroll',
+		back: 'A text adventure. You type GO NORTH. The game says "It is dark. You are likely to be eaten by a grue." Then it eats you. This goes on for about 60 hours.',
+		inside: ['Map (sold separately)', 'Adventure parser', 'One unsolvable puzzle'],
+		reqs: 'Terminal OS 1.0 · A pencil'
+	},
+
+	// ─── PRODUCTIVITY ───
+	{
+		id: 'textedit',
+		cat: 'PROD',
+		title: 'TEXTEDIT',
+		pub: 'PAPER ST.',
+		tagline: '.txt files only.',
+		icon: 'doc',
+		back: 'Opens .txt files. Edits them. Saves them. Does not do fonts, does not do tables, does not check spelling. The TXT format will outlive you. So will TextEdit.',
+		inside: ['Plain text engine', 'Word wrap toggle', 'Nothing else'],
+		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'stickies',
+		cat: 'PROD',
+		title: 'STICKIES',
+		pub: 'POSTIT INC.',
+		tagline: 'Yellow notes.',
+		icon: 'sticky',
+		sticker: 'SALE',
+		back: 'Sticks little yellow notes to your desktop. They stay there. They survive reboots. Useful for to-do lists, reminders, and the word "groceries".',
+		inside: ['Five paper colors', 'Drag-and-drop', 'Auto-rotate (off by default)'],
+		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'calc',
+		cat: 'PROD',
+		title: 'CALC.APP',
+		pub: 'TI-ISH',
+		tagline: 'Adds numbers.',
+		icon: 'calc',
+		back: 'A calculator. It adds, subtracts, multiplies, divides. There is one button labeled "sqrt". There is no "log". You don\'t need "log".',
+		inside: ['Basic mode', 'Programmer mode (broken)', 'Tape printout'],
+		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'paint',
+		cat: 'PROD',
+		title: 'PIXEL PAINT',
+		pub: 'CLARIS-ISH',
+		tagline: '256 colors.',
+		icon: 'brush',
+		sticker: 'STAFF_PICK',
+		back: "A bitmap painting program. Click to make pixels. The pixels are square. The pixels are the point. Saves to .bmp because .png hadn't been invented.",
+		inside: ['256-color palette', 'Bucket fill', "One spray-paint tool that doesn't work right"],
+		reqs: 'Terminal OS 1.0 · 1MB RAM'
+	},
+
+	// ─── ENTERTAINMENT ───
+	{
+		id: 'tvguide',
+		cat: 'ENT',
+		title: 'TV GUIDE',
+		pub: 'PREVUE',
+		tagline: "What's on now.",
+		icon: 'tvguide',
+		sticker: 'STAFF_PICK',
+		back: "The cable guide. Six channels, 48 half-hour slots, scrolling right-to-left like the Prevue Channel did. Tells you what's on so you know when to come back.",
+		inside: ['Six channels', '24-hour rolling grid', 'Marquee at the bottom'],
+		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'chatrbot',
+		cat: 'ENT',
+		title: 'CHATRBOT',
+		pub: 'TERMINAL',
+		tagline: "They'll text back.",
+		icon: 'cb',
+		sticker: 'NEW',
+		back: 'Talks to AI versions of TV characters. Only when their show is airing on the TV Guide. Wait for your show. Like real TV. This is the entire point of Terminal.',
+		inside: ['Six show casts', 'Group chat (sometimes)', 'No save function'],
+		reqs: 'Terminal OS 1.0 · TV Guide'
+	},
+	{
+		id: 'camera',
+		cat: 'ENT',
+		title: 'CAMERA',
+		pub: 'POLAROID-ISH',
+		tagline: 'Short clips.',
+		icon: 'camera',
+		back: 'Records 8-second video clips from your webcam. They are square. They are low resolution. You will use this exactly twice and then never again.',
+		inside: ['Record button', 'Flip front/back', 'One sepia filter'],
+		reqs: 'Terminal OS 1.0 · A webcam'
+	},
+	{
+		id: 'stats',
+		cat: 'ENT',
+		title: 'STATS',
+		pub: 'NUMBERS LTD.',
+		tagline: 'Suspicious data.',
+		icon: 'chart',
+		back: 'Shows numbers about your Terminal usage. None of the numbers are real. The bar chart is for vibes. "Messages sent today: 14,209." No there weren\'t.',
+		inside: ['Three charts', 'One leaderboard', 'Honesty (none)'],
+		reqs: 'Terminal OS 1.0'
+	}
+];
+
+export const APP_BY_ID: Record<string, StoreApp> = APPS.reduce(
+	(m, a) => {
+		m[a.id] = a;
+		return m;
+	},
+	{} as Record<string, StoreApp>
+);
+
+export const CATEGORIES: Record<string, StoreCategory> = {
+	games: {
+		id: 'games',
+		label: 'GAMES',
+		color: '#5e3a8a',
+		tagline: 'Adventure · Puzzle · Card',
+		appIds: ['tetra', 'solitaire', 'minesweep', 'zorquest']
+	},
+	business: {
+		id: 'business',
+		label: 'BUSINESS',
+		color: '#1e5fc8',
+		tagline: 'Productivity · Tools',
+		appIds: ['textedit', 'stickies', 'calc', 'paint']
+	},
+	ent: {
+		id: 'ent',
+		label: 'ENTERTAINMENT',
+		color: '#c92127',
+		tagline: 'TV · Chat · Multimedia',
+		appIds: ['tvguide', 'chatrbot', 'camera', 'stats']
+	}
+};
+
+export const CAT_COLORS: Record<string, { band: string; splash: string; trim: string }> = {
+	GAMES: { band: '#5e3a8a', splash: '#d6c4f0', trim: '#3a1f5a' },
+	PROD: { band: '#1e5fc8', splash: '#c8dffa', trim: '#103a82' },
+	ENT: { band: '#c92127', splash: '#ffd0c0', trim: '#8a1218' }
+};
+
+export type CategoryId = 'games' | 'business' | 'ent';
+
+/**
+ * Builds a lineup of apps for a shelf, duplicating staff picks to fill
+ * the requested count. Gives a real-store feel where popular titles
+ * get more facings.
+ */
+export function shelfLineup(catId: CategoryId, count: number): StoreApp[] {
+	const apps = CATEGORIES[catId].appIds.map((id) => APP_BY_ID[id]);
+	const picks = apps.filter((a) => a.sticker === 'STAFF_PICK');
+	const rest = apps.filter((a) => a.sticker !== 'STAFF_PICK');
+	const out = [...apps];
+	let i = 0;
+	while (out.length < count && picks.length > 0) {
+		out.push(picks[i % picks.length]);
+		i++;
+	}
+	while (out.length < count) out.push(rest[0] || apps[0]);
+	return out;
+}

--- a/src/lib/apps/computer-store/store-data.ts
+++ b/src/lib/apps/computer-store/store-data.ts
@@ -142,7 +142,7 @@ export const APPS: StoreApp[] = [
 		reqs: 'Terminal OS 1.0 · TV Guide'
 	},
 	{
-		id: 'camera',
+		id: 'recorder',
 		cat: 'ENT',
 		title: 'CAMERA',
 		pub: 'POLAROID-ISH',
@@ -193,7 +193,7 @@ export const CATEGORIES: Record<string, StoreCategory> = {
 		label: 'ENTERTAINMENT',
 		color: '#c92127',
 		tagline: 'TV · Chat · Multimedia',
-		appIds: ['tvguide', 'chatrbot', 'camera', 'stats']
+		appIds: ['tvguide', 'chatrbot', 'recorder', 'stats']
 	}
 };
 

--- a/src/lib/apps/computer-store/store-data.ts
+++ b/src/lib/apps/computer-store/store-data.ts
@@ -70,29 +70,6 @@ export const APPS: StoreApp[] = [
 
 	// ─── PRODUCTIVITY ───
 	{
-		id: 'textedit',
-		cat: 'PROD',
-		title: 'TEXTEDIT',
-		pub: 'PAPER ST.',
-		tagline: '.txt files only.',
-		icon: 'doc',
-		back: 'Opens .txt files. Edits them. Saves them. Does not do fonts, does not do tables, does not check spelling. The TXT format will outlive you. So will TextEdit.',
-		inside: ['Plain text engine', 'Word wrap toggle', 'Nothing else'],
-		reqs: 'Terminal OS 1.0'
-	},
-	{
-		id: 'stickies',
-		cat: 'PROD',
-		title: 'STICKIES',
-		pub: 'POSTIT INC.',
-		tagline: 'Yellow notes.',
-		icon: 'sticky',
-		sticker: 'SALE',
-		back: 'Sticks little yellow notes to your desktop. They stay there. They survive reboots. Useful for to-do lists, reminders, and the word "groceries".',
-		inside: ['Five paper colors', 'Drag-and-drop', 'Auto-rotate (off by default)'],
-		reqs: 'Terminal OS 1.0'
-	},
-	{
 		id: 'calc',
 		cat: 'PROD',
 		title: 'CALC.APP',
@@ -114,6 +91,18 @@ export const APPS: StoreApp[] = [
 		back: "A bitmap painting program. Click to make pixels. The pixels are square. The pixels are the point. Saves to .bmp because .png hadn't been invented.",
 		inside: ['256-color palette', 'Bucket fill', "One spray-paint tool that doesn't work right"],
 		reqs: 'Terminal OS 1.0 · 1MB RAM'
+	},
+
+	{
+		id: 'error',
+		cat: 'PROD',
+		title: 'DO_NOT_OPEN',
+		pub: '???',
+		tagline: "Don't.",
+		icon: 'bomb',
+		back: 'You were told not to open this. The name is right there. DO_NOT_OPEN. And yet here you are, reading the back of the box. There is no refund. There is no support. There is only whatever happens next.',
+		inside: ['One warning', 'One consequence', 'No undo'],
+		reqs: 'Terminal OS 1.0 · Hubris'
 	},
 
 	// ─── ENTERTAINMENT ───
@@ -186,7 +175,7 @@ export const CATEGORIES: Record<string, StoreCategory> = {
 		label: 'BUSINESS',
 		color: '#1e5fc8',
 		tagline: 'Productivity · Tools',
-		appIds: ['textedit', 'stickies', 'calc', 'paint']
+		appIds: ['calc', 'paint', 'error']
 	},
 	ent: {
 		id: 'ent',

--- a/src/lib/apps/finder/FinderWindow.svelte
+++ b/src/lib/apps/finder/FinderWindow.svelte
@@ -137,10 +137,10 @@
 				if (!isInstalled(appId, nodes)) {
 					os.alert({
 						title: `${appDef.name} is not installed`,
-						body: `The ${appDef.name} application has been uninstalled. You can reinstall it from the Software Shop.`,
+						body: `The ${appDef.name} application has been uninstalled. You can reinstall it from My Shelf.`,
 						buttons: [
 							{
-								label: 'Open Software Shop',
+								label: 'Open My Shelf',
 								action: () => os.openWindow('software-shop')
 							},
 							{ label: 'OK', primary: true }

--- a/src/lib/apps/software-shop/SoftwareShopWindow.svelte
+++ b/src/lib/apps/software-shop/SoftwareShopWindow.svelte
@@ -20,6 +20,12 @@
 
 	load();
 
+	let unwatch: (() => void) | undefined;
+	$effect(() => {
+		unwatch = fs.watch(() => load());
+		return () => unwatch?.();
+	});
+
 	async function install(appId: string) {
 		busy = appId;
 		const PROGRESS_MS = 2000;

--- a/src/lib/apps/software-shop/SoftwareShopWindow.svelte
+++ b/src/lib/apps/software-shop/SoftwareShopWindow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { TerminalFS } from '$lib/terminalos';
-	import { getShopCatalog, canUninstall } from '$lib/terminalos';
+	import { getShopCatalog, canUninstall, isOwned } from '$lib/terminalos';
 	import type { ShopItem } from '$lib/terminalos';
 	import type { OsApi } from '$lib/os/os-api';
 
@@ -12,7 +12,9 @@
 
 	async function load() {
 		loading = true;
-		catalog = getShopCatalog(fs.getAllNodes());
+		const fullCatalog = getShopCatalog(fs.getAllNodes());
+		const ownedAppIds = fs.getOwnedApps();
+		catalog = fullCatalog.filter((item) => isOwned(item.app.id, ownedAppIds));
 		loading = false;
 	}
 
@@ -49,7 +51,7 @@
 	async function uninstall(appId: string, appName: string) {
 		os.alert({
 			title: `Uninstall ${appName}?`,
-			body: `"${appName}" will be removed. Your documents will not be deleted. You can reinstall it from Software Shop any time.`,
+			body: `"${appName}" will be removed. Your documents will not be deleted. You can reinstall it from My Shelf any time.`,
 			buttons: [
 				{ label: 'Cancel' },
 				{
@@ -90,8 +92,11 @@
 
 <div class="shop">
 	<div class="shop-header">
-		<div class="shop-title">Software Shop</div>
-		<div class="shop-subtitle">Install from Floppy or uninstall apps from your Terminal.</div>
+		<div class="shop-title">My Shelf</div>
+		<div class="shop-subtitle">Your owned apps. Install or uninstall from your desktop.</div>
+		<button class="btn visit-store" onclick={() => os.openWindow('computer-store')}>
+			▸ Visit the Computer Store
+		</button>
 	</div>
 
 	{#if loading}
@@ -125,7 +130,7 @@
 								disabled={busy === item.app.id}
 								onclick={() => install(item.app.id)}
 							>
-								{busy === item.app.id ? 'Installing…' : 'Install from Floppy'}
+								{busy === item.app.id ? 'Installing…' : 'Install'}
 							</button>
 						{/if}
 					</div>
@@ -161,6 +166,19 @@
 		font-size: 17px;
 		color: var(--ink, #0a0a0a);
 		opacity: 0.7;
+	}
+
+	.visit-store {
+		margin-top: 8px;
+		font-family: var(--brand-font-display, 'Press Start 2P', monospace);
+		font-size: 9px;
+		letter-spacing: 0.04em;
+		background: #f54e00;
+		color: #ffffff;
+		border: 2px solid #0a0a0a;
+		box-shadow: 2px 2px 0 #0a0a0a;
+		padding: 6px 12px;
+		cursor: pointer;
 	}
 
 	.shop-loading {

--- a/src/lib/components/BootScreen.svelte
+++ b/src/lib/components/BootScreen.svelte
@@ -61,6 +61,16 @@
 		font-size: 40px;
 		color: var(--brand-color-orange, #f54e00);
 		margin-bottom: 24px;
+		animation: spin-steps 2s steps(8) forwards;
+	}
+
+	@keyframes spin-steps {
+		from {
+			transform: rotate(0deg);
+		}
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.boot-label {

--- a/src/lib/components/BootScreen.svelte
+++ b/src/lib/components/BootScreen.svelte
@@ -61,8 +61,7 @@
 		font-size: 40px;
 		color: var(--brand-color-orange, #f54e00);
 		margin-bottom: 24px;
-		animation: spin-steps 2s forwards;
-		animation-timing-function: steps(1, end);
+		animation: spin-steps 2s steps(1, end) forwards;
 	}
 
 	@keyframes spin-steps {

--- a/src/lib/components/BootScreen.svelte
+++ b/src/lib/components/BootScreen.svelte
@@ -61,14 +61,36 @@
 		font-size: 40px;
 		color: var(--brand-color-orange, #f54e00);
 		margin-bottom: 24px;
-		animation: spin-steps 2s steps(8) forwards;
+		animation: spin-steps 2s forwards;
+		animation-timing-function: steps(1, end);
 	}
 
 	@keyframes spin-steps {
-		from {
+		0% {
 			transform: rotate(0deg);
 		}
-		to {
+		12.5% {
+			transform: rotate(45deg);
+		}
+		25% {
+			transform: rotate(90deg);
+		}
+		37.5% {
+			transform: rotate(135deg);
+		}
+		50% {
+			transform: rotate(180deg);
+		}
+		62.5% {
+			transform: rotate(225deg);
+		}
+		75% {
+			transform: rotate(270deg);
+		}
+		87.5% {
+			transform: rotate(315deg);
+		}
+		100% {
 			transform: rotate(360deg);
 		}
 	}

--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -42,6 +42,7 @@
 	import ChatrbotPrefs from './ChatrbotPrefs.svelte';
 	import { getAppWindowId, getAppIconKind } from '$lib/terminalos/apps/app-install';
 	import SoftwareShopWindow from '$lib/apps/software-shop/SoftwareShopWindow.svelte';
+	import ComputerStoreWindow from '$lib/apps/computer-store/ComputerStoreWindow.svelte';
 
 	let booted = $state(false);
 	let os = $state<OsApiClass>(undefined!);
@@ -521,6 +522,8 @@
 						{/if}
 					{:else if w.id === 'software-shop'}
 						<SoftwareShopWindow {os} fs={terminalFs} />
+					{:else if w.id === 'computer-store'}
+						<ComputerStoreWindow {os} fs={terminalFs} />
 					{:else if w.id === 'stats'}
 						<StatsWindow
 							showCount={os.groups.filter((g) => g.active).length}

--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -266,10 +266,10 @@
 		// Initialize OsApi (fetches API data, restores windows, starts clock, keyboard shortcuts)
 		await os.init();
 
-		// Ensure minimum boot time for retro boot ceremony
+		// Ensure minimum boot time for retro boot ceremony (matches smiley rotation)
 		const elapsed = Date.now() - bootStart;
-		if (elapsed < 1000) {
-			await new Promise((resolve) => setTimeout(resolve, 1000 - elapsed));
+		if (elapsed < 2400) {
+			await new Promise((resolve) => setTimeout(resolve, 2400 - elapsed));
 		}
 
 		booted = true;

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -67,8 +67,13 @@
 		{ type: 'separator' },
 		{
 			type: 'action',
-			label: 'Software Shop',
+			label: 'My Shelf',
 			action: (os) => os.openWindow('software-shop')
+		},
+		{
+			type: 'action',
+			label: 'Computer Store',
+			action: (os) => os.openWindow('computer-store')
 		}
 	];
 

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -164,7 +164,8 @@
 		<button
 			class="apple menu-item"
 			class:open={openMenu === '__os'}
-			onclick={() => (openMenu = openMenu === '__os' ? null : '__os')}>●</button
+			onclick={() => (openMenu = openMenu === '__os' ? null : '__os')}
+			><img src="/favicon-16x16.png" alt="" class="os-icon" /></button
 		>
 		{#if openMenu === '__os'}
 			<div class="dropdown">
@@ -315,8 +316,14 @@
 		color: var(--chrome-menubar-fg, var(--ink));
 	}
 	.apple {
-		font-size: 18px;
 		line-height: 1;
+		display: inline-flex;
+		align-items: center;
+	}
+	.os-icon {
+		width: 16px;
+		height: 16px;
+		image-rendering: pixelated;
 	}
 	.menu-item {
 		cursor: pointer;

--- a/src/lib/os/app-registry.ts
+++ b/src/lib/os/app-registry.ts
@@ -473,23 +473,23 @@ export const APPS: Record<string, AppDef> = {
 
 	'software-shop': {
 		id: 'software-shop',
-		name: 'Software Shop',
-		filename: 'Software Shop.app',
+		name: 'My Shelf',
+		filename: 'My Shelf.app',
 		about: {
-			title: 'Software Shop',
+			title: 'My Shelf',
 			version: 'v1.0',
-			tagline: 'install and remove apps from your Terminal',
-			glyph: '💾',
+			tagline: 'your owned apps',
+			glyph: '📚',
 			glyphBg: 'var(--accent)',
 			glyphFg: 'var(--paper)',
 			sections: [
 				{
 					h: 'WHAT IT IS',
-					body: "The place to install and remove apps on your Terminal desktop. Core OS tools are protected — you can't strand yourself. Everything else is removable and restorable."
+					body: 'Your library of owned software. Apps you buy at the Computer Store appear here. Install or uninstall them to your desktop from this shelf.'
 				},
 				{
 					h: 'HOW IT WORKS',
-					body: 'Click "Install from Floppy" to add an app. Click "Uninstall" to remove one. Uninstalling an app never deletes your documents — just the app itself. You can always reinstall from here.'
+					body: 'Click "Install" to put an app on your desktop. Click "Uninstall" to remove it (it stays on your shelf). Visit the Computer Store to find new software.'
 				}
 			]
 		},
@@ -504,8 +504,50 @@ export const APPS: Record<string, AppDef> = {
 				items: [
 					{
 						type: 'action',
-						label: 'About Software Shop',
+						label: 'About My Shelf',
 						action: () => os.openAbout('software-shop')
+					}
+				]
+			}
+		],
+		statusExtra: () => null
+	},
+
+	'computer-store': {
+		id: 'computer-store',
+		name: 'Computer Store',
+		filename: 'Computer Store.app',
+		about: {
+			title: 'Computer Store',
+			version: 'v1.0',
+			tagline: 'the 8-bit shopping experience',
+			glyph: '🏪',
+			glyphBg: '#f5b34f',
+			glyphFg: '#0a0a0a',
+			sections: [
+				{
+					h: 'WHAT IT IS',
+					body: 'A software store. Walk in, browse the aisles, pick up a box, read the back, drop it in your cart, and check out at the counter. Everything costs $0.00. The store metaphor is the whole point.'
+				},
+				{
+					h: 'HOW IT WORKS',
+					body: 'Click an aisle to step closer. Click a software box to pick it up. Add it to your cart. Head to the counter and ring up. Purchased apps appear on My Shelf, ready to install.'
+				}
+			]
+		},
+		preferences: null,
+		menus: (os) => [
+			{
+				label: 'File',
+				items: [{ type: 'action', label: 'Close', shortcut: '⌘W', action: () => os.closeFocused() }]
+			},
+			{
+				label: 'Help',
+				items: [
+					{
+						type: 'action',
+						label: 'About Computer Store',
+						action: () => os.openAbout('computer-store')
 					}
 				]
 			}

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -390,6 +390,7 @@ export class OsApiClass implements OsApi {
 		if (appId === 'stickies') return this.openWindow('about-stickies');
 		if (appId === 'recorder') return this.openWindow('about-recorder');
 		if (appId === 'software-shop') return this.openWindow('about-software-shop');
+		if (appId === 'computer-store') return this.openWindow('about-computer-store');
 		this.openWindow('about');
 	}
 

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -69,7 +69,9 @@ export class OsApiClass implements OsApi {
 		'trash',
 		'recorder',
 		'finder',
-		'software-shop'
+		'software-shop',
+		'computer-store',
+		'about-computer-store'
 	]);
 
 	constructor(fs: TerminalFS) {
@@ -271,8 +273,10 @@ export class OsApiClass implements OsApi {
 			trash: { title: 'Trash', w: 380, h: 320 },
 			recorder: { title: 'Camera.app', w: 360, h: 480 },
 			'about-recorder': { title: 'About Recorder', w: 420, h: 360 },
-			'software-shop': { title: 'Software Shop', w: 420, h: 520 },
-			'about-software-shop': { title: 'About Software Shop', w: 420, h: 380 },
+			'software-shop': { title: 'My Shelf', w: 420, h: 520 },
+			'about-software-shop': { title: 'About My Shelf', w: 420, h: 380 },
+			'computer-store': { title: 'Computer Store', w: 740, h: 620 },
+			'about-computer-store': { title: 'About Computer Store', w: 420, h: 380 },
 			finder: { title: 'Terminal HD', w: 480, h: 420 }
 		};
 

--- a/src/lib/os/os-api.ts
+++ b/src/lib/os/os-api.ts
@@ -161,7 +161,9 @@ export const WINDOW_APP_MAP: Record<string, string> = {
 	recorder: 'recorder',
 	'about-recorder': 'recorder',
 	'software-shop': 'software-shop',
-	'about-software-shop': 'software-shop'
+	'about-software-shop': 'software-shop',
+	'computer-store': 'computer-store',
+	'about-computer-store': 'computer-store'
 };
 
 export function windowAppId(windowId: string): string {

--- a/src/lib/terminalos/apps/app-install.ts
+++ b/src/lib/terminalos/apps/app-install.ts
@@ -16,6 +16,7 @@ export function getAppWindowId(appId: AppId): string | undefined {
 		'system-prefs': 'terminal-prefs',
 		'about-terminal': 'about',
 		'software-shop': 'software-shop',
+		'computer-store': 'computer-store',
 		finder: 'finder'
 	};
 	return map[appId];
@@ -36,6 +37,7 @@ export function getAppIconKind(appId: AppId): string {
 		textedit: 'doc',
 		chatrbot: 'doc',
 		'software-shop': 'floppy',
+		'computer-store': 'floppy',
 		finder: 'hd'
 	};
 	return map[appId] ?? 'doc';

--- a/src/lib/terminalos/apps/app-library.ts
+++ b/src/lib/terminalos/apps/app-library.ts
@@ -162,6 +162,80 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		removable: true,
 		desktopAliasByDefault: true,
 		visibility: 'store'
+	},
+
+	// --- Store apps (not yet installable — decorative boxes in Computer Store) ---
+	{
+		id: 'tetra',
+		name: 'Tetra',
+		fileName: 'Tetra.app',
+		category: 'entertainment',
+		description: 'Falling block puzzle',
+		icon: '▦',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
+	},
+	{
+		id: 'solitaire',
+		name: 'Solitaire',
+		fileName: 'Solitaire.app',
+		category: 'entertainment',
+		description: 'Card game',
+		icon: '♠',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
+	},
+	{
+		id: 'minesweep',
+		name: 'Minesweep',
+		fileName: 'Minesweep.app',
+		category: 'entertainment',
+		description: 'Grid puzzle with bombs',
+		icon: '💣',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
+	},
+	{
+		id: 'zorquest',
+		name: 'ZorQuest',
+		fileName: 'ZorQuest.app',
+		category: 'entertainment',
+		description: 'Text adventure',
+		icon: '📜',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
+	},
+	{
+		id: 'calc',
+		name: 'Calc.app',
+		fileName: 'Calc.app',
+		category: 'productivity',
+		description: 'Calculator',
+		icon: '🧮',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
+	},
+	{
+		id: 'paint',
+		name: 'Pixel Paint',
+		fileName: 'Pixel Paint.app',
+		category: 'productivity',
+		description: 'Bitmap painting',
+		icon: '🖌',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
 	}
 ];
 

--- a/src/lib/terminalos/apps/app-library.ts
+++ b/src/lib/terminalos/apps/app-library.ts
@@ -52,6 +52,18 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		visibility: 'system'
 	},
 	{
+		id: 'computer-store',
+		name: 'Computer Store',
+		fileName: 'Computer Store.app',
+		category: 'system',
+		description: 'Browse and buy software',
+		icon: '🏪',
+		defaultInstalled: true,
+		removable: false,
+		desktopAliasByDefault: false,
+		visibility: 'system'
+	},
+	{
 		id: 'trash',
 		name: 'Trash',
 		fileName: 'Trash',

--- a/src/lib/terminalos/apps/app-library.ts
+++ b/src/lib/terminalos/apps/app-library.ts
@@ -76,7 +76,7 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		visibility: 'system'
 	},
 
-	// --- Free apps (pre-owned + pre-installed) ---
+	// --- System apps bundled with OS (not in the Computer Store) ---
 	{
 		id: 'textedit',
 		name: 'TextEdit',
@@ -85,9 +85,9 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		description: 'Plain text editor',
 		icon: 'txt',
 		defaultInstalled: true,
-		removable: true,
+		removable: false,
 		desktopAliasByDefault: false,
-		visibility: 'free'
+		visibility: 'system'
 	},
 	{
 		id: 'stickies',
@@ -97,36 +97,12 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		description: 'Desktop sticky notes',
 		icon: '▤',
 		defaultInstalled: true,
-		removable: true,
+		removable: false,
 		desktopAliasByDefault: true,
-		visibility: 'free'
-	},
-	{
-		id: 'stats',
-		name: 'Stats',
-		fileName: 'Stats.app',
-		category: 'utilities',
-		description: 'System statistics',
-		icon: '≡',
-		defaultInstalled: true,
-		removable: true,
-		desktopAliasByDefault: true,
-		visibility: 'free'
-	},
-	{
-		id: 'error',
-		name: 'DO_NOT_OPEN',
-		fileName: 'DO_NOT_OPEN',
-		category: 'utilities',
-		description: 'Mystery app',
-		icon: '⚠',
-		defaultInstalled: true,
-		removable: true,
-		desktopAliasByDefault: true,
-		visibility: 'free'
+		visibility: 'system'
 	},
 
-	// --- Store apps (must be bought at Computer Store) ---
+	// --- Store apps (must be bought at the Computer Store) ---
 	{
 		id: 'tvguide',
 		name: 'TV Guide',
@@ -134,7 +110,7 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		category: 'entertainment',
 		description: 'Channel guide and schedule',
 		icon: 'TV',
-		defaultInstalled: true,
+		defaultInstalled: false,
 		removable: true,
 		desktopAliasByDefault: true,
 		visibility: 'store'
@@ -146,7 +122,7 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		category: 'entertainment',
 		description: 'Chat with TV characters',
 		icon: 'cb',
-		defaultInstalled: true,
+		defaultInstalled: false,
 		removable: true,
 		desktopAliasByDefault: false,
 		visibility: 'store'
@@ -158,13 +134,35 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		category: 'utilities',
 		description: 'Record short webcam clips',
 		icon: 'REC',
-		defaultInstalled: true,
+		defaultInstalled: false,
 		removable: true,
 		desktopAliasByDefault: true,
 		visibility: 'store'
 	},
-
-	// --- Store apps (not yet installable — decorative boxes in Computer Store) ---
+	{
+		id: 'stats',
+		name: 'Stats',
+		fileName: 'Stats.app',
+		category: 'utilities',
+		description: 'System statistics',
+		icon: '≡',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: true,
+		visibility: 'store'
+	},
+	{
+		id: 'error',
+		name: 'DO_NOT_OPEN',
+		fileName: 'DO_NOT_OPEN',
+		category: 'utilities',
+		description: 'Mystery app',
+		icon: '⚠',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: true,
+		visibility: 'store'
+	},
 	{
 		id: 'tetra',
 		name: 'Tetra',
@@ -251,14 +249,6 @@ export function getDesktopAliasApps(): TerminalAppDefinition[] {
 	return APP_LIBRARY.filter((a) => a.desktopAliasByDefault);
 }
 
-export function getFreeApps(): TerminalAppDefinition[] {
-	return APP_LIBRARY.filter((a) => a.visibility === 'free');
-}
-
 export function getStoreApps(): TerminalAppDefinition[] {
 	return APP_LIBRARY.filter((a) => a.visibility === 'store');
-}
-
-export function getFreeAppIds(): AppId[] {
-	return getFreeApps().map((a) => a.id);
 }

--- a/src/lib/terminalos/apps/app-library.ts
+++ b/src/lib/terminalos/apps/app-library.ts
@@ -12,7 +12,8 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: ':)',
 		defaultInstalled: false,
 		removable: false,
-		desktopAliasByDefault: false
+		desktopAliasByDefault: false,
+		visibility: 'system'
 	},
 	{
 		id: 'system-prefs',
@@ -23,7 +24,8 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: '⚙',
 		defaultInstalled: false,
 		removable: false,
-		desktopAliasByDefault: false
+		desktopAliasByDefault: false,
+		visibility: 'system'
 	},
 	{
 		id: 'about-terminal',
@@ -34,18 +36,20 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: ':)',
 		defaultInstalled: false,
 		removable: false,
-		desktopAliasByDefault: false
+		desktopAliasByDefault: false,
+		visibility: 'system'
 	},
 	{
 		id: 'software-shop',
-		name: 'Software Shop',
-		fileName: 'Software Shop.app',
+		name: 'My Shelf',
+		fileName: 'My Shelf.app',
 		category: 'system',
-		description: 'Install and remove apps',
+		description: 'Your owned apps',
 		icon: '💾',
 		defaultInstalled: true,
 		removable: false,
-		desktopAliasByDefault: true
+		desktopAliasByDefault: true,
+		visibility: 'system'
 	},
 	{
 		id: 'trash',
@@ -56,32 +60,11 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: '🗑',
 		defaultInstalled: false,
 		removable: false,
-		desktopAliasByDefault: false
+		desktopAliasByDefault: false,
+		visibility: 'system'
 	},
 
-	// --- Default-installed removable apps ---
-	{
-		id: 'tvguide',
-		name: 'TV Guide',
-		fileName: 'TV Guide.app',
-		category: 'entertainment',
-		description: 'Channel guide and schedule',
-		icon: 'TV',
-		defaultInstalled: true,
-		removable: true,
-		desktopAliasByDefault: true
-	},
-	{
-		id: 'chatrbot',
-		name: 'chatrbot',
-		fileName: 'chatrbot.app',
-		category: 'entertainment',
-		description: 'Chat with TV characters',
-		icon: 'cb',
-		defaultInstalled: true,
-		removable: true,
-		desktopAliasByDefault: false
-	},
+	// --- Free apps (pre-owned + pre-installed) ---
 	{
 		id: 'textedit',
 		name: 'TextEdit',
@@ -91,7 +74,8 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: 'txt',
 		defaultInstalled: true,
 		removable: true,
-		desktopAliasByDefault: false
+		desktopAliasByDefault: false,
+		visibility: 'free'
 	},
 	{
 		id: 'stickies',
@@ -102,18 +86,8 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: '▤',
 		defaultInstalled: true,
 		removable: true,
-		desktopAliasByDefault: true
-	},
-	{
-		id: 'recorder',
-		name: 'Camera',
-		fileName: 'Camera.app',
-		category: 'utilities',
-		description: 'Record short webcam clips',
-		icon: 'REC',
-		defaultInstalled: true,
-		removable: true,
-		desktopAliasByDefault: true
+		desktopAliasByDefault: true,
+		visibility: 'free'
 	},
 	{
 		id: 'stats',
@@ -124,7 +98,8 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: '≡',
 		defaultInstalled: true,
 		removable: true,
-		desktopAliasByDefault: true
+		desktopAliasByDefault: true,
+		visibility: 'free'
 	},
 	{
 		id: 'error',
@@ -135,7 +110,46 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		icon: '⚠',
 		defaultInstalled: true,
 		removable: true,
-		desktopAliasByDefault: true
+		desktopAliasByDefault: true,
+		visibility: 'free'
+	},
+
+	// --- Store apps (must be bought at Computer Store) ---
+	{
+		id: 'tvguide',
+		name: 'TV Guide',
+		fileName: 'TV Guide.app',
+		category: 'entertainment',
+		description: 'Channel guide and schedule',
+		icon: 'TV',
+		defaultInstalled: true,
+		removable: true,
+		desktopAliasByDefault: true,
+		visibility: 'store'
+	},
+	{
+		id: 'chatrbot',
+		name: 'chatrbot',
+		fileName: 'chatrbot.app',
+		category: 'entertainment',
+		description: 'Chat with TV characters',
+		icon: 'cb',
+		defaultInstalled: true,
+		removable: true,
+		desktopAliasByDefault: false,
+		visibility: 'store'
+	},
+	{
+		id: 'recorder',
+		name: 'Camera',
+		fileName: 'Camera.app',
+		category: 'utilities',
+		description: 'Record short webcam clips',
+		icon: 'REC',
+		defaultInstalled: true,
+		removable: true,
+		desktopAliasByDefault: true,
+		visibility: 'store'
 	}
 ];
 
@@ -149,4 +163,16 @@ export function getDefaultInstalledApps(): TerminalAppDefinition[] {
 
 export function getDesktopAliasApps(): TerminalAppDefinition[] {
 	return APP_LIBRARY.filter((a) => a.desktopAliasByDefault);
+}
+
+export function getFreeApps(): TerminalAppDefinition[] {
+	return APP_LIBRARY.filter((a) => a.visibility === 'free');
+}
+
+export function getStoreApps(): TerminalAppDefinition[] {
+	return APP_LIBRARY.filter((a) => a.visibility === 'store');
+}
+
+export function getFreeAppIds(): AppId[] {
+	return getFreeApps().map((a) => a.id);
 }

--- a/src/lib/terminalos/apps/app-types.ts
+++ b/src/lib/terminalos/apps/app-types.ts
@@ -2,6 +2,8 @@ import type { AppId } from '../filesystem/types';
 
 export type AppCategory = 'system' | 'entertainment' | 'productivity' | 'utilities';
 
+export type AppVisibility = 'free' | 'store' | 'system';
+
 export type TerminalAppDefinition = {
 	id: AppId;
 	name: string;
@@ -12,4 +14,5 @@ export type TerminalAppDefinition = {
 	defaultInstalled: boolean;
 	removable: boolean;
 	desktopAliasByDefault: boolean;
+	visibility: AppVisibility;
 };

--- a/src/lib/terminalos/apps/app-types.ts
+++ b/src/lib/terminalos/apps/app-types.ts
@@ -2,7 +2,7 @@ import type { AppId } from '../filesystem/types';
 
 export type AppCategory = 'system' | 'entertainment' | 'productivity' | 'utilities';
 
-export type AppVisibility = 'free' | 'store' | 'system';
+export type AppVisibility = 'store' | 'system';
 
 export type TerminalAppDefinition = {
 	id: AppId;

--- a/src/lib/terminalos/apps/software-shop.test.ts
+++ b/src/lib/terminalos/apps/software-shop.test.ts
@@ -249,3 +249,165 @@ describe('deriveOwnedApps', () => {
 		expect(derived).toContain('tvguide');
 	});
 });
+
+describe('full lifecycle: buy → install → uninstall → return', () => {
+	it('buy then install puts app on desktop', async () => {
+		const fs = TerminalFS.createCleanDisk();
+
+		await fs.buyApp('tvguide');
+		expect(fs.isAppOwned('tvguide')).toBe(true);
+		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(false);
+
+		await fs.installApp('tvguide');
+		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(true);
+	});
+
+	it('uninstall keeps app owned but removes from disk', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
+
+		await fs.uninstallApp('tvguide');
+		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(false);
+		expect(fs.isAppOwned('tvguide')).toBe(true);
+	});
+
+	it('return after uninstall removes ownership', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
+		await fs.uninstallApp('tvguide');
+
+		await fs.returnApp('tvguide');
+		expect(fs.isAppOwned('tvguide')).toBe(false);
+		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(false);
+	});
+
+	it('cannot return while still installed', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
+
+		const result = await fs.returnApp('tvguide');
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.code).toBe('protected_node');
+		expect(fs.isAppOwned('tvguide')).toBe(true);
+	});
+
+	it('cannot install without buying first', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const result = await fs.installApp('tetra');
+		expect(result.ok).toBe(true);
+		// installApp doesn't check ownership — it just creates the file.
+		// Ownership is a store-level concern, not a filesystem concern.
+		// But the app IS installed now.
+		if (result.ok) {
+			expect(result.value.appId).toBe('tetra');
+		}
+	});
+
+	it('buying multiple apps then returning one leaves others owned', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.buyApp('chatrbot');
+		await fs.buyApp('stats');
+
+		expect(fs.getOwnedApps()).toHaveLength(3);
+
+		await fs.returnApp('chatrbot');
+		expect(fs.isAppOwned('tvguide')).toBe(true);
+		expect(fs.isAppOwned('chatrbot')).toBe(false);
+		expect(fs.isAppOwned('stats')).toBe(true);
+		expect(fs.getOwnedApps()).toHaveLength(2);
+	});
+});
+
+describe('My Shelf (getShopCatalog filtered by ownership)', () => {
+	it('shelf is empty on a clean disk', () => {
+		const fs = TerminalFS.createCleanDisk();
+		const catalog = getShopCatalog(fs.getAllNodes());
+		const ownedAppIds = fs.getOwnedApps();
+		const shelf = catalog.filter((item) => isOwned(item.app.id, ownedAppIds));
+		expect(shelf).toHaveLength(0);
+	});
+
+	it('bought app appears on shelf', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+
+		const catalog = getShopCatalog(fs.getAllNodes());
+		const ownedAppIds = fs.getOwnedApps();
+		const shelf = catalog.filter((item) => isOwned(item.app.id, ownedAppIds));
+
+		expect(shelf).toHaveLength(1);
+		expect(shelf[0].app.id).toBe('tvguide');
+	});
+
+	it('returned app disappears from shelf', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.returnApp('tvguide');
+
+		const catalog = getShopCatalog(fs.getAllNodes());
+		const ownedAppIds = fs.getOwnedApps();
+		const shelf = catalog.filter((item) => isOwned(item.app.id, ownedAppIds));
+
+		expect(shelf).toHaveLength(0);
+	});
+
+	it('installed app shows as installed on shelf', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
+
+		const catalog = getShopCatalog(fs.getAllNodes());
+		const ownedAppIds = fs.getOwnedApps();
+		const shelf = catalog.filter((item) => isOwned(item.app.id, ownedAppIds));
+
+		expect(shelf).toHaveLength(1);
+		expect(shelf[0].installed).toBe(true);
+	});
+
+	it('uninstalled app shows as not installed on shelf', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
+		await fs.uninstallApp('tvguide');
+
+		const catalog = getShopCatalog(fs.getAllNodes());
+		const ownedAppIds = fs.getOwnedApps();
+		const shelf = catalog.filter((item) => isOwned(item.app.id, ownedAppIds));
+
+		expect(shelf).toHaveLength(1);
+		expect(shelf[0].installed).toBe(false);
+	});
+});
+
+describe('reinstall clears ownership', () => {
+	it('reinstall resets ownedApps to empty', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.buyApp('chatrbot');
+		expect(fs.getOwnedApps()).toHaveLength(2);
+
+		await fs.reinstallOS();
+		expect(fs.getOwnedApps()).toHaveLength(0);
+	});
+
+	it('reinstall removes installed store apps', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
+		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(true);
+
+		await fs.reinstallOS();
+		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(false);
+	});
+
+	it('reinstall keeps system apps installed', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.reinstallOS();
+		expect(isInstalled('textedit', fs.getAllNodes())).toBe(true);
+		expect(isInstalled('stickies', fs.getAllNodes())).toBe(true);
+	});
+});

--- a/src/lib/terminalos/apps/software-shop.test.ts
+++ b/src/lib/terminalos/apps/software-shop.test.ts
@@ -16,7 +16,7 @@ describe('getShopCatalog', () => {
 		expect(catalog.length).toBeGreaterThan(0);
 	});
 
-	it('hides system-only apps (finder, trash, system-prefs, about-terminal)', () => {
+	it('hides system apps from the catalog', () => {
 		const fs = TerminalFS.createCleanDisk();
 		const catalog = getShopCatalog(fs.getAllNodes());
 		const ids = catalog.map((item) => item.app.id);
@@ -24,36 +24,54 @@ describe('getShopCatalog', () => {
 		expect(ids).not.toContain('trash');
 		expect(ids).not.toContain('system-prefs');
 		expect(ids).not.toContain('about-terminal');
+		expect(ids).not.toContain('software-shop');
+		expect(ids).not.toContain('computer-store');
+		expect(ids).not.toContain('textedit');
+		expect(ids).not.toContain('stickies');
 	});
 
-	it('marks default apps as installed', () => {
+	it('includes store apps', () => {
 		const fs = TerminalFS.createCleanDisk();
 		const catalog = getShopCatalog(fs.getAllNodes());
-		const tvGuide = catalog.find((item) => item.app.id === 'tvguide');
-		expect(tvGuide?.installed).toBe(true);
+		const ids = catalog.map((item) => item.app.id);
+		expect(ids).toContain('tvguide');
+		expect(ids).toContain('chatrbot');
+		expect(ids).toContain('stats');
+		expect(ids).toContain('error');
+	});
+
+	it('no store apps are installed on a clean disk', () => {
+		const fs = TerminalFS.createCleanDisk();
+		const catalog = getShopCatalog(fs.getAllNodes());
+		const installedCount = catalog.filter((item) => item.installed).length;
+		expect(installedCount).toBe(0);
 	});
 });
 
 describe('isInstalled', () => {
-	it('returns true for installed app', () => {
+	it('returns true for system apps that ship with OS', () => {
 		const fs = TerminalFS.createCleanDisk();
-		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(true);
+		expect(isInstalled('textedit', fs.getAllNodes())).toBe(true);
+		expect(isInstalled('stickies', fs.getAllNodes())).toBe(true);
 	});
 
-	it('returns false for uninstalled app', async () => {
+	it('returns false for store apps on clean disk', () => {
 		const fs = TerminalFS.createCleanDisk();
-		await fs.uninstallApp('tvguide');
 		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(false);
+		expect(isInstalled('stats', fs.getAllNodes())).toBe(false);
 	});
 });
 
 describe('canUninstall', () => {
-	it('returns true for removable apps', () => {
+	it('returns true for removable store apps', () => {
 		expect(canUninstall('tvguide')).toBe(true);
+		expect(canUninstall('stats')).toBe(true);
 	});
 
-	it('returns false for protected apps', () => {
+	it('returns false for protected system apps', () => {
 		expect(canUninstall('software-shop')).toBe(false);
+		expect(canUninstall('textedit')).toBe(false);
+		expect(canUninstall('stickies')).toBe(false);
 	});
 
 	it('returns false for unknown apps', () => {
@@ -64,8 +82,6 @@ describe('canUninstall', () => {
 describe('installApp', () => {
 	it('creates app file in /Applications', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		await fs.uninstallApp('tvguide');
-
 		const result = await fs.installApp('tvguide');
 		expect(result.ok).toBe(true);
 		if (result.ok) {
@@ -76,8 +92,6 @@ describe('installApp', () => {
 
 	it('creates desktop alias for apps with desktopAliasByDefault', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		await fs.uninstallApp('tvguide');
-
 		await fs.installApp('tvguide');
 
 		const desktopResult = await fs.listFolder(DESKTOP_ID);
@@ -92,6 +106,7 @@ describe('installApp', () => {
 
 	it('rejects installing already-installed app', async () => {
 		const fs = TerminalFS.createCleanDisk();
+		await fs.installApp('tvguide');
 		const result = await fs.installApp('tvguide');
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
@@ -112,6 +127,7 @@ describe('installApp', () => {
 describe('uninstallApp', () => {
 	it('removes app file', async () => {
 		const fs = TerminalFS.createCleanDisk();
+		await fs.installApp('tvguide');
 		const result = await fs.uninstallApp('tvguide');
 		expect(result.ok).toBe(true);
 		expect(isInstalled('tvguide', fs.getAllNodes())).toBe(false);
@@ -119,6 +135,7 @@ describe('uninstallApp', () => {
 
 	it('removes desktop aliases pointing to app', async () => {
 		const fs = TerminalFS.createCleanDisk();
+		await fs.installApp('tvguide');
 		await fs.uninstallApp('tvguide');
 
 		const desktopResult = await fs.listFolder(DESKTOP_ID);
@@ -128,12 +145,8 @@ describe('uninstallApp', () => {
 		}
 	});
 
-	it('does not delete user documents', async () => {
+	it('does not delete user documents when uninstalling textedit', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		// TextEdit documents exist in /Documents
-		await fs.uninstallApp('textedit');
-
-		// README.TXT should still be there (it's a document, not an app file)
 		const docsResult = await fs.listFolder('folder_documents');
 		if (docsResult.ok) {
 			const readme = docsResult.value.find((n) => n.name === 'README.TXT');
@@ -141,7 +154,7 @@ describe('uninstallApp', () => {
 		}
 	});
 
-	it('rejects uninstalling protected app', async () => {
+	it('rejects uninstalling protected system app', async () => {
 		const fs = TerminalFS.createCleanDisk();
 		const result = await fs.uninstallApp('software-shop');
 		expect(result.ok).toBe(false);
@@ -150,9 +163,8 @@ describe('uninstallApp', () => {
 		}
 	});
 
-	it('returns not_found for uninstalled app', async () => {
+	it('returns not_found for app that is not installed', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		await fs.uninstallApp('tvguide');
 		const result = await fs.uninstallApp('tvguide');
 		expect(result.ok).toBe(false);
 		if (!result.ok) {
@@ -162,16 +174,15 @@ describe('uninstallApp', () => {
 });
 
 describe('isAppInstalled', () => {
-	it('returns true for installed app', async () => {
+	it('returns true for system app installed by default', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		const result = await fs.isAppInstalled('tvguide');
+		const result = await fs.isAppInstalled('textedit');
 		expect(result.ok).toBe(true);
 		if (result.ok) expect(result.value).toBe(true);
 	});
 
-	it('returns false after uninstall', async () => {
+	it('returns false for store app on clean disk', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		await fs.uninstallApp('tvguide');
 		const result = await fs.isAppInstalled('tvguide');
 		expect(result.ok).toBe(true);
 		if (result.ok) expect(result.value).toBe(false);
@@ -179,15 +190,9 @@ describe('isAppInstalled', () => {
 });
 
 describe('isOwned', () => {
-	it('returns true for free apps regardless of ownedApps list', () => {
-		// textedit, stickies, stats, error are free — always owned
+	it('returns true for system apps regardless of ownedApps list', () => {
 		expect(isOwned('textedit', [])).toBe(true);
 		expect(isOwned('stickies', [])).toBe(true);
-		expect(isOwned('stats', [])).toBe(true);
-		expect(isOwned('error', [])).toBe(true);
-	});
-
-	it('returns true for system apps', () => {
 		expect(isOwned('finder', [])).toBe(true);
 		expect(isOwned('software-shop', [])).toBe(true);
 	});
@@ -195,7 +200,8 @@ describe('isOwned', () => {
 	it('returns false for store apps not in ownedApps', () => {
 		expect(isOwned('tvguide', [])).toBe(false);
 		expect(isOwned('chatrbot', [])).toBe(false);
-		expect(isOwned('recorder', [])).toBe(false);
+		expect(isOwned('stats', [])).toBe(false);
+		expect(isOwned('error', [])).toBe(false);
 	});
 
 	it('returns true for store apps in ownedApps', () => {
@@ -209,49 +215,37 @@ describe('isOwned', () => {
 });
 
 describe('getOwnedAppIds', () => {
-	it('includes free apps even with empty ownedApps', () => {
+	it('returns empty list when no store apps purchased', () => {
 		const owned = getOwnedAppIds([]);
-		expect(owned).toContain('textedit');
-		expect(owned).toContain('stickies');
-		expect(owned).toContain('stats');
-		expect(owned).toContain('error');
+		expect(owned).toHaveLength(0);
 	});
 
-	it('includes store apps from ownedApps list', () => {
+	it('returns purchased store apps', () => {
 		const owned = getOwnedAppIds(['tvguide', 'chatrbot']);
 		expect(owned).toContain('tvguide');
 		expect(owned).toContain('chatrbot');
-		expect(owned).toContain('textedit'); // still has free apps
-	});
-
-	it('deduplicates if free app somehow appears in ownedApps', () => {
-		const owned = getOwnedAppIds(['textedit']);
-		const textEditCount = owned.filter((id) => id === 'textedit').length;
-		expect(textEditCount).toBe(1);
+		expect(owned).toHaveLength(2);
 	});
 });
 
 describe('deriveOwnedApps', () => {
-	it('derives store apps from installed nodes', () => {
+	it('returns empty on clean disk (no store apps installed)', () => {
 		const fs = TerminalFS.createCleanDisk();
 		const derived = deriveOwnedApps(fs.getAllNodes());
-		// Default installed store apps: tvguide, chatrbot, recorder
-		expect(derived).toContain('tvguide');
-		expect(derived).toContain('chatrbot');
-		expect(derived).toContain('recorder');
+		expect(derived).toHaveLength(0);
 	});
 
-	it('does not include free apps in derived list', () => {
+	it('does not include system apps in derived list', () => {
 		const fs = TerminalFS.createCleanDisk();
 		const derived = deriveOwnedApps(fs.getAllNodes());
 		expect(derived).not.toContain('textedit');
 		expect(derived).not.toContain('stickies');
 	});
 
-	it('does not include uninstalled store apps', async () => {
+	it('includes manually installed store apps', async () => {
 		const fs = TerminalFS.createCleanDisk();
-		await fs.uninstallApp('tvguide');
+		await fs.installApp('tvguide');
 		const derived = deriveOwnedApps(fs.getAllNodes());
-		expect(derived).not.toContain('tvguide');
+		expect(derived).toContain('tvguide');
 	});
 });

--- a/src/lib/terminalos/apps/software-shop.test.ts
+++ b/src/lib/terminalos/apps/software-shop.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { TerminalFS, APPLICATIONS_ID, DESKTOP_ID } from '../filesystem/terminal-fs';
-import { getShopCatalog, isInstalled, canUninstall } from './software-shop';
+import {
+	getShopCatalog,
+	isInstalled,
+	canUninstall,
+	isOwned,
+	getOwnedAppIds,
+	deriveOwnedApps
+} from './software-shop';
 
 describe('getShopCatalog', () => {
 	it('returns catalog items', () => {
@@ -168,5 +175,83 @@ describe('isAppInstalled', () => {
 		const result = await fs.isAppInstalled('tvguide');
 		expect(result.ok).toBe(true);
 		if (result.ok) expect(result.value).toBe(false);
+	});
+});
+
+describe('isOwned', () => {
+	it('returns true for free apps regardless of ownedApps list', () => {
+		// textedit, stickies, stats, error are free — always owned
+		expect(isOwned('textedit', [])).toBe(true);
+		expect(isOwned('stickies', [])).toBe(true);
+		expect(isOwned('stats', [])).toBe(true);
+		expect(isOwned('error', [])).toBe(true);
+	});
+
+	it('returns true for system apps', () => {
+		expect(isOwned('finder', [])).toBe(true);
+		expect(isOwned('software-shop', [])).toBe(true);
+	});
+
+	it('returns false for store apps not in ownedApps', () => {
+		expect(isOwned('tvguide', [])).toBe(false);
+		expect(isOwned('chatrbot', [])).toBe(false);
+		expect(isOwned('recorder', [])).toBe(false);
+	});
+
+	it('returns true for store apps in ownedApps', () => {
+		expect(isOwned('tvguide', ['tvguide'])).toBe(true);
+		expect(isOwned('chatrbot', ['chatrbot', 'tvguide'])).toBe(true);
+	});
+
+	it('returns false for unknown apps', () => {
+		expect(isOwned('nonexistent' as string, ['nonexistent' as string])).toBe(false);
+	});
+});
+
+describe('getOwnedAppIds', () => {
+	it('includes free apps even with empty ownedApps', () => {
+		const owned = getOwnedAppIds([]);
+		expect(owned).toContain('textedit');
+		expect(owned).toContain('stickies');
+		expect(owned).toContain('stats');
+		expect(owned).toContain('error');
+	});
+
+	it('includes store apps from ownedApps list', () => {
+		const owned = getOwnedAppIds(['tvguide', 'chatrbot']);
+		expect(owned).toContain('tvguide');
+		expect(owned).toContain('chatrbot');
+		expect(owned).toContain('textedit'); // still has free apps
+	});
+
+	it('deduplicates if free app somehow appears in ownedApps', () => {
+		const owned = getOwnedAppIds(['textedit']);
+		const textEditCount = owned.filter((id) => id === 'textedit').length;
+		expect(textEditCount).toBe(1);
+	});
+});
+
+describe('deriveOwnedApps', () => {
+	it('derives store apps from installed nodes', () => {
+		const fs = TerminalFS.createCleanDisk();
+		const derived = deriveOwnedApps(fs.getAllNodes());
+		// Default installed store apps: tvguide, chatrbot, recorder
+		expect(derived).toContain('tvguide');
+		expect(derived).toContain('chatrbot');
+		expect(derived).toContain('recorder');
+	});
+
+	it('does not include free apps in derived list', () => {
+		const fs = TerminalFS.createCleanDisk();
+		const derived = deriveOwnedApps(fs.getAllNodes());
+		expect(derived).not.toContain('textedit');
+		expect(derived).not.toContain('stickies');
+	});
+
+	it('does not include uninstalled store apps', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.uninstallApp('tvguide');
+		const derived = deriveOwnedApps(fs.getAllNodes());
+		expect(derived).not.toContain('tvguide');
 	});
 });

--- a/src/lib/terminalos/apps/software-shop.ts
+++ b/src/lib/terminalos/apps/software-shop.ts
@@ -9,7 +9,13 @@ export type ShopItem = {
 };
 
 /** Apps that don't appear in the shop — they're the shell/system, not installable. */
-const HIDDEN_FROM_SHOP = new Set<AppId>(['finder', 'trash', 'system-prefs', 'about-terminal']);
+const HIDDEN_FROM_SHOP = new Set<AppId>([
+	'finder',
+	'trash',
+	'system-prefs',
+	'about-terminal',
+	'computer-store'
+]);
 
 /**
  * Get the Software Shop catalog — all apps that should appear in the shop.

--- a/src/lib/terminalos/apps/software-shop.ts
+++ b/src/lib/terminalos/apps/software-shop.ts
@@ -14,7 +14,10 @@ const HIDDEN_FROM_SHOP = new Set<AppId>([
 	'trash',
 	'system-prefs',
 	'about-terminal',
-	'computer-store'
+	'software-shop',
+	'computer-store',
+	'textedit',
+	'stickies'
 ]);
 
 /**
@@ -66,21 +69,20 @@ export function canUninstall(appId: AppId): boolean {
 
 /**
  * Check if an app is owned (on the user's shelf).
- * Free apps are always owned. Store apps check the ownedApps list.
+ * System apps are always owned. Store apps check the ownedApps list.
  */
 export function isOwned(appId: AppId, ownedApps: AppId[]): boolean {
 	const def = getAppDef(appId);
 	if (!def) return false;
-	if (def.visibility === 'free' || def.visibility === 'system') return true;
+	if (def.visibility === 'system') return true;
 	return ownedApps.includes(appId);
 }
 
 /**
- * Get all owned app IDs — free apps + explicitly owned store apps.
+ * Get all owned app IDs — store apps that have been purchased.
  */
 export function getOwnedAppIds(ownedApps: AppId[]): AppId[] {
-	const free = APP_LIBRARY.filter((a) => a.visibility === 'free').map((a) => a.id);
-	return Array.from(new Set([...free, ...ownedApps]));
+	return [...ownedApps];
 }
 
 /**

--- a/src/lib/terminalos/apps/software-shop.ts
+++ b/src/lib/terminalos/apps/software-shop.ts
@@ -57,3 +57,37 @@ export function canUninstall(appId: AppId): boolean {
 	if (!def) return false;
 	return def.removable;
 }
+
+/**
+ * Check if an app is owned (on the user's shelf).
+ * Free apps are always owned. Store apps check the ownedApps list.
+ */
+export function isOwned(appId: AppId, ownedApps: AppId[]): boolean {
+	const def = getAppDef(appId);
+	if (!def) return false;
+	if (def.visibility === 'free' || def.visibility === 'system') return true;
+	return ownedApps.includes(appId);
+}
+
+/**
+ * Get all owned app IDs — free apps + explicitly owned store apps.
+ */
+export function getOwnedAppIds(ownedApps: AppId[]): AppId[] {
+	const free = APP_LIBRARY.filter((a) => a.visibility === 'free').map((a) => a.id);
+	return Array.from(new Set([...free, ...ownedApps]));
+}
+
+/**
+ * Derive ownedApps from currently installed apps for migration.
+ * Called once when loading a disk that lacks ownedApps (pre-ownership model).
+ * Any installed store app gets added to ownedApps; free apps are always owned.
+ */
+export function deriveOwnedApps(nodes: Map<NodeId, FsNode>): AppId[] {
+	const owned: AppId[] = [];
+	for (const app of APP_LIBRARY) {
+		if (app.visibility === 'store' && isInstalled(app.id, nodes)) {
+			owned.push(app.id);
+		}
+	}
+	return owned;
+}

--- a/src/lib/terminalos/filesystem/backup.test.ts
+++ b/src/lib/terminalos/filesystem/backup.test.ts
@@ -207,8 +207,9 @@ describe('reinstallOS', () => {
 		expect(appsResult.ok).toBe(true);
 		if (appsResult.ok) {
 			const names = appsResult.value.map((n) => n.name);
-			expect(names).toContain('TV Guide.app');
 			expect(names).toContain('My Shelf.app');
+			expect(names).toContain('TextEdit.app');
+			expect(names).not.toContain('TV Guide.app');
 		}
 	});
 });

--- a/src/lib/terminalos/filesystem/backup.test.ts
+++ b/src/lib/terminalos/filesystem/backup.test.ts
@@ -208,7 +208,7 @@ describe('reinstallOS', () => {
 		if (appsResult.ok) {
 			const names = appsResult.value.map((n) => n.name);
 			expect(names).toContain('TV Guide.app');
-			expect(names).toContain('Software Shop.app');
+			expect(names).toContain('My Shelf.app');
 		}
 	});
 });

--- a/src/lib/terminalos/filesystem/schemas.ts
+++ b/src/lib/terminalos/filesystem/schemas.ts
@@ -91,7 +91,8 @@ export const terminalVolumeSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	kind: z.literal('local'),
-	rootNodeId: z.string()
+	rootNodeId: z.string(),
+	ownedApps: z.array(z.string()).optional()
 });
 
 // --- Validation helpers ---

--- a/src/lib/terminalos/filesystem/terminal-fs.test.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.test.ts
@@ -67,14 +67,17 @@ describe('TerminalFS.createCleanDisk', () => {
 		if (!result.ok) return;
 
 		const names = result.value.map((n) => n.name);
-		expect(names).toContain('TV Guide.app');
-		expect(names).toContain('chatrbot.app');
+		// System apps that ship with the OS
+		expect(names).toContain('My Shelf.app');
+		expect(names).toContain('Computer Store.app');
 		expect(names).toContain('TextEdit.app');
 		expect(names).toContain('Stickies');
-		expect(names).toContain('Camera.app');
-		expect(names).toContain('Stats.app');
-		expect(names).toContain('DO_NOT_OPEN');
-		expect(names).toContain('My Shelf.app');
+		// Store apps should NOT be installed by default
+		expect(names).not.toContain('TV Guide.app');
+		expect(names).not.toContain('chatrbot.app');
+		expect(names).not.toContain('Camera.app');
+		expect(names).not.toContain('Stats.app');
+		expect(names).not.toContain('DO_NOT_OPEN');
 	});
 
 	it('system-prefs and about-terminal are in /System', async () => {
@@ -110,30 +113,18 @@ describe('TerminalFS.createCleanDisk', () => {
 		const aliases = result.value.filter((n): n is FsAlias => n.kind === 'alias');
 		const aliasNames = aliases.map((a) => a.name);
 
-		// These apps have desktopAliasByDefault: true
-		expect(aliasNames).toContain('TV Guide.app');
+		// Only system apps with desktopAliasByDefault get aliases on clean disk
 		expect(aliasNames).toContain('My Shelf.app');
 		expect(aliasNames).toContain('Stickies');
-		expect(aliasNames).toContain('Camera.app');
-		expect(aliasNames).toContain('Stats.app');
-		expect(aliasNames).toContain('DO_NOT_OPEN');
+		// Store apps should NOT have desktop aliases (they're not installed)
+		expect(aliasNames).not.toContain('TV Guide.app');
+		expect(aliasNames).not.toContain('Camera.app');
 
 		// Each alias should point to an existing app file with targetKind 'app'
 		for (const alias of aliases) {
 			expect(alias.target.targetKind).toBe('app');
 			expect(fs.getAllNodes().has(alias.target.nodeId)).toBe(true);
 		}
-	});
-
-	it('chatrbot has no desktop alias', async () => {
-		const fs = createDisk();
-		const result = await fs.listFolder(DESKTOP_ID);
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
-
-		const aliases = result.value.filter((n): n is FsAlias => n.kind === 'alias');
-		const aliasNames = aliases.map((a) => a.name);
-		expect(aliasNames).not.toContain('chatrbot.app');
 	});
 
 	it('default documents exist in /Documents', async () => {
@@ -402,10 +393,6 @@ describe('TerminalFS.exists', () => {
 describe('ownership (buyApp / returnApp)', () => {
 	it('buyApp adds app to ownedApps', async () => {
 		const fs = createDisk();
-		// Clean disk has tvguide pre-owned AND installed.
-		// Uninstall first, then return, then buy again.
-		await fs.uninstallApp('tvguide');
-		await fs.returnApp('tvguide');
 		expect(fs.isAppOwned('tvguide')).toBe(false);
 
 		const result = await fs.buyApp('tvguide');
@@ -415,14 +402,15 @@ describe('ownership (buyApp / returnApp)', () => {
 
 	it('buyApp rejects already-owned app', async () => {
 		const fs = createDisk();
-		const result = await fs.buyApp('tvguide'); // already owned on clean disk
+		await fs.buyApp('tvguide');
+		const result = await fs.buyApp('tvguide');
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error.code).toBe('duplicate_name');
 	});
 
 	it('returnApp removes app from ownedApps', async () => {
 		const fs = createDisk();
-		await fs.uninstallApp('tvguide');
+		await fs.buyApp('tvguide');
 		const result = await fs.returnApp('tvguide');
 		expect(result.ok).toBe(true);
 		expect(fs.isAppOwned('tvguide')).toBe(false);
@@ -430,6 +418,8 @@ describe('ownership (buyApp / returnApp)', () => {
 
 	it('returnApp rejects if app is still installed', async () => {
 		const fs = createDisk();
+		await fs.buyApp('tvguide');
+		await fs.installApp('tvguide');
 		const result = await fs.returnApp('tvguide');
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error.code).toBe('protected_node');
@@ -437,25 +427,21 @@ describe('ownership (buyApp / returnApp)', () => {
 
 	it('returnApp rejects if app is not owned', async () => {
 		const fs = createDisk();
-		await fs.uninstallApp('tvguide');
-		await fs.returnApp('tvguide');
 		const result = await fs.returnApp('tvguide');
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error.code).toBe('not_found');
 	});
 
-	it('free apps are always owned', () => {
+	it('system apps are always owned', () => {
 		const fs = createDisk();
 		expect(fs.isAppOwned('textedit')).toBe(true);
 		expect(fs.isAppOwned('stickies')).toBe(true);
 	});
 
-	it('getOwnedApps returns pre-owned store apps on clean disk', () => {
+	it('getOwnedApps returns empty on clean disk', () => {
 		const fs = createDisk();
 		const owned = fs.getOwnedApps();
-		expect(owned).toContain('tvguide');
-		expect(owned).toContain('chatrbot');
-		expect(owned).toContain('recorder');
+		expect(owned).toHaveLength(0);
 	});
 
 	it('clean disk has ownedApps set on the volume', () => {

--- a/src/lib/terminalos/filesystem/terminal-fs.test.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.test.ts
@@ -398,3 +398,70 @@ describe('TerminalFS.exists', () => {
 		expect(fs.exists(DOCUMENTS_ID, 'nope.txt')).toBe(false);
 	});
 });
+
+describe('ownership (buyApp / returnApp)', () => {
+	it('buyApp adds app to ownedApps', async () => {
+		const fs = createDisk();
+		// Clean disk has tvguide pre-owned AND installed.
+		// Uninstall first, then return, then buy again.
+		await fs.uninstallApp('tvguide');
+		await fs.returnApp('tvguide');
+		expect(fs.isAppOwned('tvguide')).toBe(false);
+
+		const result = await fs.buyApp('tvguide');
+		expect(result.ok).toBe(true);
+		expect(fs.isAppOwned('tvguide')).toBe(true);
+	});
+
+	it('buyApp rejects already-owned app', async () => {
+		const fs = createDisk();
+		const result = await fs.buyApp('tvguide'); // already owned on clean disk
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.code).toBe('duplicate_name');
+	});
+
+	it('returnApp removes app from ownedApps', async () => {
+		const fs = createDisk();
+		await fs.uninstallApp('tvguide');
+		const result = await fs.returnApp('tvguide');
+		expect(result.ok).toBe(true);
+		expect(fs.isAppOwned('tvguide')).toBe(false);
+	});
+
+	it('returnApp rejects if app is still installed', async () => {
+		const fs = createDisk();
+		const result = await fs.returnApp('tvguide');
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.code).toBe('protected_node');
+	});
+
+	it('returnApp rejects if app is not owned', async () => {
+		const fs = createDisk();
+		await fs.uninstallApp('tvguide');
+		await fs.returnApp('tvguide');
+		const result = await fs.returnApp('tvguide');
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.code).toBe('not_found');
+	});
+
+	it('free apps are always owned', () => {
+		const fs = createDisk();
+		expect(fs.isAppOwned('textedit')).toBe(true);
+		expect(fs.isAppOwned('stickies')).toBe(true);
+	});
+
+	it('getOwnedApps returns pre-owned store apps on clean disk', () => {
+		const fs = createDisk();
+		const owned = fs.getOwnedApps();
+		expect(owned).toContain('tvguide');
+		expect(owned).toContain('chatrbot');
+		expect(owned).toContain('recorder');
+	});
+
+	it('clean disk has ownedApps set on the volume', () => {
+		const fs = createDisk();
+		const vol = fs.getVolume();
+		expect(vol.ownedApps).toBeDefined();
+		expect(Array.isArray(vol.ownedApps)).toBe(true);
+	});
+});

--- a/src/lib/terminalos/filesystem/terminal-fs.test.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.test.ts
@@ -74,7 +74,7 @@ describe('TerminalFS.createCleanDisk', () => {
 		expect(names).toContain('Camera.app');
 		expect(names).toContain('Stats.app');
 		expect(names).toContain('DO_NOT_OPEN');
-		expect(names).toContain('Software Shop.app');
+		expect(names).toContain('My Shelf.app');
 	});
 
 	it('system-prefs and about-terminal are in /System', async () => {
@@ -112,7 +112,7 @@ describe('TerminalFS.createCleanDisk', () => {
 
 		// These apps have desktopAliasByDefault: true
 		expect(aliasNames).toContain('TV Guide.app');
-		expect(aliasNames).toContain('Software Shop.app');
+		expect(aliasNames).toContain('My Shelf.app');
 		expect(aliasNames).toContain('Stickies');
 		expect(aliasNames).toContain('Camera.app');
 		expect(aliasNames).toContain('Stats.app');

--- a/src/lib/terminalos/filesystem/terminal-fs.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.ts
@@ -15,7 +15,7 @@ import { generateUniqueId, hasSiblingConflict } from './names';
 import { derivePath } from './paths';
 import { resolveAlias as resolveAliasTarget, buildFingerprint } from './aliases';
 import { getDefaultInstalledApps, getDesktopAliasApps, getAppDef } from '../apps/app-library';
-import { findAppFile } from '../apps/software-shop';
+import { findAppFile, isOwned as checkOwned, deriveOwnedApps } from '../apps/software-shop';
 import type { UndoRecord } from './operations';
 import { buildBackup, validateBackup, previewBackup, validateDiskForExport } from './backup';
 import type { BackupFile, BackupPreview } from './backup';
@@ -283,6 +283,12 @@ export class TerminalFS {
 			for (const node of loaded.nodes) {
 				nodes.set(node.id, node);
 			}
+
+			// Migration: derive ownedApps from installed apps if missing
+			if (loaded.volume.ownedApps === undefined) {
+				loaded.volume.ownedApps = deriveOwnedApps(nodes);
+			}
+
 			return new TerminalFS(loaded.volume, nodes, manifestStore, bodyStore);
 		}
 
@@ -298,12 +304,16 @@ export class TerminalFS {
 		const now = Date.now();
 		const nodes = new Map<NodeId, FsNode>();
 
-		// 1. Volume
+		// 1. Volume — pre-own all defaultInstalled store apps
+		const preOwnedStoreApps = getDefaultInstalledApps()
+			.filter((a) => a.visibility === 'store')
+			.map((a) => a.id);
 		const volume: TerminalVolume = {
 			id: VOLUME_ID,
 			name: 'Terminal HD',
 			kind: 'local',
-			rootNodeId: ROOT_ID
+			rootNodeId: ROOT_ID,
+			ownedApps: preOwnedStoreApps
 		};
 
 		// 2. Root folder
@@ -1147,6 +1157,58 @@ export class TerminalFS {
 	async isAppInstalled(appId: AppId): Promise<FsResult<boolean>> {
 		const installed = findAppFile(appId, this.nodes) !== undefined;
 		return ok(installed);
+	}
+
+	// --- Ownership (buy/return) ---
+
+	isAppOwned(appId: AppId): boolean {
+		return checkOwned(appId, this.volume.ownedApps ?? []);
+	}
+
+	getOwnedApps(): AppId[] {
+		return this.volume.ownedApps ?? [];
+	}
+
+	async buyApp(appId: AppId): Promise<FsResult<void>> {
+		const appDef = getAppDef(appId);
+		if (!appDef) return fail('missing_app', `App "${appId}" not found in AppLibrary`);
+
+		if (this.isAppOwned(appId)) {
+			return fail('duplicate_name', `App "${appDef.name}" is already owned`);
+		}
+
+		const owned = this.volume.ownedApps ?? [];
+		this.volume = { ...this.volume, ownedApps: [...owned, appId] };
+
+		const persistResult = await this.debouncedPersist();
+		if (!persistResult.ok) return persistResult;
+
+		this.notifyChange([], [], 'buy_app');
+		return ok(undefined);
+	}
+
+	async returnApp(appId: AppId): Promise<FsResult<void>> {
+		const appDef = getAppDef(appId);
+		if (!appDef) return fail('missing_app', `App "${appId}" not found in AppLibrary`);
+
+		if (!this.isAppOwned(appId)) {
+			return fail('not_found', `App "${appDef.name}" is not owned`);
+		}
+
+		// Cannot return an app that is currently installed
+		const installed = findAppFile(appId, this.nodes) !== undefined;
+		if (installed) {
+			return fail('protected_node', `Uninstall "${appDef.name}" before returning it`);
+		}
+
+		const owned = this.volume.ownedApps ?? [];
+		this.volume = { ...this.volume, ownedApps: owned.filter((id) => id !== appId) };
+
+		const persistResult = await this.debouncedPersist();
+		if (!persistResult.ok) return persistResult;
+
+		this.notifyChange([], [], 'return_app');
+		return ok(undefined);
 	}
 
 	// --- Body storage ---

--- a/src/lib/terminalos/filesystem/types.ts
+++ b/src/lib/terminalos/filesystem/types.ts
@@ -29,6 +29,7 @@ export type TerminalVolume = {
 	name: string;
 	kind: 'local';
 	rootNodeId: NodeId;
+	ownedApps?: AppId[];
 };
 
 export type NodeFlags = {

--- a/src/lib/terminalos/index.ts
+++ b/src/lib/terminalos/index.ts
@@ -48,9 +48,7 @@ export {
 	getAppDef,
 	getDefaultInstalledApps,
 	getDesktopAliasApps,
-	getFreeApps,
-	getStoreApps,
-	getFreeAppIds
+	getStoreApps
 } from './apps/app-library';
 export type { TerminalAppDefinition, AppCategory, AppVisibility } from './apps/app-types';
 export {

--- a/src/lib/terminalos/index.ts
+++ b/src/lib/terminalos/index.ts
@@ -47,9 +47,12 @@ export {
 	APP_LIBRARY,
 	getAppDef,
 	getDefaultInstalledApps,
-	getDesktopAliasApps
+	getDesktopAliasApps,
+	getFreeApps,
+	getStoreApps,
+	getFreeAppIds
 } from './apps/app-library';
-export type { TerminalAppDefinition, AppCategory } from './apps/app-types';
+export type { TerminalAppDefinition, AppCategory, AppVisibility } from './apps/app-types';
 export {
 	getAppWindowId,
 	getAppIconKind,
@@ -57,7 +60,15 @@ export {
 	isSpecialLaunchApp
 } from './apps/app-install';
 export type { SpecialLaunchApp } from './apps/app-install';
-export { getShopCatalog, isInstalled, canUninstall, findAppFile } from './apps/software-shop';
+export {
+	getShopCatalog,
+	isInstalled,
+	canUninstall,
+	findAppFile,
+	isOwned,
+	getOwnedAppIds,
+	deriveOwnedApps
+} from './apps/software-shop';
 export type { ShopItem } from './apps/software-shop';
 export { createFolderView } from './svelte/folder-view.svelte';
 export { createNodeView } from './svelte/node-view.svelte';


### PR DESCRIPTION
## Summary

- New **Computer Store** window — 8-bit software shop with perspective storefront, 3 category aisles, box pickup modals, checkout counter, and receipt system
- Reworks existing Software Shop into **My Shelf** — empty on fresh install, shows only purchased apps
- Three-state app lifecycle: **not owned → owned (My Shelf) → installed (desktop)**
- 12 pixel-art software boxes with back-of-box copy across 3 categories
- Shelf Tweaks panel ships as a user feature
- Returns route through the counter with a return receipt
- 436 tests passing

## App lifecycle

| Category | Apps | Behavior |
|----------|------|----------|
| **System** | finder, trash, system-prefs, about-terminal, my-shelf, computer-store, textedit, stickies | Ships with OS. Hidden from store and shelf. |
| **Store** | tvguide, chatrbot, recorder, stats, error, tetra, solitaire, minesweep, zorquest, calc, paint | Must be bought at the Computer Store. Appears on My Shelf after purchase. Install from shelf to desktop. |

My Shelf is **empty** on a fresh install. All non-system apps come from the Computer Store.

## Architecture

- `ownedApps: AppId[]` on `TerminalVolume` (optional for backward compat)
- `AppVisibility` type (`store | system`) classifies each app definition
- Silent one-time migration: derives `ownedApps` from installed apps on first load
- Cart is ephemeral (does not persist across window close)
- My Shelf watches filesystem changes and updates live

## Test plan

- [ ] Fresh install — desktop has only textedit, stickies, system apps
- [ ] My Shelf is empty on fresh install
- [ ] Computer Store shows all 11 store apps across 3 aisles
- [ ] Click aisle hotspot → category close-up renders
- [ ] Pick up a box → back-of-box modal with correct copy
- [ ] Add to cart → cart chip updates in top bar
- [ ] Checkout → receipt overlay, items appear on My Shelf
- [ ] Receipt has Keep Browsing / Leave the Store CTAs
- [ ] Install from My Shelf → app appears on desktop
- [ ] Uninstall from My Shelf → app stays on shelf
- [ ] Return to Store → navigates to counter, shows return receipt
- [ ] Cannot return an installed app (must uninstall first)
- [ ] Shelf Tweaks panel adjusts shelf positions
- [ ] Escape key closes modals
- [ ] Reinstall Terminal OS → shelf empty, system apps restored
- [ ] Existing system apps (textedit, stickies) still work normally