### PR TITLE
Install gate, data-driven dock, welcome updates

### DIFF
--- a/src/lib/apps/welcome/WelcomeWindow.svelte
+++ b/src/lib/apps/welcome/WelcomeWindow.svelte
@@ -9,18 +9,19 @@
 		A retro desktop you visit in a browser. Drag windows. Open apps. Tweak things until they feel right.
 	</div>
 	<p class="tagline">
-		Terminal is a tiny operating system that runs in a tab. It's what the inside of a computer
-		looked like before screens got slick. Floppy icons, striped title bars, chunky borders, a clock
-		you can change.
+		Terminal is a tiny operating system that runs in a tab. Floppy icons, striped title bars, chunky
+		borders, a clock you can change. It's what computers looked like before screens got slick.
 	</p>
 	<p class="tagline">
-		Open <b>TV Guide.app</b> to see what's broadcasting. Open <b>README.txt</b> for the manual. Drag the
-		windows around. Resize them. Stack them. Lose one behind another and find it again in the dock. The
-		desktop is yours.
+		Start at the <b>Computer Store</b> — browse the aisles, pick up software boxes, and bring them
+		to the counter. Purchased apps land on <b>My Shelf</b>, where you install and uninstall them.
+	</p>
+	<p class="tagline">
+		Once you've got apps installed, the desktop is yours. Drag windows around, stack them, lose one
+		behind another and fish it out of the dock.
 	</p>
 	<div class="btn-row">
-		<button class="btn primary" onclick={() => onopen('tv-guide')}>OPEN TV GUIDE</button>
-		<button class="btn yellow" onclick={() => onopen('readme')}>READ THE MANUAL</button>
+		<button class="btn primary" onclick={() => onopen('computer-store')}>VISIT THE STORE</button>
 	</div>
 	<div class="logo-marquee">
 		<div class="logo-marquee-track">

--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -365,9 +365,10 @@
 				: ''}
 			role="toolbar"
 			tabindex="-1"
-			onclick={() => {
+			onclick={(e) => {
 				selectedIconId = null;
 				closeDeskCtx();
+				if (e.target === e.currentTarget) os.activeId = null;
 			}}
 			onkeydown={(e) => {
 				if (e.key === 'Escape') {
@@ -572,7 +573,11 @@
 				</Window>
 			{/each}
 
-			<Dock onopen={(id) => os.openWindow(id)} openIds={dockOpenIds} />
+			<Dock
+				installedApps={terminalFs.getInstalledApps()}
+				onopen={(id) => os.openWindow(id)}
+				openIds={dockOpenIds}
+			/>
 
 			{#if os.alertSpec}
 				<div class="system-alert-backdrop" role="presentation" onclick={(e) => e.stopPropagation()}>

--- a/src/lib/components/Dock.svelte
+++ b/src/lib/components/Dock.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+	import type { InstalledApp } from '$lib/terminalos';
+
 	let {
+		installedApps = [],
 		onopen,
 		openIds = []
 	}: {
+		installedApps: InstalledApp[];
 		onopen: (id: string) => void;
 		openIds: string[];
 	} = $props();
@@ -11,16 +15,16 @@
 	let pos = $state<{ x: number; y: number } | null>(null);
 	let dragRef: { offX: number; offY: number } | null = null;
 
-	const items = [
+	const systemItems = [
 		{ id: 'welcome', icon: '★', tip: 'Welcome' },
-		{ id: 'tv-guide', icon: '▦', tip: 'TV Guide' },
-		{ id: 'chat', icon: '✎', tip: 'New Chat' },
-		{ id: 'pricing', icon: '$', tip: 'Pricing' },
-		{ id: 'stats', icon: '≡', tip: 'Stats' },
-		{ id: 'readme', icon: '?', tip: 'README' },
 		{ id: 'about', icon: 'i', tip: 'About' },
 		{ id: 'trash', icon: 'T', tip: 'Trash' }
 	];
+
+	const items = $derived([
+		...systemItems,
+		...installedApps.map((app) => ({ id: app.windowId, icon: app.icon, tip: app.name }))
+	]);
 
 	function onPointerDown(e: PointerEvent) {
 		if (

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -74,6 +74,12 @@
 			type: 'action',
 			label: 'Computer Store',
 			action: (os) => os.openWindow('computer-store')
+		},
+		{ type: 'separator' },
+		{
+			type: 'action',
+			label: 'Reinstall Terminal OS…',
+			action: (os) => os.reinstallOS()
 		}
 	];
 

--- a/src/lib/os/app-registry.ts
+++ b/src/lib/os/app-registry.ts
@@ -101,12 +101,6 @@ export const APPS: Record<string, AppDef> = {
 						action: () => os.restoreBackup()
 					},
 					{ type: 'separator' },
-					{
-						type: 'action',
-						label: 'Reinstall Terminal OS…',
-						action: () => os.reinstallOS()
-					},
-					{ type: 'separator' },
 					{ type: 'action', label: 'Restart', action: () => os.openWindow('error') },
 					{ type: 'action', label: "Shut Down (don't)", action: () => os.openWindow('error') }
 				]

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -14,6 +14,7 @@ import {
 	clearAllPreferences
 } from '$lib/persistence';
 import { getAppWindowId } from '$lib/terminalos/apps/app-install';
+import { getAppDef } from '$lib/terminalos/apps/app-library';
 import type { TerminalFS } from '$lib/terminalos';
 
 export class OsApiClass implements OsApi {
@@ -103,8 +104,12 @@ export class OsApiClass implements OsApi {
 			// API failure is non-fatal — the OS runs without guide data
 		}
 
-		// Restore windows or show welcome
-		const saved = loadWindows();
+		// Restore windows or show welcome (filter out uninstalled store apps)
+		const saved = loadWindows().filter((w) => {
+			const wAppId = windowAppId(w.id);
+			const def = getAppDef(wAppId);
+			return !def || def.visibility !== 'store' || this.fs.isAppInstalledSync(wAppId);
+		});
 		if (saved.length > 0) {
 			this.windows = saved;
 			this.normalizeZOrder();
@@ -143,10 +148,7 @@ export class OsApiClass implements OsApi {
 		const handleKeydown = (e: KeyboardEvent) => {
 			if (!(e.metaKey || e.ctrlKey)) return;
 			const key = e.key.toLowerCase();
-			if (key === 'g') {
-				e.preventDefault();
-				this.openWindow('tv-guide');
-			} else if (key === 'w') {
+			if (key === 'w') {
 				e.preventDefault();
 				if (this.activeId) this.closeWindow(this.activeId);
 			} else if (key === 'n') {
@@ -156,7 +158,6 @@ export class OsApiClass implements OsApi {
 				const fileMenu = menus.find((m) => m.label === 'File');
 				const newItem = fileMenu?.items.find((it) => it.type === 'action' && it.shortcut === '⌘N');
 				if (newItem && newItem.type === 'action' && newItem.action) newItem.action(this);
-				else this.openWindow('tv-guide');
 			} else if (key === ',') {
 				e.preventDefault();
 				const appId = this.activeId ? windowAppId(this.activeId) : 'finder';
@@ -197,6 +198,41 @@ export class OsApiClass implements OsApi {
 		if (alias) {
 			alias();
 			return;
+		}
+
+		// Gate: store apps must be installed before any of their windows open
+		const appId = windowAppId(id);
+		const appDef = getAppDef(appId);
+		if (appDef?.visibility === 'store') {
+			const installed = this.fs.isAppInstalledSync(appId);
+			if (!installed) {
+				const name = appDef.name;
+				const owned = this.fs.isAppOwned(appId);
+				this.alert({
+					title: `${name} is not installed`,
+					body: owned
+						? `"${name}" is on your shelf but not installed. Open My Shelf to install it.`
+						: `"${name}" hasn't been purchased yet. Visit the Computer Store to pick it up.`,
+					buttons: owned
+						? [
+								{
+									label: 'Open My Shelf',
+									primary: true,
+									action: () => this.openWindow('software-shop')
+								},
+								{ label: 'OK' }
+							]
+						: [
+								{
+									label: 'Visit Store',
+									primary: true,
+									action: () => this.openWindow('computer-store')
+								},
+								{ label: 'OK' }
+							]
+				});
+				return;
+			}
 		}
 
 		if (this.isMobile) {
@@ -596,6 +632,10 @@ export class OsApiClass implements OsApi {
 	}
 
 	// ── Derived state ─────────────────────────────────────────────────────
+
+	isAppInstalled(appId: string): boolean {
+		return this.fs.isAppInstalledSync(appId);
+	}
 
 	get activeAppId(): string {
 		return this.activeId ? windowAppId(this.activeId) : 'finder';

--- a/src/lib/os/os-api.test.ts
+++ b/src/lib/os/os-api.test.ts
@@ -26,6 +26,13 @@ function createOs() {
 	return { os, fs };
 }
 
+async function createOsWithApp(appId: string) {
+	const { os, fs } = createOs();
+	await fs.buyApp(appId);
+	await fs.installApp(appId);
+	return { os, fs };
+}
+
 // ── Window management ─────────────────────────────────────────────────────
 
 describe('window management', () => {
@@ -52,7 +59,7 @@ describe('window management', () => {
 	it('openWindow on existing window focuses it instead of duplicating', () => {
 		const { os } = createOs();
 		os.openWindow('finder');
-		os.openWindow('tv-guide');
+		os.openWindow('welcome');
 		os.openWindow('finder');
 
 		expect(os.windows).toHaveLength(2);
@@ -62,11 +69,11 @@ describe('window management', () => {
 	it('closeWindow removes the window', () => {
 		const { os } = createOs();
 		os.openWindow('finder');
-		os.openWindow('tv-guide');
+		os.openWindow('welcome');
 		os.closeWindow('finder');
 
 		expect(os.windows).toHaveLength(1);
-		expect(os.windows[0].id).toBe('tv-guide');
+		expect(os.windows[0].id).toBe('welcome');
 	});
 
 	it('closeWindow clears activeId when closing the active window', () => {
@@ -79,15 +86,15 @@ describe('window management', () => {
 	it('closeWindow does not clear activeId when closing a non-active window', () => {
 		const { os } = createOs();
 		os.openWindow('finder');
-		os.openWindow('tv-guide');
+		os.openWindow('welcome');
 		os.closeWindow('finder');
-		expect(os.activeId).toBe('tv-guide');
+		expect(os.activeId).toBe('welcome');
 	});
 
 	it('focusWindow sets activeId and increments z-order', () => {
 		const { os } = createOs();
 		os.openWindow('finder');
-		os.openWindow('tv-guide');
+		os.openWindow('welcome');
 		const zBefore = os.windows.find((w) => w.id === 'finder')!.z;
 		os.focusWindow('finder');
 		const zAfter = os.windows.find((w) => w.id === 'finder')!.z;
@@ -119,11 +126,11 @@ describe('window management', () => {
 	it('z-order normalizes when counter exceeds 1000', () => {
 		const { os } = createOs();
 		os.openWindow('finder');
-		os.openWindow('tv-guide');
+		os.openWindow('welcome');
 
 		// Focus many times to push the counter past 1000
 		for (let i = 0; i < 1001; i++) {
-			os.focusWindow(i % 2 === 0 ? 'finder' : 'tv-guide');
+			os.focusWindow(i % 2 === 0 ? 'finder' : 'welcome');
 		}
 
 		// After normalization triggers, z values reset to small numbers
@@ -217,14 +224,14 @@ describe('launch routing', () => {
 		expect(handler).toHaveBeenCalledWith({ file: 'test.txt' });
 	});
 
-	it('launchApp tvguide opens tv-guide window', () => {
-		const { os } = createOs();
+	it('launchApp tvguide opens tv-guide window when installed', async () => {
+		const { os } = await createOsWithApp('tvguide');
 		os.launchApp('tvguide');
 		expect(os.windows.some((w) => w.id === 'tv-guide')).toBe(true);
 	});
 
-	it('launchApp recorder opens recorder window', () => {
-		const { os } = createOs();
+	it('launchApp recorder opens recorder window when installed', async () => {
+		const { os } = await createOsWithApp('recorder');
 		os.launchApp('recorder');
 		expect(os.windows.some((w) => w.id === 'recorder')).toBe(true);
 	});
@@ -420,8 +427,8 @@ describe('isKnownWindowId', () => {
 // ── Navigation routing ────────────────────────────────────────────────────
 
 describe('navigation routing', () => {
-	it('openAbout chatrbot opens about-chatrbot window', () => {
-		const { os } = createOs();
+	it('openAbout chatrbot opens about-chatrbot window', async () => {
+		const { os } = await createOsWithApp('chatrbot');
 		os.openAbout('chatrbot');
 		expect(os.windows.some((w) => w.id === 'about-chatrbot')).toBe(true);
 	});
@@ -432,8 +439,8 @@ describe('navigation routing', () => {
 		expect(os.windows.some((w) => w.id === 'about')).toBe(true);
 	});
 
-	it('openAbout tvguide opens about-tvguide', () => {
-		const { os } = createOs();
+	it('openAbout tvguide opens about-tvguide', async () => {
+		const { os } = await createOsWithApp('tvguide');
 		os.openAbout('tvguide');
 		expect(os.windows.some((w) => w.id === 'about-tvguide')).toBe(true);
 	});
@@ -444,8 +451,8 @@ describe('navigation routing', () => {
 		expect(os.windows.some((w) => w.id === 'about-textedit')).toBe(true);
 	});
 
-	it('openAbout stats opens about-stats', () => {
-		const { os } = createOs();
+	it('openAbout stats opens about-stats', async () => {
+		const { os } = await createOsWithApp('stats');
 		os.openAbout('stats');
 		expect(os.windows.some((w) => w.id === 'about-stats')).toBe(true);
 	});
@@ -456,8 +463,8 @@ describe('navigation routing', () => {
 		expect(os.windows.some((w) => w.id === 'about-stickies')).toBe(true);
 	});
 
-	it('openAbout recorder opens about-recorder', () => {
-		const { os } = createOs();
+	it('openAbout recorder opens about-recorder', async () => {
+		const { os } = await createOsWithApp('recorder');
 		os.openAbout('recorder');
 		expect(os.windows.some((w) => w.id === 'about-recorder')).toBe(true);
 	});
@@ -490,8 +497,8 @@ describe('navigation routing', () => {
 		expect(os.windows).toHaveLength(1);
 	});
 
-	it('startNewConversation opens tv-guide', () => {
-		const { os } = createOs();
+	it('startNewConversation opens tv-guide when installed', async () => {
+		const { os } = await createOsWithApp('tvguide');
 		os.startNewConversation();
 		expect(os.windows.some((w) => w.id === 'tv-guide')).toBe(true);
 	});
@@ -499,11 +506,11 @@ describe('navigation routing', () => {
 	it('listWindows returns the current windows', () => {
 		const { os } = createOs();
 		os.openWindow('finder');
-		os.openWindow('tv-guide');
+		os.openWindow('welcome');
 		const list = os.listWindows();
 		expect(list).toHaveLength(2);
 		expect(list.map((w) => w.id)).toContain('finder');
-		expect(list.map((w) => w.id)).toContain('tv-guide');
+		expect(list.map((w) => w.id)).toContain('welcome');
 	});
 });
 
@@ -562,14 +569,14 @@ describe('derived state', () => {
 		expect(os.activeAppId).toBe('finder');
 	});
 
-	it('activeAppId returns chatrbot for chat- windows', () => {
-		const { os } = createOs();
+	it('activeAppId returns chatrbot for chat- windows', async () => {
+		const { os } = await createOsWithApp('chatrbot');
 		os.openWindow('chat-seinfeld');
 		expect(os.activeAppId).toBe('chatrbot');
 	});
 
-	it('activeAppId returns tvguide for tv-guide window', () => {
-		const { os } = createOs();
+	it('activeAppId returns tvguide for tv-guide window', async () => {
+		const { os } = await createOsWithApp('tvguide');
 		os.openWindow('tv-guide');
 		expect(os.activeAppId).toBe('tvguide');
 	});
@@ -580,8 +587,8 @@ describe('derived state', () => {
 		expect(os.activeChatGroupSlug).toBeNull();
 	});
 
-	it('activeChatGroupSlug returns slug for active chat window', () => {
-		const { os } = createOs();
+	it('activeChatGroupSlug returns slug for active chat window', async () => {
+		const { os } = await createOsWithApp('chatrbot');
 		os.openWindow('chat-seinfeld');
 		expect(os.activeChatGroupSlug).toBe('seinfeld');
 	});
@@ -590,8 +597,8 @@ describe('derived state', () => {
 // ── Dock aliases ──────────────────────────────────────────────────────────
 
 describe('dock aliases', () => {
-	it('openWindow with dock alias chat routes to tv-guide', () => {
-		const { os } = createOs();
+	it('openWindow with dock alias chat routes to tv-guide when installed', async () => {
+		const { os } = await createOsWithApp('tvguide');
 		os.initDockAliases(() => {});
 		os.openWindow('chat');
 		expect(os.windows.some((w) => w.id === 'tv-guide')).toBe(true);
@@ -603,6 +610,87 @@ describe('dock aliases', () => {
 		os.initDockAliases(openFile);
 		os.openWindow('pricing');
 		expect(openFile).toHaveBeenCalledWith('Pricing.txt');
+	});
+});
+
+// ── Store app install gate ────────────────────────────────────────────────
+
+describe('store app install gate', () => {
+	it('blocks unowned store app and shows purchase alert', () => {
+		const { os } = createOs();
+		os.openWindow('tv-guide');
+
+		expect(os.windows).toHaveLength(0);
+		expect(os.alertSpec?.title).toBe('TV Guide is not installed');
+		expect(os.alertSpec?.body).toContain('Computer Store');
+		expect(os.alertSpec?.buttons?.[0].label).toBe('Visit Store');
+	});
+
+	it('blocks owned-but-not-installed store app and shows shelf alert', async () => {
+		const { os, fs } = createOs();
+		await fs.buyApp('tvguide');
+		os.openWindow('tv-guide');
+
+		expect(os.windows).toHaveLength(0);
+		expect(os.alertSpec?.title).toBe('TV Guide is not installed');
+		expect(os.alertSpec?.body).toContain('My Shelf');
+		expect(os.alertSpec?.buttons?.[0].label).toBe('Open My Shelf');
+	});
+
+	it('allows installed store app to open', async () => {
+		const { os } = await createOsWithApp('tvguide');
+		os.openWindow('tv-guide');
+
+		expect(os.windows).toHaveLength(1);
+		expect(os.windows[0].id).toBe('tv-guide');
+		expect(os.alertSpec).toBeNull();
+	});
+
+	it('does not gate system apps', () => {
+		const { os } = createOs();
+		os.openWindow('finder');
+
+		expect(os.windows).toHaveLength(1);
+		expect(os.alertSpec).toBeNull();
+	});
+
+	it('blocks chat windows when chatrbot is not installed', () => {
+		const { os } = createOs();
+		os.openWindow('chat-seinfeld');
+
+		expect(os.windows).toHaveLength(0);
+		expect(os.alertSpec?.title).toBe('chatrbot is not installed');
+	});
+
+	it('blocks about windows for uninstalled store apps', () => {
+		const { os } = createOs();
+		os.openAbout('tvguide');
+
+		expect(os.windows).toHaveLength(0);
+		expect(os.alertSpec?.title).toBe('TV Guide is not installed');
+	});
+
+	it('purchase alert Visit Store button opens computer-store', () => {
+		const { os } = createOs();
+		os.openWindow('tv-guide');
+
+		const visitBtn = os.alertSpec?.buttons?.[0];
+		expect(visitBtn?.label).toBe('Visit Store');
+		visitBtn?.action?.();
+
+		expect(os.windows.some((w) => w.id === 'computer-store')).toBe(true);
+	});
+
+	it('shelf alert Open My Shelf button opens software-shop', async () => {
+		const { os, fs } = createOs();
+		await fs.buyApp('recorder');
+		os.openWindow('recorder');
+
+		const shelfBtn = os.alertSpec?.buttons?.[0];
+		expect(shelfBtn?.label).toBe('Open My Shelf');
+		shelfBtn?.action?.();
+
+		expect(os.windows.some((w) => w.id === 'software-shop')).toBe(true);
 	});
 });
 

--- a/src/lib/os/os-api.ts
+++ b/src/lib/os/os-api.ts
@@ -127,6 +127,7 @@ export interface OsApi {
 
 	openChat: (group: GroupMeta) => void;
 	setTimezone: (tz: string) => void;
+	isAppInstalled: (appId: string) => boolean;
 }
 
 export interface AlertButton {

--- a/src/lib/terminalos/apps/app-install.ts
+++ b/src/lib/terminalos/apps/app-install.ts
@@ -44,16 +44,6 @@ export function getAppIconKind(appId: AppId): string {
 }
 
 /**
- * Returns true if the given appId is installed (has a filesystem node).
- * For v1 this checks the AppLibrary catalog.
- */
-export function isAppInstalled(appId: AppId): boolean {
-	const def = getAppDef(appId);
-	if (!def) return false;
-	return def.defaultInstalled;
-}
-
-/**
  * Apps that require special launch handling (not just "open window X").
  * - 'stickies' creates a new note
  * - 'chatrbot' needs a show context from TV Guide

--- a/src/lib/terminalos/filesystem/terminal-fs.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.ts
@@ -8,6 +8,7 @@ import type {
 	FsFile,
 	FsAlias,
 	FsResult,
+	InstalledApp,
 	TerminalVolume
 } from './types';
 import { ok, fail } from './errors';
@@ -15,6 +16,7 @@ import { generateUniqueId, hasSiblingConflict } from './names';
 import { derivePath } from './paths';
 import { resolveAlias as resolveAliasTarget, buildFingerprint } from './aliases';
 import { getDefaultInstalledApps, getDesktopAliasApps, getAppDef } from '../apps/app-library';
+import { getAppWindowId } from '../apps/app-install';
 import { findAppFile, isOwned as checkOwned, deriveOwnedApps } from '../apps/software-shop';
 import type { UndoRecord } from './operations';
 import { buildBackup, validateBackup, previewBackup, validateDiskForExport } from './backup';
@@ -42,6 +44,11 @@ const README_CONTENT = `README.TXT — Terminal v1.0
 Terminal is a desktop OS that lives in a browser tab. Apps run inside it.
 You drag windows. You open the menu bar. You change the timezone by clicking the clock.
 The whole thing is meant to feel like a computer from 1995 that someone restored for you.
+
+GETTING STARTED
+Open the Computer Store to browse software. Pick up boxes, read the back,
+and bring them to the counter. Purchased apps go to My Shelf, where you
+install and uninstall them. Installed apps appear on your desktop.
 
 NAVIGATION
 - Double-click a desktop icon to open it
@@ -1155,8 +1162,23 @@ export class TerminalFS {
 	}
 
 	async isAppInstalled(appId: AppId): Promise<FsResult<boolean>> {
-		const installed = findAppFile(appId, this.nodes) !== undefined;
-		return ok(installed);
+		return ok(this.isAppInstalledSync(appId));
+	}
+
+	isAppInstalledSync(appId: AppId): boolean {
+		return findAppFile(appId, this.nodes) !== undefined;
+	}
+
+	getInstalledApps(): InstalledApp[] {
+		const apps: InstalledApp[] = [];
+		for (const node of this.nodes.values()) {
+			if (node.kind !== 'file' || node.fileType !== 'app' || !node.appId) continue;
+			const def = getAppDef(node.appId);
+			const windowId = getAppWindowId(node.appId);
+			if (!def || !windowId) continue;
+			apps.push({ id: node.appId, name: def.name, icon: def.icon, windowId });
+		}
+		return apps;
 	}
 
 	// --- Ownership (buy/return) ---

--- a/src/lib/terminalos/filesystem/types.ts
+++ b/src/lib/terminalos/filesystem/types.ts
@@ -3,6 +3,13 @@ export type NodeId = string;
 export type BodyId = string;
 export type AppId = string;
 
+export type InstalledApp = {
+	id: AppId;
+	name: string;
+	icon: string;
+	windowId: string;
+};
+
 export type FsResult<T> = { ok: true; value: T } | { ok: false; error: FsError };
 
 export type FsErrorCode =

--- a/src/lib/terminalos/index.ts
+++ b/src/lib/terminalos/index.ts
@@ -24,7 +24,8 @@ export type {
 	FileType,
 	BodyRef,
 	AliasTarget,
-	NodeFlags
+	NodeFlags,
+	InstalledApp
 } from './filesystem/types';
 export { ok, fail, fsErr } from './filesystem/errors';
 export {
@@ -51,12 +52,7 @@ export {
 	getStoreApps
 } from './apps/app-library';
 export type { TerminalAppDefinition, AppCategory, AppVisibility } from './apps/app-types';
-export {
-	getAppWindowId,
-	getAppIconKind,
-	isAppInstalled,
-	isSpecialLaunchApp
-} from './apps/app-install';
+export { getAppWindowId, getAppIconKind, isSpecialLaunchApp } from './apps/app-install';
 export type { SpecialLaunchApp } from './apps/app-install';
 export {
 	getShopCatalog,


### PR DESCRIPTION
## Summary

- Store apps must be purchased and installed before any of their windows open — `openWindow()` gates on install state with contextual alerts directing to Computer Store or My Shelf
- Dock is now data-driven from `getInstalledApps()` instead of a hardcoded list — only shows buttons for apps that are actually installed
- Welcome screen updated for the store-first flow with a single "Visit the Store" CTA
- Reinstall Terminal OS moved from Finder's Special menu to the global OS menu
- Desktop background click switches focus to Finder without interfering with window clicks
- New `InstalledApp` type and `getInstalledApps()` on TerminalFS as reusable lookup
- Saved windows filtered on page restore to remove uninstalled store app windows
- Removed stale `isAppInstalled()` from app-install.ts, dead keyboard shortcuts

## Test plan
- [ ] Fresh install: welcome screen shows "Visit the Store" button, no broken TV Guide button
- [ ] Buy and install an app from the Computer Store — it appears in the dock
- [ ] Uninstall an app — it disappears from the dock
- [ ] Try to open an uninstalled store app via URL hash (#tv-guide) — gate alert appears
- [ ] Reload page after uninstalling an app — its window does not reappear
- [ ] Click desktop background — menubar switches to Finder
- [ ] Click inside a window — menubar stays on that app
- [ ] Reinstall Terminal OS accessible from the system (apple) menu
- [ ] `pnpm vitest run` — 444 tests pass
- [ ] `pnpm check` — no type errors