### PR TITLE
Feature/add streaming player

### DIFF
--- a/.claude/projects/-Users-brandt-codes-brandtam-terminal-bli-net/memory/feedback_direct_approach.md
+++ b/.claude/projects/-Users-brandt-codes-brandtam-terminal-bli-net/memory/feedback_direct_approach.md
@@ -1,0 +1,12 @@
+---
+name: feedback-direct-approach
+description: Try the user's suggested approach first instead of proposing alternatives; say upfront when something isn't possible
+metadata:
+  type: feedback
+---
+
+When the user asks for a specific approach (e.g., canvas-based distortion, transform scale), try it directly instead of substituting CSS workarounds or alternative techniques. If something is technically impossible (e.g., barrel distortion on cross-origin iframes), say so immediately — don't burn multiple rounds discovering it.
+
+**Why:** Multiple rounds of "that didn't work" / "that's not what I asked for" during the VCR TV/screen convex effect work. The user asked for canvas, got CSS overlays. Asked for scaling, got aspect-ratio hacks. The final solution (transform: scale on a fixed-size unit) was what they were driving at from the start.
+
+**How to apply:** Lead with honest constraints, then implement the user's requested approach. Don't substitute your preferred technique when the user has specified one.

--- a/src/app.html
+++ b/src/app.html
@@ -17,7 +17,7 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
-			href="https://fonts.googleapis.com/css2?family=VT323&family=Press+Start+2P&family=Pixelify+Sans:wght@400..700&family=Inter:wght@400;500;600;700&display=swap"
+			href="https://fonts.googleapis.com/css2?family=VT323&family=Press+Start+2P&family=Pixelify+Sans:wght@400..700&family=Inter:wght@400;500;600;700&family=Caveat:wght@400;700&display=swap"
 			rel="stylesheet"
 		/>
 		%sveltekit.head%

--- a/src/lib/apps/computer-store/BoxDetailModal.svelte
+++ b/src/lib/apps/computer-store/BoxDetailModal.svelte
@@ -46,8 +46,10 @@
 	<div class="modal" onclick={(e) => e.stopPropagation()}>
 		<!-- header -->
 		<div class="header">
-			<span>◂ YOU PICKED IT UP</span>
-			<button class="close-btn" onclick={onclose}>× PUT BACK</button>
+			<span>{owned || inCart ? '◂ DETAILS' : '◂ YOU PICKED IT UP'}</span>
+			<button class="close-btn" onclick={onclose}
+				>{owned || inCart ? '× CLOSE' : '× PUT BACK'}</button
+			>
 		</div>
 
 		<!-- body -->
@@ -80,11 +82,11 @@
 			{#if owned}
 				<div class="chip chip-owned">● ALREADY OWNED</div>
 				<button class="btn btn-warn" onclick={onreturn}>RETURN TO STORE</button>
-				<button class="btn btn-plain ml-auto" onclick={onclose}>◂ PUT BACK</button>
+				<button class="btn btn-plain ml-auto" onclick={onclose}>× CLOSE</button>
 			{:else if inCart}
 				<div class="chip chip-cart">● IN YOUR CART</div>
 				<button class="btn btn-warn" onclick={onremovefromcart}>TAKE OUT OF CART</button>
-				<button class="btn btn-plain ml-auto" onclick={onclose}>◂ PUT BACK</button>
+				<button class="btn btn-plain ml-auto" onclick={onclose}>× CLOSE</button>
 			{:else}
 				<button class="btn btn-primary" onclick={onaddtocart}>▸ ADD TO CART</button>
 				<button class="btn btn-plain ml-auto" onclick={onclose}>◂ PUT BACK ON SHELF</button>

--- a/src/lib/apps/computer-store/PixelIcon.svelte
+++ b/src/lib/apps/computer-store/PixelIcon.svelte
@@ -138,6 +138,22 @@
 			<rect x="3" y="7" width="2" height="2" fill="#f54e00" stroke="#0a0a0a" />
 			<rect x="6" y="3" width="1" height="2" fill="#0a0a0a" />
 		</svg>
+	{:else if name === 'vcr'}
+		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
+			<!-- VCR cassette body -->
+			<rect x="2" y="4" width="12" height="9" fill="#1a1a1a" stroke="#0a0a0a" />
+			<!-- label -->
+			<rect x="3" y="5" width="10" height="3" fill="#f0d8a0" stroke="#0a0a0a" />
+			<rect x="4" y="6" width="6" height="1" fill="#5a3820" />
+			<!-- tape reels -->
+			<rect x="4" y="9" width="3" height="3" rx="1" fill="#333" stroke="#555" />
+			<rect x="9" y="9" width="3" height="3" rx="1" fill="#333" stroke="#555" />
+			<!-- reel centers -->
+			<rect x="5" y="10" width="1" height="1" fill="#fff" />
+			<rect x="10" y="10" width="1" height="1" fill="#fff" />
+			<!-- tape between reels -->
+			<rect x="7" y="11" width="2" height="1" fill="#5a2a0a" />
+		</svg>
 	{:else if name === 'chart'}
 		<svg viewBox="0 0 16 16" shape-rendering="crispEdges">
 			<rect x="2" y="3" width="1" height="11" fill="#0a0a0a" />

--- a/src/lib/apps/computer-store/store-data.ts
+++ b/src/lib/apps/computer-store/store-data.ts
@@ -151,6 +151,18 @@ export const APPS: StoreApp[] = [
 		back: 'Shows numbers about your Terminal usage. None of the numbers are real. The bar chart is for vibes. "Messages sent today: 14,209." No there weren\'t.',
 		inside: ['Three charts', 'One leaderboard', 'Honesty (none)'],
 		reqs: 'Terminal OS 1.0'
+	},
+	{
+		id: 'vcr',
+		cat: 'ENT',
+		title: 'VCR',
+		pub: 'ARCHIVE LABS',
+		tagline: 'Be kind, rewind.',
+		icon: 'vcr',
+		sticker: 'NEW',
+		back: 'A video cassette recorder for your desktop. Loads tapes from the Internet Archive — full episodes of The Computer Chronicles, BBS: The Documentary, and other relics of early computing. Hit play. Watch Stewart Cheifet explain the World Wide Web in 1996.',
+		inside: ['Four show collections', 'Internet Archive streaming', 'CRT display mode'],
+		reqs: 'Terminal OS 1.0 · Internet'
 	}
 ];
 
@@ -182,7 +194,7 @@ export const CATEGORIES: Record<string, StoreCategory> = {
 		label: 'ENTERTAINMENT',
 		color: '#c92127',
 		tagline: 'TV · Chat · Multimedia',
-		appIds: ['tvguide', 'chatrbot', 'recorder', 'stats']
+		appIds: ['tvguide', 'chatrbot', 'recorder', 'stats', 'vcr']
 	}
 };
 

--- a/src/lib/apps/vcr/VCRWindow.svelte
+++ b/src/lib/apps/vcr/VCRWindow.svelte
@@ -1,0 +1,526 @@
+<script lang="ts">
+	import { SHOWS, type VCRShow, type VCREpisode } from './vcr-data';
+
+	let selectedShow = $state<VCRShow | null>(null);
+	let currentEpisode = $state<VCREpisode | null>(null);
+	let transport = $state<'idle' | 'play' | 'pause' | 'stop'>('idle');
+	let browseMode = $state<'shows' | 'episodes'>('shows');
+
+	function selectShow(show: VCRShow) {
+		selectedShow = show;
+		browseMode = 'episodes';
+	}
+
+	function playEpisode(ep: VCREpisode) {
+		currentEpisode = ep;
+		transport = 'play';
+	}
+
+	let currentIndex = $derived(
+		selectedShow && currentEpisode ? selectedShow.episodes.indexOf(currentEpisode) : -1
+	);
+
+	let canRew = $derived(selectedShow !== null && currentIndex > 0);
+	let canFf = $derived(
+		selectedShow !== null && currentIndex >= 0 && currentIndex < selectedShow.episodes.length - 1
+	);
+	let hasTape = $derived(currentEpisode !== null);
+
+	function pressPlayPause() {
+		if (!currentEpisode) return;
+		if (transport === 'play') transport = 'pause';
+		else transport = 'play';
+	}
+
+	function pressEject() {
+		transport = 'idle';
+		currentEpisode = null;
+	}
+
+	function pressRew() {
+		if (!selectedShow || currentIndex <= 0) return;
+		currentEpisode = selectedShow.episodes[currentIndex - 1];
+		transport = 'play';
+	}
+
+	function pressFf() {
+		if (!selectedShow || currentIndex < 0 || currentIndex >= selectedShow.episodes.length - 1)
+			return;
+		currentEpisode = selectedShow.episodes[currentIndex + 1];
+		transport = 'play';
+	}
+
+	function backToShows() {
+		browseMode = 'shows';
+		selectedShow = null;
+	}
+
+	let embedUrl = $derived(
+		currentEpisode ? `https://archive.org/embed/${currentEpisode.archiveId}` : ''
+	);
+
+	let showVideo = $derived(transport === 'play' || transport === 'pause');
+
+	const REF_W = 560;
+	const REF_H = 523;
+
+	let shellEl: HTMLElement;
+	let unitScale = $state(1);
+
+	$effect(() => {
+		if (!shellEl) return;
+		const observer = new ResizeObserver((entries) => {
+			const { width, height } = entries[0].contentRect;
+			unitScale = Math.min(width / REF_W, height / REF_H);
+		});
+		observer.observe(shellEl);
+		return () => observer.disconnect();
+	});
+</script>
+
+<svg width="0" height="0" aria-hidden="true" style="position:absolute">
+	<defs>
+		<clipPath id="crt-barrel" clipPathUnits="objectBoundingBox">
+			<path
+				d="M 0.04,0.055 Q 0.5,-0.01 0.96,0.055 Q 1,0.5 0.96,0.945 Q 0.5,1.01 0.04,0.945 Q 0,0.5 0.04,0.055 Z"
+			/>
+		</clipPath>
+	</defs>
+</svg>
+
+<div class="shell" bind:this={shellEl}>
+	<div class="unit" style="transform: scale({unitScale});">
+		<!-- ── TV ──────────────────────────────────── -->
+		<div class="tv">
+			<div class="bezel">
+				<svg class="seams" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
+					<line x1="0" y1="0" x2="7" y2="9" vector-effect="non-scaling-stroke" />
+					<line x1="100" y1="0" x2="93" y2="9" vector-effect="non-scaling-stroke" />
+					<line x1="100" y1="100" x2="93" y2="91" vector-effect="non-scaling-stroke" />
+					<line x1="0" y1="100" x2="7" y2="91" vector-effect="non-scaling-stroke" />
+				</svg>
+				<div class="screen">
+					{#if showVideo && currentEpisode}
+						<iframe src={embedUrl} title={currentEpisode.title} allowfullscreen class="video"
+						></iframe>
+						{#if transport === 'pause'}
+							<div class="overlay">▐▐ PAUSED</div>
+						{/if}
+					{:else}
+						<div class="osd">
+							{#if browseMode === 'shows'}
+								<div class="osd-title">TAPE LIBRARY</div>
+								<div class="osd-list">
+									{#each SHOWS as show (show.id)}
+										<button class="osd-row" onclick={() => selectShow(show)}>
+											<span class="osd-tape">📼</span>
+											<span class="osd-name">{show.name}</span>
+											<span class="osd-count">{show.episodes.length}</span>
+											<span class="osd-arrow">▸</span>
+										</button>
+									{/each}
+								</div>
+								{#if hasTape}
+									<button class="osd-resume" onclick={pressPlayPause}
+										>▶ Resume: {currentEpisode?.title}</button
+									>
+								{/if}
+							{:else if selectedShow}
+								<button class="osd-back" onclick={backToShows}>◂ {selectedShow.name}</button>
+								<div class="osd-list">
+									{#each selectedShow.episodes as ep (ep.id)}
+										<button
+											class="osd-row"
+											class:playing={currentEpisode?.id === ep.id}
+											onclick={() => playEpisode(ep)}
+										>
+											<span class="osd-tape">{currentEpisode?.id === ep.id ? '▶' : '○'}</span>
+											<span class="osd-name">{ep.title}</span>
+											<span class="osd-count">{ep.year}</span>
+										</button>
+									{/each}
+								</div>
+							{/if}
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+
+		<!-- ── VCR DECK ───────────────────────────── -->
+		<div class="deck">
+			<div class="slot"></div>
+			<div class="panel">
+				<!-- Cassette tape -->
+				<div class="cassette">
+					<div class="cassette-label">
+						<span class="cassette-text">
+							{#if currentEpisode}{currentEpisode.title}{:else}No tape loaded{/if}
+						</span>
+						<span class="cassette-stripes">
+							<span class="cs" style="background:#f54e00"></span>
+							<span class="cs" style="background:#f9bd2b"></span>
+							<span class="cs" style="background:#1e5fc8"></span>
+						</span>
+					</div>
+				</div>
+
+				<!-- 3 large buttons -->
+				<div class="btns">
+					<button class="tb" disabled={!canRew} onclick={pressRew} title="Rewind">◀▏</button>
+					<button
+						class="tb tb-main"
+						class:engaged={transport === 'play'}
+						disabled={!hasTape}
+						onclick={pressPlayPause}
+						title="Play/Pause"
+					>
+						{#if transport === 'pause'}▐▐{:else}▶{/if}
+					</button>
+					<button class="tb" disabled={!canFf} onclick={pressFf} title="Fast Forward">▕▶</button>
+				</div>
+			</div>
+			{#if hasTape}
+				<button class="eject-btn" onclick={pressEject}>⏏ EJECT</button>
+			{/if}
+		</div>
+	</div>
+</div>
+
+<style>
+	.shell {
+		width: 100%;
+		height: 100%;
+		position: relative;
+		background: #0a0a0a;
+		overflow: hidden;
+	}
+
+	.unit {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 560px;
+		height: 523px;
+		transform-origin: center center;
+		translate: -50% -50%;
+		display: flex;
+		flex-direction: column;
+		background: #d4cdb8;
+		overflow: hidden;
+	}
+
+	/* ── TV ─────────────────────────────────────── */
+	.tv {
+		flex: 1;
+		min-height: 0;
+		padding: 12px 12px 6px;
+	}
+
+	.bezel {
+		width: 100%;
+		height: 100%;
+		background: #7a7268;
+		border: 2px solid #0a0a0a;
+		display: flex;
+		position: relative;
+	}
+
+	.seams {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 2;
+		pointer-events: none;
+	}
+	.seams line {
+		stroke: #0a0a0a;
+		stroke-width: 1.5px;
+	}
+
+	.screen {
+		flex: 1;
+		background: #181818;
+		position: relative;
+		overflow: hidden;
+		margin: 3% 2.5%;
+		clip-path: url(#crt-barrel);
+	}
+
+	.video {
+		width: 100%;
+		height: 100%;
+		border: none;
+		display: block;
+	}
+
+	/* ── OVERLAY ────────────────────────────────── */
+	.overlay {
+		position: absolute;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 12px;
+		color: #fff;
+		letter-spacing: 3px;
+		z-index: 1;
+	}
+
+	/* ── ON-SCREEN DISPLAY ─────────────────────── */
+	.osd {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		padding: 10px;
+		overflow: hidden;
+	}
+
+	.osd-title {
+		font-family: 'Press Start 2P', monospace;
+		font-size: 10px;
+		color: #ffffff;
+		letter-spacing: 2px;
+		padding-bottom: 8px;
+		border-bottom: 1px solid #333;
+		margin-bottom: 6px;
+		flex-shrink: 0;
+	}
+
+	.osd-back {
+		background: none;
+		border: none;
+		border-bottom: 1px solid #333;
+		color: #ffffff;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 8px;
+		padding: 0 0 8px;
+		margin-bottom: 6px;
+		cursor: pointer;
+		text-align: left;
+		letter-spacing: 1px;
+		flex-shrink: 0;
+	}
+	.osd-back:hover {
+		color: #f9bd2b;
+	}
+
+	.osd-list {
+		flex: 1;
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.osd-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		padding: 5px 4px;
+		background: none;
+		border: none;
+		border-bottom: 1px solid #222;
+		color: #ffffff;
+		cursor: pointer;
+		text-align: left;
+	}
+	.osd-row:hover {
+		background: #f9bd2b;
+		color: #0a0a0a;
+	}
+	.osd-row.playing {
+		color: #f9bd2b;
+	}
+
+	.osd-tape {
+		flex: 0 0 auto;
+		font-size: 13px;
+		width: 18px;
+		text-align: center;
+	}
+	.osd-name {
+		flex: 1;
+		font-family: 'VT323', monospace;
+		font-size: 18px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
+	}
+	.osd-count {
+		flex: 0 0 auto;
+		font-family: 'VT323', monospace;
+		font-size: 15px;
+		opacity: 0.5;
+	}
+	.osd-arrow {
+		flex: 0 0 auto;
+		opacity: 0.4;
+	}
+
+	.osd-resume {
+		flex-shrink: 0;
+		margin-top: 6px;
+		padding: 6px 8px;
+		background: #f9bd2b;
+		border: none;
+		color: #0a0a0a;
+		font-family: 'VT323', monospace;
+		font-size: 16px;
+		cursor: pointer;
+		text-align: left;
+	}
+	.osd-resume:hover {
+		background: #ffffff;
+	}
+
+	.osd-list::-webkit-scrollbar {
+		width: 10px;
+	}
+	.osd-list::-webkit-scrollbar-track {
+		background: #181818;
+	}
+	.osd-list::-webkit-scrollbar-thumb {
+		background: #444;
+		border: 2px solid #181818;
+	}
+
+	/* ── VCR DECK ──────────────────────────────── */
+	.deck {
+		flex: 0 0 auto;
+		background: #d4cdb8;
+		border-top: 3px solid #0a0a0a;
+		padding: 10px 14px 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.slot {
+		width: 55%;
+		max-width: 200px;
+		height: 8px;
+		background: #0a0a0a;
+		margin: 0 auto;
+	}
+
+	.panel {
+		display: flex;
+		align-items: stretch;
+		gap: 6px;
+		min-height: 48px;
+	}
+
+	/* ── CASSETTE TAPE ─────────────────────────── */
+	.cassette {
+		flex: 1;
+		min-width: 0;
+		background: #2a2a2a;
+		border: 2px solid #0a0a0a;
+		border-radius: 6px;
+		padding: 6px 6px 6px 8px;
+		display: flex;
+		align-items: center;
+	}
+
+	.cassette-label {
+		flex: 1;
+		min-width: 0;
+		background: #ffffff;
+		border: 1px solid #aaa;
+		display: flex;
+		align-items: center;
+		overflow: hidden;
+		height: 100%;
+	}
+
+	.cassette-text {
+		flex: 1;
+		min-width: 0;
+		padding: 2px 10px;
+		font-family: 'Caveat', cursive;
+		font-size: 20px;
+		font-weight: 700;
+		color: #0a0a0a;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		line-height: 1.2;
+	}
+
+	.cassette-stripes {
+		flex: 0 0 18px;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+	.cs {
+		flex: 1;
+	}
+
+	/* ── TRANSPORT (3 large buttons) ───────────── */
+	.btns {
+		flex: 0 0 auto;
+		display: flex;
+		gap: 4px;
+	}
+
+	.tb {
+		width: 48px;
+		height: 48px;
+		background: #0a0a0a;
+		border: 2px solid #0a0a0a;
+		box-shadow: 3px 3px 0 rgba(0, 0, 0, 0.3);
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 16px;
+		color: #ffffff;
+		padding: 0;
+	}
+	.tb:hover:not(:disabled) {
+		transform: translate(1px, 1px);
+		box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.3);
+	}
+	.tb:active:not(:disabled),
+	.tb.engaged:not(:disabled) {
+		transform: translate(3px, 3px);
+		box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+	}
+	.tb:disabled {
+		opacity: 0.2;
+		cursor: default;
+	}
+
+	.tb-main {
+		background: #f9bd2b;
+		color: #0a0a0a;
+		border-color: #0a0a0a;
+	}
+	.tb-main.engaged {
+		background: #f54e00;
+		color: #ffffff;
+	}
+
+	/* ── EJECT ─────────────────────────────────── */
+	.eject-btn {
+		align-self: flex-end;
+		background: none;
+		border: none;
+		font-family: 'Press Start 2P', monospace;
+		font-size: 7px;
+		color: #0a0a0a;
+		opacity: 0.5;
+		cursor: pointer;
+		padding: 0;
+		letter-spacing: 1px;
+	}
+	.eject-btn:hover {
+		opacity: 1;
+	}
+</style>

--- a/src/lib/apps/vcr/VCRWindow.svelte
+++ b/src/lib/apps/vcr/VCRWindow.svelte
@@ -82,7 +82,7 @@
 	<defs>
 		<clipPath id="crt-barrel" clipPathUnits="objectBoundingBox">
 			<path
-				d="M 0.04,0.055 Q 0.5,-0.01 0.96,0.055 Q 1,0.5 0.96,0.945 Q 0.5,1.01 0.04,0.945 Q 0,0.5 0.04,0.055 Z"
+				d="M 0.04,0.045 Q 0.5,-0.01 0.96,0.045 Q 1,0.5 0.96,0.955 Q 0.5,1.01 0.04,0.955 Q 0,0.5 0.04,0.045 Z"
 			/>
 		</clipPath>
 	</defs>
@@ -245,6 +245,7 @@
 		position: relative;
 		overflow: hidden;
 		margin: 3% 2.5%;
+		padding: 2%;
 		clip-path: url(#crt-barrel);
 	}
 
@@ -275,7 +276,7 @@
 		height: 100%;
 		display: flex;
 		flex-direction: column;
-		padding: 10px;
+		padding: 20px;
 		overflow: hidden;
 	}
 

--- a/src/lib/apps/vcr/vcr-data.ts
+++ b/src/lib/apps/vcr/vcr-data.ts
@@ -1,0 +1,325 @@
+export type VCRShow = {
+	id: string;
+	name: string;
+	years: string;
+	description: string;
+	episodes: VCREpisode[];
+};
+
+export type VCREpisode = {
+	id: string;
+	title: string;
+	year: number;
+	archiveId: string;
+	description: string;
+};
+
+export const SHOWS: VCRShow[] = [
+	{
+		id: 'computer-chronicles',
+		name: 'The Computer Chronicles',
+		years: '1983–2002',
+		description:
+			'The longest-running TV series about personal computers. Stewart Cheifet hosted 20 seasons covering every major moment in PC history.',
+		episodes: [
+			{
+				id: 'cc-macintosh',
+				title: 'The Macintosh Computer',
+				year: 1985,
+				archiveId: 'TheMacin1985',
+				description:
+					'Apple just released the Macintosh. 128K of RAM. A mouse. People are confused and delighted.'
+			},
+			{
+				id: 'cc-games-84',
+				title: 'Computer Games',
+				year: 1984,
+				archiveId: 'Computer1984_4',
+				description: 'The state of computer gaming in 1984. Text adventures and 8-bit graphics.'
+			},
+			{
+				id: 'cc-printers',
+				title: 'Printers',
+				year: 1984,
+				archiveId: 'Printers1984',
+				description: 'Dot matrix, daisy wheel, and the new laser printers. Paper jams for everyone.'
+			},
+			{
+				id: 'cc-security',
+				title: 'Computer Security',
+				year: 1984,
+				archiveId: 'Computer1984_2',
+				description: 'Passwords, hackers, and the first generation of computer crime.'
+			},
+			{
+				id: 'cc-robotics',
+				title: 'Robotics',
+				year: 1984,
+				archiveId: 'Robotics1984',
+				description: 'Industrial robots and the dream of household automation.'
+			},
+			{
+				id: 'cc-ai',
+				title: 'Artificial Intelligence',
+				year: 1984,
+				archiveId: 'Artifici1984',
+				description:
+					'Expert systems, natural language processing, and the AI winter nobody saw coming.'
+			},
+			{
+				id: 'cc-speech',
+				title: 'Speech Synthesis',
+				year: 1984,
+				archiveId: 'SpeechSy1984',
+				description: 'Computers that talk. Kind of. If you listen very carefully.'
+			},
+			{
+				id: 'cc-networking',
+				title: 'Networking',
+				year: 1984,
+				archiveId: 'Networki1984',
+				description: 'LANs, modems, and the dream of connecting every computer on earth.'
+			},
+			{
+				id: 'cc-amiga-atari',
+				title: 'Amiga and Atari',
+				year: 1985,
+				archiveId: 'Amigaand1985',
+				description:
+					'The Amiga and the Atari ST go head to head. Multimedia before the word existed.'
+			},
+			{
+				id: 'cc-modems',
+				title: 'Modems & Bulletin Boards',
+				year: 1985,
+				archiveId: 'ModemsBu1985',
+				description: "2400 baud, ANSI art, and dialing into other people's computers at 3am."
+			},
+			{
+				id: 'cc-graphics',
+				title: 'Computer Graphics',
+				year: 1985,
+				archiveId: 'Computer1985_10',
+				description: 'Ray tracing, wireframe models, and pixels the size of chicklets.'
+			},
+			{
+				id: 'cc-desktop-publishing',
+				title: 'Desktop Publishing',
+				year: 1986,
+				archiveId: 'DesktopP1986',
+				description:
+					'PageMaker, LaserWriter, and the death of the print shop. Everyone is a publisher now.'
+			},
+			{
+				id: 'cc-email',
+				title: 'Electronic Mail',
+				year: 1986,
+				archiveId: 'Electron1986',
+				description:
+					'Sending letters through a phone line. Faster than the post, slower than a fax.'
+			},
+			{
+				id: 'cc-speech-rec',
+				title: 'Speech Recognition',
+				year: 1987,
+				archiveId: 'SpeechRe1987',
+				description:
+					'Computers that understand words. If you speak very slowly. And clearly. And repeat yourself.'
+			},
+			{
+				id: 'cc-portable',
+				title: 'Portable Computers',
+				year: 1987,
+				archiveId: 'Portable1987',
+				description: 'Laptops that weigh 8 pounds and cost $4,000. The future of mobile computing.'
+			},
+			{
+				id: 'cc-windows-30',
+				title: 'Windows 3.0',
+				year: 1990,
+				archiveId: 'windows30',
+				description:
+					'Microsoft finally makes Windows usable. Program Manager, File Manager, Solitaire.'
+			},
+			{
+				id: 'cc-vr',
+				title: 'Virtual Reality',
+				year: 1992,
+				archiveId: 'virtualreali',
+				description:
+					'VR in 1992. Head-mounted displays the size of a motorcycle helmet. The future is now.'
+			},
+			{
+				id: 'cc-internet',
+				title: 'The Internet',
+				year: 1993,
+				archiveId: 'episode_1134',
+				description:
+					'A look at this new thing called the Internet. Mosaic, FTP, Gopher, and the earliest web browsers.'
+			},
+			{
+				id: 'cc-windows-nt',
+				title: 'Windows NT',
+				year: 1993,
+				archiveId: 'WindowsN',
+				description:
+					'Microsoft builds a real operating system. 32-bit, preemptive multitasking, and a new kernel.'
+			},
+			{
+				id: 'cc-windows-95',
+				title: 'Windows 95',
+				year: 1995,
+				archiveId: 'CC1301_windows_95',
+				description:
+					'The Start button arrives. Jay Leno was at the launch. Midnight lines at CompUSA.'
+			},
+			{
+				id: 'cc-internet-95',
+				title: 'Internet 1995',
+				year: 1995,
+				archiveId: 'CC1232_internet',
+				description:
+					'The internet goes mainstream. Netscape, Yahoo, and the first wave of dot-com mania.'
+			},
+			{
+				id: 'cc-greatest-games',
+				title: 'Greatest Computer Games',
+				year: 1995,
+				archiveId: 'CC1308_greatest_games',
+				description:
+					'DOOM, Myst, SimCity, and the shareware revolution. The golden age of PC gaming.'
+			}
+		]
+	},
+	{
+		id: 'computer-programme',
+		name: 'The Computer Programme',
+		years: '1982',
+		description:
+			'BBC series that introduced personal computing to Britain. Ian McNaught-Davis and Chris Serle stumble through BASIC.',
+		episodes: [
+			{
+				id: 'tcp-ep1',
+				title: "It's Happening Now",
+				year: 1982,
+				archiveId: 'the_computer_programme_ep01',
+				description:
+					'The BBC Micro arrives. Two men who barely understand computers try to explain them to millions.'
+			},
+			{
+				id: 'tcp-ep2',
+				title: 'Just One Thing After Another',
+				year: 1982,
+				archiveId: 'the_computer_programme_ep02',
+				description: 'Programming in BASIC. Line numbers. GOTO statements. What could go wrong.'
+			},
+			{
+				id: 'tcp-ep3',
+				title: 'Talking To A Machine',
+				year: 1982,
+				archiveId: 'the_computer_programme_ep03',
+				description:
+					'Programming languages beyond BASIC. How do you actually tell a computer what to do.'
+			},
+			{
+				id: 'tcp-ep4',
+				title: "It's On The Computer",
+				year: 1982,
+				archiveId: 'the_computer_programme_ep04',
+				description:
+					'Data storage and retrieval. Databases, filing systems, and getting information back out.'
+			},
+			{
+				id: 'tcp-ep5',
+				title: 'The New Media',
+				year: 1982,
+				archiveId: 'the_computer_programme_ep05',
+				description:
+					'Computers and communications. Viewdata, Prestel, and the information superhighway circa 1982.'
+			}
+		]
+	},
+	{
+		id: 'arpanet-doc',
+		name: 'Computer Networks: The Heralds of Resource Sharing',
+		years: '1972',
+		description:
+			'The 1972 ARPANET documentary. Thirty minutes of bearded engineers explaining the future of communication to a camera. They were right about everything.',
+		episodes: [
+			{
+				id: 'arpanet-full',
+				title: 'The Heralds of Resource Sharing',
+				year: 1972,
+				archiveId: 'ComputerNetworks_TheHeraldsOfResourceSharing',
+				description:
+					'The entire ARPANET documentary. BBN, UCLA, MIT. Packet switching. "We thought if we could connect these machines together…"'
+			}
+		]
+	},
+	{
+		id: 'bbs-documentary',
+		name: 'BBS: The Documentary',
+		years: '2005',
+		description:
+			"Jason Scott's documentary about bulletin board systems. The internet before the internet. Dial-up modems, ANSI art, and the people who built a world at 2400 baud.",
+		episodes: [
+			{
+				id: 'bbs-baud',
+				title: 'Baud',
+				year: 2005,
+				archiveId: 'BBS_Documentary_Clips_Baud',
+				description:
+					'The birth of the BBS. Ward Christensen and Randy Suess, a Chicago blizzard, and a phone line.'
+			},
+			{
+				id: 'bbs-community',
+				title: 'Sysops and Users',
+				year: 2005,
+				archiveId: 'BBS_Documentary_Clips_Sysops_and_Users_1',
+				description: 'How strangers became friends through 80-column text and 300 baud modems.'
+			},
+			{
+				id: 'bbs-fidonet',
+				title: 'FidoNet',
+				year: 2005,
+				archiveId: 'BBS_Documentary_Clips_Fidonet',
+				description:
+					'The network that connected BBSes worldwide. Store-and-forward messaging across phone lines.'
+			},
+			{
+				id: 'bbs-no-carrier',
+				title: 'No Carrier',
+				year: 2005,
+				archiveId: 'BBS_Documentary_Clips_No_Carrier',
+				description: 'The end of the BBS era. The internet arrives and the modems go silent.'
+			},
+			{
+				id: 'bbs-artscene',
+				title: 'Sidelines and Musings',
+				year: 2005,
+				archiveId: 'BBS_Documentary_Clips_Sidelines',
+				description: "The culture, the drama, and the stories that didn't fit anywhere else."
+			}
+		]
+	}
+];
+
+export const SHOW_BY_ID: Record<string, VCRShow> = SHOWS.reduce(
+	(m, s) => {
+		m[s.id] = s;
+		return m;
+	},
+	{} as Record<string, VCRShow>
+);
+
+export function getAllEpisodes(): { show: VCRShow; episode: VCREpisode }[] {
+	return SHOWS.flatMap((show) => show.episodes.map((episode) => ({ show, episode })));
+}
+
+export function findEpisode(episodeId: string): { show: VCRShow; episode: VCREpisode } | undefined {
+	for (const show of SHOWS) {
+		const episode = show.episodes.find((e) => e.id === episodeId);
+		if (episode) return { show, episode };
+	}
+	return undefined;
+}

--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -43,6 +43,7 @@
 	import { getAppWindowId, getAppIconKind } from '$lib/terminalos/apps/app-install';
 	import SoftwareShopWindow from '$lib/apps/software-shop/SoftwareShopWindow.svelte';
 	import ComputerStoreWindow from '$lib/apps/computer-store/ComputerStoreWindow.svelte';
+	import VCRWindow from '$lib/apps/vcr/VCRWindow.svelte';
 
 	let booted = $state(false);
 	let os = $state<OsApiClass>(undefined!);
@@ -463,6 +464,8 @@
 					z={w.z}
 					active={os.activeId === w.id}
 					chromeless={w.id.startsWith('sticky-')}
+					minW={def.minW}
+					minH={def.minH}
 					onfocus={(id) => os.focusWindow(id)}
 					onclose={(id) => os.closeWindow(id)}
 					onmove={(id, x, y) => os.moveWindow(id, x, y)}
@@ -534,6 +537,8 @@
 						<ErrorDialog onclose={() => os.closeWindow('error')} />
 					{:else if w.id === 'trash'}
 						<FinderWindow {os} fs={terminalFs} folderId={TRASH_ID} />
+					{:else if w.id === 'vcr'}
+						<VCRWindow />
 					{:else if w.id === 'recorder'}
 						<RecorderWindow bind:recording={cameraRecording} fs={terminalFs} />
 					{:else if w.id.startsWith('recorder-')}

--- a/src/lib/components/Window.svelte
+++ b/src/lib/components/Window.svelte
@@ -13,6 +13,8 @@
 		resizable = true,
 		chromeless = false,
 		className = '',
+		minW = 260,
+		minH = 140,
 		onfocus,
 		onclose,
 		onmove,
@@ -30,6 +32,8 @@
 		resizable?: boolean;
 		chromeless?: boolean;
 		className?: string;
+		minW?: number;
+		minH?: number;
 		onfocus: (id: string) => void;
 		onclose: (id: string) => void;
 		onmove: (id: string, x: number, y: number) => void;
@@ -37,8 +41,8 @@
 		children: Snippet;
 	} = $props();
 
-	const MIN_W = 260;
-	const MIN_H = 140;
+	const MIN_W = minW;
+	const MIN_H = minH;
 
 	let dragState: { startX: number; startY: number; origX: number; origY: number } | null = null;
 	let resizeSEState: { startX: number; startY: number; origW: number; origH: number } | null = null;
@@ -179,7 +183,9 @@
 					aria-label="close"
 				></button>
 			</div>
-			<div class="title">{title}</div>
+			<div class="title">
+				{title} <span class="dims">{Math.round(width)}×{Math.round(height)}</span>
+			</div>
 			<div class="btns right">
 				{#if resizable}
 					<div
@@ -311,6 +317,12 @@
 		white-space: nowrap;
 		line-height: 1;
 		color: var(--chrome-titlebar-fg, var(--ink));
+	}
+
+	.dims {
+		font-size: 10px;
+		font-weight: 400;
+		opacity: 0.6;
 	}
 
 	.window-btn {

--- a/src/lib/os/app-registry.ts
+++ b/src/lib/os/app-registry.ts
@@ -549,6 +549,58 @@ export const APPS: Record<string, AppDef> = {
 		statusExtra: () => null
 	},
 
+	vcr: {
+		id: 'vcr',
+		name: 'VCR',
+		filename: 'VCR.app',
+		about: {
+			title: 'VCR',
+			version: 'v1.0',
+			tagline: 'be kind, rewind',
+			glyph: '📼',
+			glyphBg: '#1a1a1a',
+			glyphFg: '#3f3',
+			sections: [
+				{
+					h: 'WHAT IT IS',
+					body: 'A video cassette recorder for your desktop. Loads tapes from the Internet Archive — full episodes of retro computing shows, streamed directly to your CRT.'
+				},
+				{
+					h: 'THE LIBRARY',
+					body: 'The Computer Chronicles (1983–2002), BBS: The Documentary, The Computer Programme, the 1972 ARPANET documentary, and Net Cafe. More tapes being added.'
+				},
+				{
+					h: 'HOW IT WORKS',
+					body: 'Pick a show from the tape library. Pick an episode. Hit play. The video streams from archive.org. No account needed, no ads, no fees.'
+				},
+				{
+					h: 'CREDITS',
+					body: 'The Internet Archive, for preserving everything. Stewart Cheifet, for 20 years of Computer Chronicles. Jason Scott, for the BBS Documentary. The BBC, for The Computer Programme.'
+				}
+			]
+		},
+		preferences: null,
+		menus: (os) => [
+			{
+				label: 'File',
+				items: [
+					{
+						type: 'action',
+						label: 'New VCR Window',
+						shortcut: '⌘N',
+						action: () => os.openWindow('vcr')
+					},
+					{ type: 'action', label: 'Close', shortcut: '⌘W', action: () => os.closeFocused() }
+				]
+			},
+			{
+				label: 'Help',
+				items: [{ type: 'action', label: 'About VCR', action: () => os.openAbout('vcr') }]
+			}
+		],
+		statusExtra: () => null
+	},
+
 	textedit: {
 		id: 'textedit',
 		name: 'TextEdit',

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -72,7 +72,9 @@ export class OsApiClass implements OsApi {
 		'finder',
 		'software-shop',
 		'computer-store',
-		'about-computer-store'
+		'about-computer-store',
+		'vcr',
+		'about-vcr'
 	]);
 
 	constructor(fs: TerminalFS) {
@@ -291,8 +293,11 @@ export class OsApiClass implements OsApi {
 
 	// ── Window definition lookup ──────────────────────────────────────────
 
-	getWindowDef(id: string): { title: string; w: number; h: number } {
-		const defs: Record<string, { title: string; w: number; h: number }> = {
+	getWindowDef(id: string): { title: string; w: number; h: number; minW?: number; minH?: number } {
+		const defs: Record<
+			string,
+			{ title: string; w: number; h: number; minW?: number; minH?: number }
+		> = {
 			welcome: { title: 'Welcome.app', w: 460, h: 540 },
 			'tv-guide': { title: 'TV Guide.app', w: 660, h: 700 },
 			'terminal-prefs': { title: 'System Preferences', w: 380, h: 360 },
@@ -313,7 +318,9 @@ export class OsApiClass implements OsApi {
 			'about-software-shop': { title: 'About My Shelf', w: 420, h: 380 },
 			'computer-store': { title: 'Computer Store', w: 740, h: 620 },
 			'about-computer-store': { title: 'About Computer Store', w: 420, h: 380 },
-			finder: { title: 'Terminal HD', w: 480, h: 420 }
+			finder: { title: 'Terminal HD', w: 480, h: 420 },
+			vcr: { title: 'VCR.app', w: 560, h: 523, minW: 480, minH: 470 },
+			'about-vcr': { title: 'About VCR', w: 420, h: 460 }
 		};
 
 		if (id.startsWith('chat-')) {

--- a/src/lib/terminalos/apps/app-install.ts
+++ b/src/lib/terminalos/apps/app-install.ts
@@ -17,7 +17,8 @@ export function getAppWindowId(appId: AppId): string | undefined {
 		'about-terminal': 'about',
 		'software-shop': 'software-shop',
 		'computer-store': 'computer-store',
-		finder: 'finder'
+		finder: 'finder',
+		vcr: 'vcr'
 	};
 	return map[appId];
 }
@@ -38,7 +39,8 @@ export function getAppIconKind(appId: AppId): string {
 		chatrbot: 'doc',
 		'software-shop': 'floppy',
 		'computer-store': 'floppy',
-		finder: 'hd'
+		finder: 'hd',
+		vcr: 'tv'
 	};
 	return map[appId] ?? 'doc';
 }

--- a/src/lib/terminalos/apps/app-library.ts
+++ b/src/lib/terminalos/apps/app-library.ts
@@ -234,6 +234,18 @@ export const APP_LIBRARY: TerminalAppDefinition[] = [
 		removable: true,
 		desktopAliasByDefault: false,
 		visibility: 'store'
+	},
+	{
+		id: 'vcr',
+		name: 'VCR',
+		fileName: 'VCR.app',
+		category: 'entertainment',
+		description: 'Retro video player',
+		icon: '📼',
+		defaultInstalled: false,
+		removable: true,
+		desktopAliasByDefault: true,
+		visibility: 'store'
 	}
 ];
 


### PR DESCRIPTION
* Add VCR app: retro TV/VCR combo with Internet Archive streaming

- Add VCR app with CRT-styled TV screen and VCR deck controls
- Stream full episodes from Internet Archive (Computer Chronicles,
  BBS Documentary, The Computer Programme, Computer Networks)
- Apply barrel-shaped SVG clip-path to screen for CRT convex effect
- Use transform: scale() to maintain fixed proportions of the entire
  TV/VCR unit at any window size, with black letterboxing
- Add per-window minW/minH support to the Window component
- Display live pixel dimensions in window title bars during development
- Register VCR in app library, store catalog, and app registry
- Add VCR pixel icon and Caveat font for cassette tape labels
- Update Computer Store modal copy for owned/in-cart states

* Tune CRT screen clip-path and padding

- Reduce barrel clip-path top/bottom inset by 1% for taller visible area
- Add 2% padding to screen so content clears the clip edges
- Increase OSD padding to 20px for better text clearance