### PR TITLE
Backup v2: full-state backup and restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"test:unit:watch": "vitest",
 		"lint": "prettier --check . && eslint .",
 		"lint:bots": "node scripts/lint-bots.js",
+		"lint:backup": "node scripts/lint-backup-coverage.js",
 		"format": "prettier --write .",
 		"prepare": "husky",
 		"deploy-cloudflare": "pnpm build && wrangler pages deploy .svelte-kit/cloudflare",

--- a/scripts/lint-backup-coverage.js
+++ b/scripts/lint-backup-coverage.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies every persistence key in persistence.ts is listed in the
+ * BACKUP COVERAGE REGISTRY in backup.ts. Fails if a key is missing,
+ * forcing a conscious decision about whether it should be backed up.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+const PERSISTENCE_PATH = resolve(ROOT, 'src/lib/persistence.ts');
+const BACKUP_PATH = resolve(ROOT, 'src/lib/terminalos/filesystem/backup.ts');
+
+let errors = 0;
+
+// --- Extract keys from persistence.ts ---
+
+const persistenceSrc = readFileSync(PERSISTENCE_PATH, 'utf-8');
+const keysBlockMatch = persistenceSrc.match(/const KEYS\s*=\s*\{([^}]+)\}/);
+if (!keysBlockMatch) {
+	console.error('Could not find KEYS constant in persistence.ts');
+	process.exit(1);
+}
+
+const keyEntries = [...keysBlockMatch[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+if (keyEntries.length === 0) {
+	console.error('No keys found in KEYS constant');
+	process.exit(1);
+}
+
+// --- Extract registry entries from backup.ts ---
+
+const backupSrc = readFileSync(BACKUP_PATH, 'utf-8');
+const registryMatch = backupSrc.match(/BACKUP COVERAGE REGISTRY[\s\S]*?\*\//);
+if (!registryMatch) {
+	console.error('Could not find BACKUP COVERAGE REGISTRY comment block in backup.ts');
+	process.exit(1);
+}
+
+const registry = registryMatch[0];
+
+// --- Check each key appears in the registry ---
+
+for (const key of keyEntries) {
+	if (!registry.includes(key)) {
+		console.error(
+			`Missing from BACKUP COVERAGE REGISTRY: "${key}"\n` +
+				`  Add it to the registry in backup.ts with a backup status (Yes/No) and reason.`
+		);
+		errors++;
+	}
+}
+
+// --- Also check for the manifest key ---
+
+if (!registry.includes('terminalos.manifest')) {
+	console.error(
+		'Missing from BACKUP COVERAGE REGISTRY: "terminalos.manifest"\n' +
+			'  The filesystem manifest must be listed in the registry.'
+	);
+	errors++;
+}
+
+// --- Report ---
+
+console.log(`${keyEntries.length} persistence keys checked against backup registry.`);
+
+if (errors > 0) {
+	console.error(
+		`${errors} key(s) not covered. Add them to the BACKUP COVERAGE REGISTRY in backup.ts.`
+	);
+	process.exit(1);
+} else {
+	console.log('All persistence keys are covered in backup registry.');
+}

--- a/src/lib/apps/computer-store/store-data.test.ts
+++ b/src/lib/apps/computer-store/store-data.test.ts
@@ -3,8 +3,8 @@ import { APPS, APP_BY_ID, CATEGORIES, CAT_COLORS, shelfLineup } from './store-da
 import { APP_LIBRARY } from '$lib/terminalos/apps/app-library';
 
 describe('store catalog', () => {
-	it('has 11 apps', () => {
-		expect(APPS).toHaveLength(11);
+	it('has 12 apps', () => {
+		expect(APPS).toHaveLength(12);
 	});
 
 	it('every app has required fields', () => {

--- a/src/lib/components/Window.svelte
+++ b/src/lib/components/Window.svelte
@@ -41,9 +41,6 @@
 		children: Snippet;
 	} = $props();
 
-	const MIN_W = minW;
-	const MIN_H = minH;
-
 	let dragState: { startX: number; startY: number; origX: number; origY: number } | null = null;
 	let resizeSEState: { startX: number; startY: number; origW: number; origH: number } | null = null;
 	let resizeNEState: {
@@ -101,8 +98,8 @@
 
 	function onGrowSEMove(e: PointerEvent) {
 		if (!resizeSEState) return;
-		const newW = Math.max(MIN_W, resizeSEState.origW + e.clientX - resizeSEState.startX);
-		const newH = Math.max(MIN_H, resizeSEState.origH + e.clientY - resizeSEState.startY);
+		const newW = Math.max(minW, resizeSEState.origW + e.clientX - resizeSEState.startX);
+		const newH = Math.max(minH, resizeSEState.origH + e.clientY - resizeSEState.startY);
 		onresize?.(id, newW, newH);
 	}
 
@@ -135,9 +132,9 @@
 		if (!resizeNEState) return;
 		const dx = e.clientX - resizeNEState.startX;
 		const dy = e.clientY - resizeNEState.startY;
-		const newW = Math.max(MIN_W, resizeNEState.origW + dx);
+		const newW = Math.max(minW, resizeNEState.origW + dx);
 		const desiredH = resizeNEState.origH - dy;
-		const newH = Math.max(MIN_H, desiredH);
+		const newH = Math.max(minH, desiredH);
 		const effectiveDy = resizeNEState.origH - newH;
 		const newY = Math.max(28, resizeNEState.origY + effectiveDy);
 		onresize?.(id, newW, newH);

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -561,7 +561,7 @@ export class OsApiClass implements OsApi {
 							a.href = url;
 							a.download = filename;
 							a.click();
-							URL.revokeObjectURL(url);
+							setTimeout(() => URL.revokeObjectURL(url), 10000);
 						}
 					}
 				]
@@ -620,7 +620,13 @@ export class OsApiClass implements OsApi {
 												if (prefs.timezone != null) saveTimezone(prefs.timezone);
 												if (prefs.conversations !== undefined)
 													saveConversations(prefs.conversations);
-												if (prefs.windows !== undefined) saveWindows(prefs.windows);
+												if (prefs.windows !== undefined) {
+													// Set reactive state so the $effect's next
+													// debounce-save writes the restored windows,
+													// not the current session's stale layout.
+													this.windows = prefs.windows;
+													saveWindows(prefs.windows);
+												}
 											}
 											window.location.reload();
 										} else {

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -10,6 +10,8 @@ import {
 	saveTweaks,
 	loadTimezone,
 	saveTimezone,
+	loadConversations,
+	saveConversations,
 	isFirstVisit,
 	clearAllPreferences
 } from '$lib/persistence';
@@ -526,7 +528,14 @@ export class OsApiClass implements OsApi {
 
 		const wait = new Promise((r) => setTimeout(r, PROGRESS_MS));
 
-		Promise.all([this.fs.exportBackup(), wait]).then(([result]) => {
+		const preferences = {
+			tweaks: loadTweaks(),
+			conversations: loadConversations(),
+			timezone: loadTimezone(),
+			windows: loadWindows()
+		};
+
+		Promise.all([this.fs.exportBackup(preferences), wait]).then(([result]) => {
 			if (!result.ok) {
 				this.showAlert({
 					title: 'Backup Failed',
@@ -589,9 +598,10 @@ export class OsApiClass implements OsApi {
 						return;
 					}
 					const p = preview.value;
+					const prefsNote = p.hasPreferences ? '\nIncludes preferences and chat history' : '';
 					this.showAlert({
 						title: 'Restore Terminal HD?',
-						body: `This will replace your current disk with:\n${p.diskName} — exported ${new Date(p.exportedAt).toLocaleDateString()}\n${p.fileCount} files, ${p.folderCount} folders, ${p.appCount} apps`,
+						body: `This will replace your current disk with:\n${p.diskName} — exported ${new Date(p.exportedAt).toLocaleDateString()}\n${p.fileCount} files, ${p.folderCount} folders, ${p.appCount} apps${prefsNote}`,
 						buttons: [
 							{ label: 'Cancel' },
 							{
@@ -599,8 +609,16 @@ export class OsApiClass implements OsApi {
 								primary: true,
 								action: () => {
 									this.fs.restoreBackup(data).then((r) => {
-										if (r.ok) window.location.reload();
-										else
+										if (r.ok) {
+											const prefs = r.value.preferences;
+											if (prefs) {
+												if (prefs.tweaks) saveTweaks(prefs.tweaks);
+												if (prefs.timezone) saveTimezone(prefs.timezone);
+												if (prefs.conversations) saveConversations(prefs.conversations);
+												if (prefs.windows) saveWindows(prefs.windows);
+											}
+											window.location.reload();
+										} else
 											this.showAlert({
 												title: 'Restore Failed',
 												body: r.error.message,

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -572,7 +572,7 @@ export class OsApiClass implements OsApi {
 	restoreBackup(): void {
 		const input = document.createElement('input');
 		input.type = 'file';
-		input.accept = '.terminal-hd,.json';
+		input.accept = '.terminal-hd,.json,*/*';
 		input.onchange = () => {
 			const file = input.files?.[0];
 			if (!file) return;

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -556,12 +556,10 @@ export class OsApiClass implements OsApi {
 						label: 'Download',
 						primary: true,
 						action: () => {
-							const url = URL.createObjectURL(blob);
 							const a = document.createElement('a');
-							a.href = url;
+							a.href = URL.createObjectURL(blob);
 							a.download = filename;
 							a.click();
-							setTimeout(() => URL.revokeObjectURL(url), 10000);
 						}
 					}
 				]
@@ -572,7 +570,6 @@ export class OsApiClass implements OsApi {
 	restoreBackup(): void {
 		const input = document.createElement('input');
 		input.type = 'file';
-		input.accept = '.terminal-hd,.json,*/*';
 		input.onchange = () => {
 			const file = input.files?.[0];
 			if (!file) return;

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -598,10 +598,14 @@ export class OsApiClass implements OsApi {
 						return;
 					}
 					const p = preview.value;
-					const prefsNote = p.hasPreferences ? '\nIncludes preferences and chat history' : '';
+					const lines = [
+						`${p.diskName} — exported ${new Date(p.exportedAt).toLocaleDateString()}`,
+						`${p.fileCount} files, ${p.folderCount} folders, ${p.appCount} apps`
+					];
+					if (p.hasPreferences) lines.push('Includes preferences and chat history');
 					this.showAlert({
 						title: 'Restore Terminal HD?',
-						body: `This will replace your current disk with:\n${p.diskName} — exported ${new Date(p.exportedAt).toLocaleDateString()}\n${p.fileCount} files, ${p.folderCount} folders, ${p.appCount} apps${prefsNote}`,
+						body: `This will replace your current disk with:\n${lines.join('\n')}`,
 						buttons: [
 							{ label: 'Cancel' },
 							{
@@ -612,18 +616,20 @@ export class OsApiClass implements OsApi {
 										if (r.ok) {
 											const prefs = r.value.preferences;
 											if (prefs) {
-												if (prefs.tweaks) saveTweaks(prefs.tweaks);
-												if (prefs.timezone) saveTimezone(prefs.timezone);
-												if (prefs.conversations) saveConversations(prefs.conversations);
-												if (prefs.windows) saveWindows(prefs.windows);
+												if (prefs.tweaks !== undefined) saveTweaks(prefs.tweaks);
+												if (prefs.timezone != null) saveTimezone(prefs.timezone);
+												if (prefs.conversations !== undefined)
+													saveConversations(prefs.conversations);
+												if (prefs.windows !== undefined) saveWindows(prefs.windows);
 											}
 											window.location.reload();
-										} else
+										} else {
 											this.showAlert({
 												title: 'Restore Failed',
 												body: r.error.message,
 												buttons: [{ label: 'OK', primary: true }]
 											});
+										}
 									});
 								}
 							}

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -545,7 +545,7 @@ export class OsApiClass implements OsApi {
 				return;
 			}
 			const json = JSON.stringify(result.value, null, 2);
-			const blob = new Blob([json], { type: 'application/json' });
+			const blob = new Blob([json], { type: 'application/octet-stream' });
 			const filename = `terminal-hd-${new Date().toISOString().slice(0, 10)}.terminal-hd`;
 			this.showAlert({
 				title: 'Backup Complete',

--- a/src/lib/os/os-api.test.ts
+++ b/src/lib/os/os-api.test.ts
@@ -4,6 +4,7 @@ import { TerminalFS } from '$lib/terminalos';
 // Mock persistence so nothing touches localStorage
 vi.mock('$lib/persistence', () => ({
 	loadWindows: () => [],
+	saveWindows: vi.fn(),
 	loadTweaks: () => ({
 		wallpaper: 'teal',
 		accent: '#f54e00',
@@ -14,6 +15,8 @@ vi.mock('$lib/persistence', () => ({
 	saveTweaks: vi.fn(),
 	loadTimezone: () => null,
 	saveTimezone: vi.fn(),
+	loadConversations: () => ({}),
+	saveConversations: vi.fn(),
 	isFirstVisit: () => false,
 	clearAllPreferences: vi.fn()
 }));
@@ -252,6 +255,25 @@ describe('system actions', () => {
 		expect(spy).toHaveBeenCalledOnce();
 	});
 
+	it('exportBackup collects preferences and passes them to fs', async () => {
+		const { os, fs } = createOs();
+		const spy = vi.spyOn(fs, 'exportBackup');
+
+		vi.useFakeTimers();
+		os.exportBackup();
+		await vi.advanceTimersByTimeAsync(2000);
+		vi.useRealTimers();
+
+		expect(spy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tweaks: expect.objectContaining({ wallpaper: 'teal' }),
+				conversations: expect.any(Object),
+				timezone: null,
+				windows: expect.any(Array)
+			})
+		);
+	});
+
 	it('exportBackup shows a progress alert then a completion alert', async () => {
 		vi.useFakeTimers();
 		const { os, fs } = createOs();
@@ -261,7 +283,7 @@ describe('system actions', () => {
 			ok: true as const,
 			value: {
 				format: 'terminal-hd' as const,
-				version: 1 as const,
+				version: 2 as const,
 				exportedAt: new Date().toISOString(),
 				disk: { id: 'volume_terminal_hd', name: 'Terminal HD' },
 				nodes: [],

--- a/src/lib/os/os-api.test.ts
+++ b/src/lib/os/os-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TerminalFS } from '$lib/terminalos';
+import { windowAppId } from './os-api';
 
 // Mock persistence so nothing touches localStorage
 vi.mock('$lib/persistence', () => ({
@@ -304,6 +305,69 @@ describe('system actions', () => {
 		expect(os.alertSpec?.buttons?.[1].label).toBe('Download');
 
 		vi.useRealTimers();
+	});
+
+	it('restoreBackup applies window layout to reactive state', async () => {
+		const { os, fs } = createOs();
+
+		// Buy and install VCR so the backup has it
+		await fs.buyApp('vcr');
+		await fs.installApp('vcr');
+
+		// Export with window layout
+		const prefs = {
+			tweaks: {
+				wallpaper: 'teal',
+				accent: '#f54e00',
+				tvGridLoop: 400,
+				marqueeLoop: 100,
+				tvPauseOnHover: false
+			},
+			conversations: {},
+			timezone: null,
+			windows: [
+				{ id: 'welcome', x: 50, y: 50, w: 460, h: 940, z: 1 },
+				{ id: 'vcr', x: 600, y: 50, w: 860, h: 833, z: 2 }
+			]
+		};
+		const exported = await fs.exportBackup(prefs);
+		if (!exported.ok) throw new Error('export failed');
+
+		// Simulate a fresh OS that only has welcome open
+		const freshFs = TerminalFS.createCleanDisk();
+		const freshOs = new OsApiClass(freshFs);
+		freshOs.openWindow('welcome');
+		expect(freshOs.windows).toHaveLength(1);
+
+		// Stub reload to prevent actual navigation
+		const origReload = globalThis.window?.location?.reload;
+		let reloaded = false;
+		if (typeof globalThis.window !== 'undefined') {
+			Object.defineProperty(window, 'location', {
+				value: { ...window.location, reload: () => (reloaded = true) },
+				writable: true
+			});
+		}
+
+		// Call restoreBackup on the fresh FS and trigger the restore action
+		const restoreResult = await freshFs.restoreBackup(exported.value);
+		expect(restoreResult.ok).toBe(true);
+		if (restoreResult.ok && restoreResult.value.preferences?.windows) {
+			freshOs.windows = restoreResult.value.preferences.windows;
+		}
+
+		// Verify the reactive state now has both windows
+		expect(freshOs.windows).toHaveLength(2);
+		expect(freshOs.windows.find((w) => w.id === 'vcr')).toBeDefined();
+		expect(freshOs.windows.find((w) => w.id === 'welcome')?.x).toBe(50);
+
+		// Restore original
+		if (origReload && typeof globalThis.window !== 'undefined') {
+			Object.defineProperty(window, 'location', {
+				value: { ...window.location, reload: origReload },
+				writable: true
+			});
+		}
 	});
 
 	it('reinstallOS shows a confirmation alert with Cancel and Reinstall', () => {
@@ -725,5 +789,35 @@ describe('timezone', () => {
 		os.setTimezone('America/New_York');
 		expect(os.timezone).toBe('America/New_York');
 		expect(saveTimezone).toHaveBeenCalledWith('America/New_York');
+	});
+});
+
+// ── Window app ID mapping ────────────────────────────────────────────────
+
+describe('windowAppId', () => {
+	it('maps store app window IDs to their app IDs', () => {
+		expect(windowAppId('tv-guide')).toBe('tvguide');
+		expect(windowAppId('recorder')).toBe('recorder');
+		expect(windowAppId('vcr')).toBe('vcr');
+		expect(windowAppId('stats')).toBe('stats');
+		expect(windowAppId('software-shop')).toBe('software-shop');
+		expect(windowAppId('computer-store')).toBe('computer-store');
+	});
+
+	it('maps prefix-based window IDs', () => {
+		expect(windowAppId('chat-seinfeld')).toBe('chatrbot');
+		expect(windowAppId('sticky-abc')).toBe('stickies');
+		expect(windowAppId('textedit-xyz')).toBe('textedit');
+		expect(windowAppId('recorder-123')).toBe('recorder');
+	});
+
+	it('maps about windows to their app', () => {
+		expect(windowAppId('about-vcr')).toBe('vcr');
+		expect(windowAppId('about-chatrbot')).toBe('chatrbot');
+		expect(windowAppId('about-tvguide')).toBe('tvguide');
+	});
+
+	it('falls back to finder for unknown IDs', () => {
+		expect(windowAppId('unknown-thing')).toBe('finder');
 	});
 });

--- a/src/lib/os/os-api.test.ts
+++ b/src/lib/os/os-api.test.ts
@@ -307,15 +307,14 @@ describe('system actions', () => {
 		vi.useRealTimers();
 	});
 
-	it('restoreBackup applies window layout to reactive state', async () => {
-		const { os, fs } = createOs();
+	it('restoreBackup returns window layout in preferences', async () => {
+		const { fs } = createOs();
 
-		// Buy and install VCR so the backup has it
-		await fs.buyApp('vcr');
-		await fs.installApp('vcr');
-
-		// Export with window layout
-		const prefs = {
+		const windows = [
+			{ id: 'welcome', x: 50, y: 50, w: 460, h: 940, z: 1 },
+			{ id: 'vcr', x: 600, y: 50, w: 860, h: 833, z: 2 }
+		];
+		const exported = await fs.exportBackup({
 			tweaks: {
 				wallpaper: 'teal',
 				accent: '#f54e00',
@@ -323,51 +322,19 @@ describe('system actions', () => {
 				marqueeLoop: 100,
 				tvPauseOnHover: false
 			},
-			conversations: {},
-			timezone: null,
-			windows: [
-				{ id: 'welcome', x: 50, y: 50, w: 460, h: 940, z: 1 },
-				{ id: 'vcr', x: 600, y: 50, w: 860, h: 833, z: 2 }
-			]
-		};
-		const exported = await fs.exportBackup(prefs);
+			windows
+		});
 		if (!exported.ok) throw new Error('export failed');
 
-		// Simulate a fresh OS that only has welcome open
 		const freshFs = TerminalFS.createCleanDisk();
-		const freshOs = new OsApiClass(freshFs);
-		freshOs.openWindow('welcome');
-		expect(freshOs.windows).toHaveLength(1);
+		const result = await freshFs.restoreBackup(exported.value);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
 
-		// Stub reload to prevent actual navigation
-		const origReload = globalThis.window?.location?.reload;
-		let reloaded = false;
-		if (typeof globalThis.window !== 'undefined') {
-			Object.defineProperty(window, 'location', {
-				value: { ...window.location, reload: () => (reloaded = true) },
-				writable: true
-			});
-		}
-
-		// Call restoreBackup on the fresh FS and trigger the restore action
-		const restoreResult = await freshFs.restoreBackup(exported.value);
-		expect(restoreResult.ok).toBe(true);
-		if (restoreResult.ok && restoreResult.value.preferences?.windows) {
-			freshOs.windows = restoreResult.value.preferences.windows;
-		}
-
-		// Verify the reactive state now has both windows
-		expect(freshOs.windows).toHaveLength(2);
-		expect(freshOs.windows.find((w) => w.id === 'vcr')).toBeDefined();
-		expect(freshOs.windows.find((w) => w.id === 'welcome')?.x).toBe(50);
-
-		// Restore original
-		if (origReload && typeof globalThis.window !== 'undefined') {
-			Object.defineProperty(window, 'location', {
-				value: { ...window.location, reload: origReload },
-				writable: true
-			});
-		}
+		expect(result.value.preferences?.windows).toHaveLength(2);
+		expect(result.value.preferences?.windows?.[0].id).toBe('welcome');
+		expect(result.value.preferences?.windows?.[0].x).toBe(50);
+		expect(result.value.preferences?.windows?.[1].id).toBe('vcr');
 	});
 
 	it('reinstallOS shows a confirmation alert with Cancel and Reinstall', () => {

--- a/src/lib/os/os-api.ts
+++ b/src/lib/os/os-api.ts
@@ -164,7 +164,9 @@ export const WINDOW_APP_MAP: Record<string, string> = {
 	'software-shop': 'software-shop',
 	'about-software-shop': 'software-shop',
 	'computer-store': 'computer-store',
-	'about-computer-store': 'computer-store'
+	'about-computer-store': 'computer-store',
+	vcr: 'vcr',
+	'about-vcr': 'vcr'
 };
 
 export function windowAppId(windowId: string): string {

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -113,6 +113,10 @@ export function saveConversation(botId: string, conversation: Conversation): voi
 	set(KEYS.conversations, all);
 }
 
+export function saveConversations(all: Record<string, Conversation>): void {
+	set(KEYS.conversations, all);
+}
+
 export function loadTimezone(): string | null {
 	return get<string | null>(KEYS.timezone, null);
 }

--- a/src/lib/terminalos/filesystem/backup.test.ts
+++ b/src/lib/terminalos/filesystem/backup.test.ts
@@ -157,6 +157,21 @@ describe('validateBackup', () => {
 		expect(result.ok).toBe(true);
 	});
 
+	it('rejects v2 backup with malformed preferences', () => {
+		const result = validateBackup({
+			format: 'terminal-hd',
+			version: 2,
+			exportedAt: '2025-01-01T00:00:00.000Z',
+			disk: { id: 'v', name: 'V' },
+			nodes: [],
+			bodies: {},
+			preferences: {
+				tweaks: { wallpaper: 123 }
+			}
+		});
+		expect(result.ok).toBe(false);
+	});
+
 	it('rejects version 3 (future)', () => {
 		const result = validateBackup({
 			format: 'terminal-hd',
@@ -363,6 +378,24 @@ describe('restoreBackup', () => {
 		if (result.ok) {
 			expect(result.value.preferences).toBeUndefined();
 		}
+	});
+
+	it('restoring v1 backup does not clear existing ownedApps', async () => {
+		const target = TerminalFS.createCleanDisk();
+		await target.buyApp('tvguide');
+
+		const source = TerminalFS.createCleanDisk();
+		const v1Backup = {
+			format: 'terminal-hd' as const,
+			version: 1 as const,
+			exportedAt: new Date().toISOString(),
+			disk: { id: 'volume_terminal_hd', name: 'Terminal HD' },
+			nodes: Array.from(source.getAllNodes().values()).filter((n) => !n.flags?.hidden),
+			bodies: {} as Record<string, string>
+		};
+
+		await target.restoreBackup(v1Backup);
+		expect(target.getVolume().ownedApps).toContain('tvguide');
 	});
 
 	it('restoring v2 backup with missing preferences uses undefined', async () => {

--- a/src/lib/terminalos/filesystem/backup.test.ts
+++ b/src/lib/terminalos/filesystem/backup.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { TerminalFS, DOCUMENTS_ID, APPLICATIONS_ID, ROOT_ID } from './terminal-fs';
 import { validateBackup, previewBackup, validateDiskForExport } from './backup';
+import type { BackupPreferences } from './backup';
 
 describe('exportBackup', () => {
-	it('produces a valid backup file', async () => {
+	it('produces a valid v2 backup file', async () => {
 		const fs = TerminalFS.createCleanDisk();
 		const result = await fs.exportBackup();
 		expect(result.ok).toBe(true);
 		if (result.ok) {
 			expect(result.value.format).toBe('terminal-hd');
-			expect(result.value.version).toBe(1);
+			expect(result.value.version).toBe(2);
 			expect(result.value.disk.name).toBe('Terminal HD');
 			expect(result.value.nodes.length).toBeGreaterThan(0);
 		}
@@ -39,12 +40,65 @@ describe('exportBackup', () => {
 		const fs = TerminalFS.createCleanDisk();
 		const result = await fs.exportBackup();
 		if (result.ok) {
-			// README.TXT and Pricing.txt should have their bodies in the bodies map
 			const textFiles = result.value.nodes.filter(
 				(n) => n.kind === 'file' && n.bodyRef?.kind === 'inline-text'
 			);
 			expect(textFiles.length).toBeGreaterThan(0);
 			expect(Object.keys(result.value.bodies).length).toBeGreaterThan(0);
+		}
+	});
+
+	it('backup disk includes ownedApps', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.buyApp('recorder');
+		const result = await fs.exportBackup();
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.disk.ownedApps).toBeDefined();
+			expect(result.value.disk.ownedApps).toContain('tvguide');
+			expect(result.value.disk.ownedApps).toContain('recorder');
+		}
+	});
+
+	it('backup includes preferences when provided', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const prefs: BackupPreferences = {
+			tweaks: {
+				wallpaper: 'midnight',
+				accent: '#000000',
+				tvGridLoop: 200,
+				marqueeLoop: 50,
+				tvPauseOnHover: true
+			},
+			timezone: 'America/New_York',
+			conversations: {
+				seinfeld: {
+					botId: 'jerry',
+					group: 'seinfeld',
+					messages: [{ role: 'user', content: 'hello' }],
+					updatedAt: Date.now()
+				}
+			},
+			windows: [{ id: 'finder', x: 10, y: 20, w: 480, h: 420, z: 1 }]
+		};
+		const result = await fs.exportBackup(prefs);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.preferences).toBeDefined();
+			expect(result.value.preferences?.tweaks?.wallpaper).toBe('midnight');
+			expect(result.value.preferences?.timezone).toBe('America/New_York');
+			expect(result.value.preferences?.conversations?.seinfeld).toBeDefined();
+			expect(result.value.preferences?.windows).toHaveLength(1);
+		}
+	});
+
+	it('backup without preferences has undefined preferences', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const result = await fs.exportBackup();
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.preferences).toBeUndefined();
 		}
 	});
 });
@@ -70,10 +124,43 @@ describe('validateBackup', () => {
 		expect(result.ok).toBe(false);
 	});
 
-	it('rejects wrong version', () => {
+	it('still accepts version 1 backups', () => {
+		const result = validateBackup({
+			format: 'terminal-hd',
+			version: 1,
+			exportedAt: '2025-01-01T00:00:00.000Z',
+			disk: { id: 'v', name: 'V' },
+			nodes: [],
+			bodies: {}
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	it('accepts version 2 backups', () => {
 		const result = validateBackup({
 			format: 'terminal-hd',
 			version: 2,
+			exportedAt: '2025-01-01T00:00:00.000Z',
+			disk: { id: 'v', name: 'V', ownedApps: ['tvguide'] },
+			nodes: [],
+			bodies: {},
+			preferences: {
+				tweaks: {
+					wallpaper: 'teal',
+					accent: '#f54e00',
+					tvGridLoop: 400,
+					marqueeLoop: 100,
+					tvPauseOnHover: false
+				}
+			}
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	it('rejects version 3 (future)', () => {
+		const result = validateBackup({
+			format: 'terminal-hd',
+			version: 3,
 			exportedAt: '',
 			disk: { id: '', name: '' },
 			nodes: [],
@@ -96,24 +183,59 @@ describe('previewBackup', () => {
 		expect(preview.appCount).toBeGreaterThan(0);
 		expect(preview.totalNodes).toBeGreaterThan(0);
 	});
+
+	it('hasPreferences is true for v2 backup with preferences', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const prefs: BackupPreferences = {
+			tweaks: {
+				wallpaper: 'teal',
+				accent: '#f54e00',
+				tvGridLoop: 400,
+				marqueeLoop: 100,
+				tvPauseOnHover: false
+			}
+		};
+		const exportResult = await fs.exportBackup(prefs);
+		if (!exportResult.ok) throw new Error('export failed');
+
+		const preview = previewBackup(exportResult.value);
+		expect(preview.hasPreferences).toBe(true);
+	});
+
+	it('hasPreferences is false for v2 backup without preferences', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const exportResult = await fs.exportBackup();
+		if (!exportResult.ok) throw new Error('export failed');
+
+		const preview = previewBackup(exportResult.value);
+		expect(preview.hasPreferences).toBe(false);
+	});
+
+	it('hasPreferences is false for v1 backup', () => {
+		const preview = previewBackup({
+			format: 'terminal-hd',
+			version: 1,
+			exportedAt: '2025-01-01T00:00:00.000Z',
+			disk: { id: 'v', name: 'V' },
+			nodes: [],
+			bodies: {}
+		});
+		expect(preview.hasPreferences).toBe(false);
+	});
 });
 
 describe('restoreBackup', () => {
 	it('restores disk from backup', async () => {
 		const fs = TerminalFS.createCleanDisk();
 
-		// Export
 		const exportResult = await fs.exportBackup();
 		if (!exportResult.ok) throw new Error('export failed');
 
-		// Create a file, then restore (the file should disappear)
 		await fs.createTextFile(DOCUMENTS_ID, 'will-vanish.txt', 'bye');
 
-		// Restore
 		const restoreResult = await fs.restoreBackup(exportResult.value);
 		expect(restoreResult.ok).toBe(true);
 
-		// The file should be gone
 		const docsResult = await fs.listFolder(DOCUMENTS_ID);
 		if (docsResult.ok) {
 			const vanished = docsResult.value.find((n) => n.name === 'will-vanish.txt');
@@ -128,14 +250,11 @@ describe('restoreBackup', () => {
 		if (!exportResult.ok) throw new Error('export failed');
 		const originalNodeCount = exportResult.value.nodes.length;
 
-		// Add some files
 		await fs.createTextFile(DOCUMENTS_ID, 'extra1.txt', 'x');
 		await fs.createTextFile(DOCUMENTS_ID, 'extra2.txt', 'y');
 
-		// Restore
 		await fs.restoreBackup(exportResult.value);
 
-		// Node count should match original
 		expect(fs.getAllNodes().size).toBe(originalNodeCount);
 	});
 
@@ -160,20 +279,150 @@ describe('restoreBackup', () => {
 			expect(restoreResult.value.totalNodes).toBeGreaterThan(0);
 		}
 	});
+
+	it('restores ownedApps to the volume', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.buyApp('recorder');
+
+		const exportResult = await fs.exportBackup();
+		if (!exportResult.ok) throw new Error('export failed');
+
+		const freshFs = TerminalFS.createCleanDisk();
+		expect(freshFs.getVolume().ownedApps ?? []).toHaveLength(0);
+
+		const restoreResult = await freshFs.restoreBackup(exportResult.value);
+		expect(restoreResult.ok).toBe(true);
+		expect(freshFs.getVolume().ownedApps).toContain('tvguide');
+		expect(freshFs.getVolume().ownedApps).toContain('recorder');
+	});
+
+	it('restoring v2 backup without ownedApps clears existing purchases', async () => {
+		const target = TerminalFS.createCleanDisk();
+		await target.buyApp('tvguide');
+		expect(target.getVolume().ownedApps).toContain('tvguide');
+
+		const source = TerminalFS.createCleanDisk();
+		const exportResult = await source.exportBackup();
+		if (!exportResult.ok) throw new Error('export failed');
+
+		await target.restoreBackup(exportResult.value);
+		expect(target.getVolume().ownedApps).toEqual([]);
+	});
+
+	it('returns preferences so caller can apply them', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const prefs: BackupPreferences = {
+			tweaks: {
+				wallpaper: 'midnight',
+				accent: '#222',
+				tvGridLoop: 100,
+				marqueeLoop: 30,
+				tvPauseOnHover: true
+			},
+			timezone: 'Europe/Berlin',
+			conversations: {
+				test: {
+					botId: 'bot1',
+					group: 'test',
+					messages: [{ role: 'user', content: 'hi' }],
+					updatedAt: 1000
+				}
+			},
+			windows: [{ id: 'finder', x: 0, y: 0, w: 480, h: 420, z: 1 }]
+		};
+		const exportResult = await fs.exportBackup(prefs);
+		if (!exportResult.ok) throw new Error('export failed');
+
+		const freshFs = TerminalFS.createCleanDisk();
+		const restoreResult = await freshFs.restoreBackup(exportResult.value);
+		expect(restoreResult.ok).toBe(true);
+		if (restoreResult.ok) {
+			expect(restoreResult.value.preferences).toBeDefined();
+			expect(restoreResult.value.preferences?.tweaks?.wallpaper).toBe('midnight');
+			expect(restoreResult.value.preferences?.timezone).toBe('Europe/Berlin');
+			expect(restoreResult.value.preferences?.conversations?.test.botId).toBe('bot1');
+			expect(restoreResult.value.preferences?.windows).toHaveLength(1);
+		}
+	});
+
+	it('restoring v1 backup works and returns no preferences', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const v1Backup = {
+			format: 'terminal-hd' as const,
+			version: 1 as const,
+			exportedAt: new Date().toISOString(),
+			disk: { id: 'volume_terminal_hd', name: 'Terminal HD' },
+			nodes: Array.from(fs.getAllNodes().values()).filter((n) => !n.flags?.hidden),
+			bodies: {} as Record<string, string>
+		};
+
+		const freshFs = TerminalFS.createCleanDisk();
+		const result = await freshFs.restoreBackup(v1Backup);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.preferences).toBeUndefined();
+		}
+	});
+
+	it('restoring v2 backup with missing preferences uses undefined', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const exportResult = await fs.exportBackup(); // no preferences passed
+		if (!exportResult.ok) throw new Error('export failed');
+
+		const freshFs = TerminalFS.createCleanDisk();
+		const result = await freshFs.restoreBackup(exportResult.value);
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.preferences).toBeUndefined();
+		}
+	});
+
+	it('round-trip preserves ownedApps and node count', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		await fs.buyApp('tvguide');
+		await fs.createTextFile(DOCUMENTS_ID, 'round-trip.txt', 'content');
+
+		const exported = await fs.exportBackup({
+			tweaks: {
+				wallpaper: 'pink',
+				accent: '#ff0000',
+				tvGridLoop: 300,
+				marqueeLoop: 80,
+				tvPauseOnHover: false
+			}
+		});
+		if (!exported.ok) throw new Error('export failed');
+
+		const freshFs = TerminalFS.createCleanDisk();
+		await freshFs.restoreBackup(exported.value);
+
+		const reExported = await freshFs.exportBackup({
+			tweaks: {
+				wallpaper: 'pink',
+				accent: '#ff0000',
+				tvGridLoop: 300,
+				marqueeLoop: 80,
+				tvPauseOnHover: false
+			}
+		});
+		if (!reExported.ok) throw new Error('re-export failed');
+
+		expect(reExported.value.nodes.length).toBe(exported.value.nodes.length);
+		expect(reExported.value.disk.ownedApps).toEqual(exported.value.disk.ownedApps);
+		expect(reExported.value.preferences?.tweaks?.wallpaper).toBe('pink');
+	});
 });
 
 describe('reinstallOS', () => {
 	it('rebuilds factory disk', async () => {
 		const fs = TerminalFS.createCleanDisk();
 
-		// Add custom files
 		await fs.createTextFile(DOCUMENTS_ID, 'my-file.txt', 'custom content');
 
-		// Reinstall
 		const result = await fs.reinstallOS();
 		expect(result.ok).toBe(true);
 
-		// Custom file should be gone
 		const docsResult = await fs.listFolder(DOCUMENTS_ID);
 		if (docsResult.ok) {
 			const customFile = docsResult.value.find((n) => n.name === 'my-file.txt');
@@ -185,7 +434,6 @@ describe('reinstallOS', () => {
 		const fs = TerminalFS.createCleanDisk();
 		await fs.reinstallOS();
 
-		// System folders should exist
 		const rootResult = await fs.listFolder(ROOT_ID);
 		expect(rootResult.ok).toBe(true);
 		if (rootResult.ok) {

--- a/src/lib/terminalos/filesystem/backup.ts
+++ b/src/lib/terminalos/filesystem/backup.ts
@@ -30,47 +30,45 @@ export type BackupPreferences = {
 	windows?: WindowState[];
 };
 
-const backupPreferencesSchema = z
-	.object({
-		tweaks: z
-			.object({
-				wallpaper: z.string(),
-				accent: z.string(),
-				tvGridLoop: z.number(),
-				marqueeLoop: z.number(),
-				tvPauseOnHover: z.boolean()
+const backupPreferencesSchema = z.object({
+	tweaks: z
+		.object({
+			wallpaper: z.string(),
+			accent: z.string(),
+			tvGridLoop: z.number(),
+			marqueeLoop: z.number(),
+			tvPauseOnHover: z.boolean()
+		})
+		.optional(),
+	conversations: z
+		.record(
+			z.object({
+				botId: z.string(),
+				group: z.string(),
+				messages: z.array(
+					z.object({
+						role: z.enum(['user', 'assistant']),
+						content: z.string()
+					})
+				),
+				updatedAt: z.number()
 			})
-			.optional(),
-		conversations: z
-			.record(
-				z.object({
-					botId: z.string(),
-					group: z.string(),
-					messages: z.array(
-						z.object({
-							role: z.enum(['user', 'assistant']),
-							content: z.string()
-						})
-					),
-					updatedAt: z.number()
-				})
-			)
-			.optional(),
-		timezone: z.string().nullable().optional(),
-		windows: z
-			.array(
-				z.object({
-					id: z.string(),
-					x: z.number(),
-					y: z.number(),
-					w: z.number(),
-					h: z.number(),
-					z: z.number()
-				})
-			)
-			.optional()
-	})
-	.optional();
+		)
+		.optional(),
+	timezone: z.string().nullable().optional(),
+	windows: z
+		.array(
+			z.object({
+				id: z.string(),
+				x: z.number(),
+				y: z.number(),
+				w: z.number(),
+				h: z.number(),
+				z: z.number()
+			})
+		)
+		.optional()
+});
 
 // --- Backup format ---
 
@@ -142,7 +140,7 @@ const backupSchemaV2 = z.object({
 	}),
 	nodes: z.array(fsNodeSchema),
 	bodies: z.record(z.string()),
-	preferences: backupPreferencesSchema
+	preferences: backupPreferencesSchema.optional()
 });
 
 const backupSchema = z.discriminatedUnion('version', [backupSchemaV1, backupSchemaV2]);
@@ -214,7 +212,7 @@ export function previewBackup(backup: BackupFile): BackupPreview {
 	const hasPreferences =
 		backup.version === 2 &&
 		backup.preferences != null &&
-		Object.keys(backup.preferences).length > 0;
+		Object.values(backup.preferences).some((v) => v != null);
 
 	return {
 		diskName: backup.disk.name,

--- a/src/lib/terminalos/filesystem/backup.ts
+++ b/src/lib/terminalos/filesystem/backup.ts
@@ -2,10 +2,79 @@ import { z } from 'zod';
 import type { FsNode, FsResult, NodeId, TerminalVolume } from './types';
 import { fsNodeSchema } from './schemas';
 import { ok, fail } from './errors';
+import type { TweaksState, Conversation, WindowState } from '$lib/types';
+
+/*
+ * BACKUP COVERAGE REGISTRY
+ *
+ * Every persistent state key must appear here. When adding new persisted
+ * state, add an entry — scripts/lint-backup-coverage.js enforces this.
+ *
+ * Key                                  | Backed up | Reason if excluded
+ * ------------------------------------ | --------- | ---------------------------
+ * terminalos.manifest (nodes+volume)   | Yes       | Core disk data
+ * terminal.os.tweaks                   | Yes (v2)  | User preferences
+ * terminal.app.chatrbot.conversations  | Yes (v2)  | Chat history
+ * terminal.os.timezone                 | Yes (v2)  | User preference
+ * terminal.os.windows                  | Yes (v2)  | Window layout
+ * terminal.os.session                  | No        | Per-session unique ID
+ * terminal.os.firstVisit               | No        | Should reset on new device
+ */
+
+// --- Backup preferences ---
+
+export type BackupPreferences = {
+	tweaks?: TweaksState;
+	conversations?: Record<string, Conversation>;
+	timezone?: string | null;
+	windows?: WindowState[];
+};
+
+const backupPreferencesSchema = z
+	.object({
+		tweaks: z
+			.object({
+				wallpaper: z.string(),
+				accent: z.string(),
+				tvGridLoop: z.number(),
+				marqueeLoop: z.number(),
+				tvPauseOnHover: z.boolean()
+			})
+			.optional(),
+		conversations: z
+			.record(
+				z.object({
+					botId: z.string(),
+					group: z.string(),
+					messages: z.array(
+						z.object({
+							role: z.enum(['user', 'assistant']),
+							content: z.string()
+						})
+					),
+					updatedAt: z.number()
+				})
+			)
+			.optional(),
+		timezone: z.string().nullable().optional(),
+		windows: z
+			.array(
+				z.object({
+					id: z.string(),
+					x: z.number(),
+					y: z.number(),
+					w: z.number(),
+					h: z.number(),
+					z: z.number()
+				})
+			)
+			.optional()
+	})
+	.optional();
 
 // --- Backup format ---
 
-export type BackupFile = {
+export type BackupFileV1 = {
 	format: 'terminal-hd';
 	version: 1;
 	exportedAt: string;
@@ -14,8 +83,24 @@ export type BackupFile = {
 		name: string;
 	};
 	nodes: FsNode[];
-	bodies: Record<string, string>; // bodyId -> base64-encoded text (for inline text bodies in v1)
+	bodies: Record<string, string>;
 };
+
+export type BackupFileV2 = {
+	format: 'terminal-hd';
+	version: 2;
+	exportedAt: string;
+	disk: {
+		id: string;
+		name: string;
+		ownedApps?: string[];
+	};
+	nodes: FsNode[];
+	bodies: Record<string, string>;
+	preferences?: BackupPreferences;
+};
+
+export type BackupFile = BackupFileV1 | BackupFileV2;
 
 export type BackupPreview = {
 	diskName: string;
@@ -25,11 +110,16 @@ export type BackupPreview = {
 	aliasCount: number;
 	appCount: number;
 	totalNodes: number;
+	hasPreferences: boolean;
 };
 
-// --- Zod schema for backup validation ---
+export type BackupRestoreResult = BackupPreview & {
+	preferences?: BackupPreferences;
+};
 
-const backupSchema = z.object({
+// --- Zod schemas ---
+
+const backupSchemaV1 = z.object({
 	format: z.literal('terminal-hd'),
 	version: z.literal(1),
 	exportedAt: z.string(),
@@ -41,23 +131,37 @@ const backupSchema = z.object({
 	bodies: z.record(z.string())
 });
 
+const backupSchemaV2 = z.object({
+	format: z.literal('terminal-hd'),
+	version: z.literal(2),
+	exportedAt: z.string(),
+	disk: z.object({
+		id: z.string(),
+		name: z.string(),
+		ownedApps: z.array(z.string()).optional()
+	}),
+	nodes: z.array(fsNodeSchema),
+	bodies: z.record(z.string()),
+	preferences: backupPreferencesSchema
+});
+
+const backupSchema = z.discriminatedUnion('version', [backupSchemaV1, backupSchemaV2]);
+
 // --- Export ---
 
-/**
- * Build a backup from the current visible disk state.
- * Excludes: private app data, caches, operation history, undo state.
- */
-export function buildBackup(volume: TerminalVolume, nodes: Map<NodeId, FsNode>): BackupFile {
+export function buildBackup(
+	volume: TerminalVolume,
+	nodes: Map<NodeId, FsNode>,
+	preferences?: BackupPreferences
+): BackupFileV2 {
 	const visibleNodes: FsNode[] = [];
 	const bodies: Record<string, string> = {};
 
 	for (const node of nodes.values()) {
-		// Skip hidden nodes
 		if (node.flags?.hidden) continue;
 
 		visibleNodes.push(node);
 
-		// Collect inline text bodies
 		if (node.kind === 'file' && node.bodyRef?.kind === 'inline-text') {
 			bodies[node.id] = node.bodyRef.text;
 		}
@@ -65,22 +169,21 @@ export function buildBackup(volume: TerminalVolume, nodes: Map<NodeId, FsNode>):
 
 	return {
 		format: 'terminal-hd',
-		version: 1,
+		version: 2,
 		exportedAt: new Date().toISOString(),
 		disk: {
 			id: volume.id,
-			name: volume.name
+			name: volume.name,
+			ownedApps: volume.ownedApps
 		},
 		nodes: visibleNodes,
-		bodies
+		bodies,
+		preferences
 	};
 }
 
 // --- Validate ---
 
-/**
- * Validate a backup file's structure. Returns typed result.
- */
 export function validateBackup(data: unknown): FsResult<BackupFile> {
 	const result = backupSchema.safeParse(data);
 	if (!result.success) {
@@ -91,9 +194,6 @@ export function validateBackup(data: unknown): FsResult<BackupFile> {
 
 // --- Preview ---
 
-/**
- * Generate a preview summary from a validated backup.
- */
 export function previewBackup(backup: BackupFile): BackupPreview {
 	let fileCount = 0;
 	let folderCount = 0;
@@ -111,6 +211,11 @@ export function previewBackup(backup: BackupFile): BackupPreview {
 		}
 	}
 
+	const hasPreferences =
+		backup.version === 2 &&
+		backup.preferences != null &&
+		Object.keys(backup.preferences).length > 0;
+
 	return {
 		diskName: backup.disk.name,
 		exportedAt: backup.exportedAt,
@@ -118,16 +223,13 @@ export function previewBackup(backup: BackupFile): BackupPreview {
 		folderCount,
 		aliasCount,
 		appCount,
-		totalNodes: backup.nodes.length
+		totalNodes: backup.nodes.length,
+		hasPreferences
 	};
 }
 
 // --- Validate for export ---
 
-/**
- * Quick sanity check that the current disk is exportable.
- * Returns ok if the disk looks sane, fail if something is wrong.
- */
 export function validateDiskForExport(
 	volume: TerminalVolume,
 	nodes: Map<NodeId, FsNode>

--- a/src/lib/terminalos/filesystem/terminal-fs.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.ts
@@ -20,7 +20,7 @@ import { getAppWindowId } from '../apps/app-install';
 import { findAppFile, isOwned as checkOwned, deriveOwnedApps } from '../apps/software-shop';
 import type { UndoRecord } from './operations';
 import { buildBackup, validateBackup, previewBackup, validateDiskForExport } from './backup';
-import type { BackupFile, BackupPreview } from './backup';
+import type { BackupFileV2, BackupPreferences, BackupRestoreResult } from './backup';
 import type { ManifestStore, BodyStore } from './storage/storage-types';
 import { InMemoryManifestStore, InMemoryBodyStore } from './storage/storage-types';
 import { computeDiskUsage } from './usage';
@@ -1276,25 +1276,25 @@ export class TerminalFS {
 
 	// --- Backup / Restore ---
 
-	async exportBackup(): Promise<FsResult<BackupFile>> {
+	async exportBackup(preferences?: BackupPreferences): Promise<FsResult<BackupFileV2>> {
 		const validation = validateDiskForExport(this.volume, this.nodes);
-		if (!validation.ok) return validation as FsResult<BackupFile>;
+		if (!validation.ok) return validation as FsResult<BackupFileV2>;
 
-		const backup = buildBackup(this.volume, this.nodes);
+		const backup = buildBackup(this.volume, this.nodes, preferences);
 		return ok(backup);
 	}
 
-	async validateBackup(data: unknown): Promise<FsResult<BackupPreview>> {
+	async validateBackup(data: unknown): Promise<FsResult<BackupRestoreResult>> {
 		const validated = validateBackup(data);
-		if (!validated.ok) return validated as FsResult<BackupPreview>;
+		if (!validated.ok) return validated as FsResult<BackupRestoreResult>;
 
 		const preview = previewBackup(validated.value);
 		return ok(preview);
 	}
 
-	async restoreBackup(data: unknown): Promise<FsResult<BackupPreview>> {
+	async restoreBackup(data: unknown): Promise<FsResult<BackupRestoreResult>> {
 		const validated = validateBackup(data);
-		if (!validated.ok) return validated as FsResult<BackupPreview>;
+		if (!validated.ok) return validated as FsResult<BackupRestoreResult>;
 
 		const backup = validated.value;
 		const preview = previewBackup(backup);
@@ -1305,9 +1305,14 @@ export class TerminalFS {
 			this.nodes.set(node.id, node as FsNode);
 		}
 
+		// Restore ownedApps from v2 backups (always set — even if empty/undefined)
+		if (backup.version === 2) {
+			this.volume = { ...this.volume, ownedApps: backup.disk.ownedApps ?? [] };
+		}
+
 		// Persist the restored state
 		const persistResult = await this.persist();
-		if (!persistResult.ok) return persistResult as FsResult<BackupPreview>;
+		if (!persistResult.ok) return persistResult as FsResult<BackupRestoreResult>;
 
 		// Clear undo — restore is a full disk replacement
 		this.lastUndo = null;
@@ -1316,7 +1321,11 @@ export class TerminalFS {
 		const allNodeIds = Array.from(this.nodes.keys());
 		this.notifyChange(allNodeIds, allNodeIds, 'restore');
 
-		return ok(preview);
+		const result: BackupRestoreResult = {
+			...preview,
+			preferences: backup.version === 2 ? backup.preferences : undefined
+		};
+		return ok(result);
 	}
 
 	// --- Reinstall ---

--- a/src/lib/terminalos/index.ts
+++ b/src/lib/terminalos/index.ts
@@ -34,7 +34,14 @@ export {
 	previewBackup,
 	validateDiskForExport
 } from './filesystem/backup';
-export type { BackupFile, BackupPreview } from './filesystem/backup';
+export type {
+	BackupFile,
+	BackupFileV1,
+	BackupFileV2,
+	BackupPreview,
+	BackupPreferences,
+	BackupRestoreResult
+} from './filesystem/backup';
 export type { AliasResolution } from './filesystem/aliases';
 export type { OperationKind, UndoRecord } from './filesystem/operations';
 export type { DiskUsage } from './filesystem/usage';


### PR DESCRIPTION
## Summary

- Bumps backup format from v1 to v2, adding `disk.ownedApps` and a `preferences` object (tweaks, conversations, timezone, window layout) to the backup file
- v1 backups still accepted on import via Zod discriminated union — export always produces v2
- OS API layer collects all current preferences before export and applies restored preferences before page reload
- Adds `scripts/lint-backup-coverage.js` that extracts every persistence key and verifies it appears in the BACKUP COVERAGE REGISTRY comment block in `backup.ts` — forces a decision about backup status when new state is added
- Fixes the restore bug where `ownedApps` was never written back to the volume, and a v2 backup with no purchases now correctly clears stale purchases on the target machine

## Test plan

- [ ] `pnpm check` — 0 errors
- [ ] `pnpm test:unit` — 459 tests passing
- [ ] `pnpm lint:backup` — all persistence keys covered
- [ ] Manual: export backup → inspect JSON has `version: 2`, `ownedApps`, `preferences`
- [ ] Manual: restore backup → verify tweaks, conversations, timezone, windows survive
- [ ] Manual: restore a v1 `.terminal-hd` file → should work, just without preferences
- [ ] Manual: add a fake key to `KEYS` in `persistence.ts` → `pnpm lint:backup` fails