### PR TITLE
Route Finder and Desktop document opens through LaunchServices

### DIFF
--- a/src/lib/apps/finder/FinderWindow.svelte
+++ b/src/lib/apps/finder/FinderWindow.svelte
@@ -12,9 +12,8 @@
 	import type { FsNode, FsFile, FsAlias } from '$lib/terminalos';
 	import { getSystem } from '$lib/os/os-context';
 	import PixelIcon from '$lib/components/PixelIcon.svelte';
-	import { getAppWindowId, getAppIconKind } from '$lib/terminalos/apps/app-install';
-	import { getAppDef } from '$lib/terminalos/apps/app-library';
-	import { isInstalled } from '$lib/terminalos/apps/software-shop';
+	import { getAppIconKind } from '$lib/terminalos/apps/app-install';
+	import { openFilesystemNode } from '$lib/os/filesystem-open';
 
 	// Zero-prop: os/fs come from the host context. The starting folder is an
 	// explicit static arg on the matched window (finder → ROOT_ID, trash → TRASH_ID)
@@ -93,86 +92,16 @@
 		selectedId = id;
 	}
 
-	function openDocFile(file: FsFile) {
-		if (file.appId === 'textedit') {
-			os.openWindow(`textedit:${file.id}`);
-		} else if (file.appId === 'recorder') {
-			// Route through the single document-open rule: a recording is tagged
-			// opensWith:'player', so it opens in the system Player (which reads the
-			// blob via readBody) instead of the old inline branch that called
-			// readText() and showed "Recording not found." for blob bodies.
-			os.openDocument(file);
-		} else if (file.appId === 'stickies') {
-			// Open THIS note (the file id is the note id), not a new blank one — the
-			// flat sticky:<noteId> window is a live view of its own file.
-			os.openWindow(`sticky:${file.id}`);
-		}
-	}
-
 	function handleOpen(node: FsNode) {
-		if (node.kind === 'folder') {
-			currentFolderId = node.id;
-			selectedId = null;
-			return;
-		}
-		if (node.kind === 'alias') {
-			const target = resolveNode(node);
-			if (target) handleOpen(target);
-			return;
-		}
-		const file = node as FsFile;
-		const appId = file.appId;
-		if (!appId) {
-			os.openWindow(file.id);
-			return;
-		}
-
-		// A document whose handler is a SYSTEM app (e.g. a recording tagged
-		// opensWith:'player') opens through the single open rule regardless of
-		// whether its *creator* app is installed — the handler is always present.
-		// Gate on the handler, not the creator. Only when the creator IS the
-		// handler (textedit, stickies → opensWith === appId) does the
-		// install gate below still apply.
-		if (file.opensWith && file.opensWith !== appId) {
-			const handler = getAppDef(file.opensWith);
-			if (handler?.isSystem) {
-				os.openDocument(file);
-				return;
-			}
-		}
-
-		// For document-type files, check if the owning app is still installed
-		const docApps = new Set(['textedit', 'recorder', 'stickies']);
-		if (docApps.has(appId)) {
-			const appDef = getAppDef(appId);
-			if (appDef) {
-				const nodes = fs.getAllNodes();
-				if (!isInstalled(appId, nodes)) {
-					os.alert({
-						title: `${appDef.name} is not installed`,
-						body: `The ${appDef.name} application has been uninstalled. You can reinstall it from My Shelf.`,
-						buttons: [
-							{
-								label: 'Open My Shelf',
-								action: () => os.openWindow('software-shop')
-							},
-							{ label: 'OK', primary: true }
-						]
-					});
-				} else {
-					openDocFile(file);
-				}
-				return;
-			}
-		}
-
-		// Generic: look up window ID from AppLibrary
-		const windowId = getAppWindowId(appId);
-		if (windowId) {
-			os.openWindow(windowId);
-			return;
-		}
-		os.openWindow(file.id);
+		openFilesystemNode(node, {
+			resolveAlias: (alias) => resolveNode(alias),
+			openFolder: (folder) => {
+				currentFolderId = folder.id;
+				selectedId = null;
+			},
+			launchApp: (appId) => os.launchApp(appId),
+			openDocument: (file) => os.openDocument(file)
+		});
 	}
 
 	function navigateTo(id: string) {

--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -30,9 +30,10 @@
 		setStickyColor
 	} from '$lib/apps/stickies/stickies-manager.svelte';
 	import DesktopContextMenu from './DesktopContextMenu.svelte';
-	import { getAppWindowId, getAppIconKind } from '$lib/terminalos/apps/app-install';
+	import { getAppIconKind } from '$lib/terminalos/apps/app-install';
 	import { matchWindow } from '$lib/terminalos/apps/app-catalog';
 	import { vcrPrefs } from '$lib/apps/vcr/vcr-prefs.svelte';
+	import { openFilesystemNode } from '$lib/os/filesystem-open';
 
 	// matchWindow is the sole render gate: a window-id renders iff a manifest claims
 	// it via windows[]. Every window goes through the one WindowHost path, which
@@ -60,34 +61,15 @@
 		return target;
 	}
 
-	async function openDesktopNode(node: FsNode) {
-		if (node.kind === 'alias') {
-			const target = resolveAliasSync(node);
-			if (target) openDesktopNode(target);
-			return;
-		}
-		if (node.kind === 'file') {
-			const file = node as FsFile;
-			const appId = file.appId;
-			if (!appId) {
-				os.openWindow(file.id);
-				return;
-			}
-			// Special apps need their own handling
-			if (appId === 'stickies') {
-				const id = await createStickyNote(terminalFs);
-				if (id) os.openWindow(`sticky:${id}`);
-				return;
-			}
-			// Generic: look up the window ID
-			const windowId = getAppWindowId(appId);
-			if (windowId) {
-				os.openWindow(windowId);
-				return;
-			}
-			// Fallback for files opened by their app (textedit docs, recordings)
-			os.openWindow(file.id);
-		}
+	function openDesktopNode(node: FsNode) {
+		openFilesystemNode(node, {
+			resolveAlias: (alias) => resolveAliasSync(alias),
+			openFolder: (folder) => {
+				os.openWindow(folder.id === TRASH_ID ? 'trash' : 'finder');
+			},
+			launchApp: (appId) => os.launchApp(appId),
+			openDocument: (file) => os.openDocument(file)
+		});
 	}
 
 	function desktopIconKind(node: FsNode): string {

--- a/src/lib/os/filesystem-open-usage.test.ts
+++ b/src/lib/os/filesystem-open-usage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+function read(relPath: string): string {
+	return readFileSync(fileURLToPath(new URL(relPath, import.meta.url)), 'utf8');
+}
+
+function functionBody(source: string, name: string): string {
+	const marker = `function ${name}`;
+	const start = source.indexOf(marker);
+	expect(start).toBeGreaterThanOrEqual(0);
+
+	const openBrace = source.indexOf('{', start);
+	expect(openBrace).toBeGreaterThanOrEqual(0);
+
+	let depth = 0;
+	for (let i = openBrace; i < source.length; i++) {
+		if (source[i] === '{') depth++;
+		if (source[i] === '}') depth--;
+		if (depth === 0) return source.slice(openBrace, i + 1);
+	}
+	throw new Error(`Could not read function body for ${name}`);
+}
+
+const finderSource = read('../apps/finder/FinderWindow.svelte');
+const desktopSource = read('../components/Desktop.svelte');
+
+describe('Finder/Desktop filesystem open policy', () => {
+	it('routes Finder opens through the shared filesystem policy', () => {
+		const body = functionBody(finderSource, 'handleOpen');
+
+		expect(body).toContain('openFilesystemNode(node');
+		expect(body).toContain('currentFolderId = folder.id');
+		expect(body).toContain('os.launchApp(appId)');
+		expect(body).toContain('os.openDocument(file)');
+	});
+
+	it('routes Desktop opens through the shared filesystem policy', () => {
+		const body = functionBody(desktopSource, 'openDesktopNode');
+
+		expect(body).toContain('openFilesystemNode(node');
+		expect(body).toContain("folder.id === TRASH_ID ? 'trash' : 'finder'");
+		expect(body).toContain('os.launchApp(appId)');
+		expect(body).toContain('os.openDocument(file)');
+	});
+
+	it('keeps app-specific document policy out of Finder', () => {
+		const body = functionBody(finderSource, 'handleOpen');
+
+		expect(body).not.toContain('docApps');
+		expect(body).not.toContain('getAppWindowId');
+		expect(body).not.toContain('getAppDef');
+		expect(body).not.toContain('isInstalled');
+		expect(body).not.toContain('openDocFile');
+		expect(body).not.toContain("appId === '");
+	});
+
+	it('keeps app-specific document policy out of Desktop file opens', () => {
+		const body = functionBody(desktopSource, 'openDesktopNode');
+
+		expect(body).not.toContain('getAppWindowId');
+		expect(body).not.toContain('createStickyNote');
+		expect(body).not.toContain('os.openWindow(file.id)');
+		expect(body).not.toContain("appId === '");
+	});
+});

--- a/src/lib/os/filesystem-open.test.ts
+++ b/src/lib/os/filesystem-open.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FsAlias, FsFile, FsFolder } from '$lib/terminalos';
+import { openFilesystemNode } from './filesystem-open';
+
+function file(overrides: Partial<FsFile> = {}): FsFile {
+	return {
+		id: 'file_1',
+		volumeId: 'volume_terminal_hd',
+		kind: 'file',
+		parentId: 'folder_documents',
+		name: 'Clip.webm',
+		fileType: 'recording',
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides
+	};
+}
+
+function folder(overrides: Partial<FsFolder> = {}): FsFolder {
+	return {
+		id: 'folder_1',
+		volumeId: 'volume_terminal_hd',
+		kind: 'folder',
+		parentId: 'folder_documents',
+		name: 'Projects',
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides
+	};
+}
+
+function alias(targetNodeId: string, overrides: Partial<FsAlias> = {}): FsAlias {
+	return {
+		id: 'alias_1',
+		volumeId: 'volume_terminal_hd',
+		kind: 'alias',
+		parentId: 'folder_desktop',
+		name: 'Clip alias',
+		target: {
+			nodeId: targetNodeId,
+			originalPath: '/Recordings/Clip.webm',
+			originalName: 'Clip.webm',
+			targetKind: 'file'
+		},
+		createdAt: 1,
+		updatedAt: 1,
+		...overrides
+	};
+}
+
+function router() {
+	return {
+		resolveAlias: vi.fn(),
+		openFolder: vi.fn(),
+		launchApp: vi.fn(),
+		openDocument: vi.fn()
+	};
+}
+
+describe('openFilesystemNode', () => {
+	it('opens a recording through document routing instead of launching its creator app', () => {
+		const recording = file({
+			appId: 'recorder',
+			opensWith: 'player',
+			bodyRef: {
+				kind: 'indexeddb-blob',
+				bodyId: 'body_1',
+				size: 10,
+				contentType: 'video/webm'
+			}
+		});
+		const r = router();
+
+		openFilesystemNode(recording, r);
+
+		expect(r.openDocument).toHaveBeenCalledWith(recording);
+		expect(r.launchApp).not.toHaveBeenCalled();
+		expect(r.openFolder).not.toHaveBeenCalled();
+	});
+
+	it('opens a desktop document alias through the same document route as its target', () => {
+		const recording = file({ id: 'rec_1', appId: 'recorder', opensWith: 'player' });
+		const recordingAlias = alias(recording.id);
+		const r = router();
+		r.resolveAlias.mockReturnValue(recording);
+
+		openFilesystemNode(recordingAlias, r);
+
+		expect(r.resolveAlias).toHaveBeenCalledWith(recordingAlias);
+		expect(r.openDocument).toHaveBeenCalledWith(recording);
+		expect(r.launchApp).not.toHaveBeenCalled();
+	});
+
+	it('opens a generic content-type blob through document routing even without a creator app', () => {
+		const video = file({
+			id: 'video_1',
+			appId: undefined,
+			opensWith: undefined,
+			fileType: 'data',
+			bodyRef: {
+				kind: 'indexeddb-blob',
+				bodyId: 'body_video',
+				size: 10,
+				contentType: 'video/mp4'
+			}
+		});
+		const r = router();
+
+		openFilesystemNode(video, r);
+
+		expect(r.openDocument).toHaveBeenCalledWith(video);
+		expect(r.launchApp).not.toHaveBeenCalled();
+	});
+
+	it('launches app files as apps', () => {
+		const appFile = file({
+			id: 'app_textedit',
+			name: 'TextEdit.app',
+			fileType: 'app',
+			appId: 'textedit'
+		});
+		const r = router();
+
+		openFilesystemNode(appFile, r);
+
+		expect(r.launchApp).toHaveBeenCalledWith('textedit');
+		expect(r.openDocument).not.toHaveBeenCalled();
+	});
+
+	it('delegates folders to the caller-specific folder behavior', () => {
+		const projects = folder();
+		const r = router();
+
+		openFilesystemNode(projects, r);
+
+		expect(r.openFolder).toHaveBeenCalledWith(projects);
+		expect(r.openDocument).not.toHaveBeenCalled();
+		expect(r.launchApp).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/os/filesystem-open.ts
+++ b/src/lib/os/filesystem-open.ts
@@ -1,0 +1,39 @@
+import type { FsAlias, FsFile, FsFolder, FsNode } from '$lib/terminalos';
+
+export type FilesystemOpenRouter = {
+	resolveAlias: (alias: FsAlias) => FsNode | null;
+	openFolder: (folder: FsFolder) => void;
+	launchApp: (appId: string) => void;
+	openDocument: (file: FsFile) => void;
+};
+
+/**
+ * Shared Finder/Desktop open policy. Callers still decide how folders behave
+ * in their context, but app files launch apps and every non-app file enters
+ * LaunchServices through os.openDocument.
+ */
+export function openFilesystemNode(
+	node: FsNode,
+	router: FilesystemOpenRouter,
+	seen = new Set<string>()
+): void {
+	if (node.kind === 'alias') {
+		if (seen.has(node.id)) return;
+		seen.add(node.id);
+		const target = router.resolveAlias(node);
+		if (target) openFilesystemNode(target, router, seen);
+		return;
+	}
+
+	if (node.kind === 'folder') {
+		router.openFolder(node);
+		return;
+	}
+
+	if (node.fileType === 'app' && node.appId) {
+		router.launchApp(node.appId);
+		return;
+	}
+
+	router.openDocument(node);
+}

--- a/src/lib/os/window-host.test.ts
+++ b/src/lib/os/window-host.test.ts
@@ -167,6 +167,27 @@ describe('recorder statusExtra (REC badge)', () => {
 });
 
 describe('resolveOpenTarget', () => {
+	it('routes TextEdit documents to their textedit instance window', () => {
+		const file = mkFile({
+			id: 'readme1',
+			name: 'README.TXT',
+			fileType: 'text',
+			opensWith: 'textedit'
+		});
+		expect(resolveOpenTarget(file)).toBe('textedit:readme1');
+	});
+
+	it('routes sticky documents to their sticky note instance window', () => {
+		const file = mkFile({
+			id: 'note1',
+			name: 'Untitled Note',
+			appId: 'stickies',
+			fileType: 'sticky',
+			opensWith: 'stickies'
+		});
+		expect(resolveOpenTarget(file)).toBe('sticky:note1');
+	});
+
 	it('routes a recording to the Player via opensWith (the bug_002 path)', () => {
 		const file = mkFile({
 			id: 'rec1',

--- a/src/lib/terminalos/apps/manifests.ts
+++ b/src/lib/terminalos/apps/manifests.ts
@@ -397,17 +397,16 @@ export const MANIFESTS = [
 		iconKind: 'doc',
 		// One window minted per open document, keyed `textedit:<fileId>`. The `:`
 		// separator matches chat:/player:/about: (file-ids contain `-`; the tail is
-		// sliced by prefix length, unambiguous either way). NO `opens`: TextEdit is
-		// launched (File ▸ New/Open, Finder double-click), not a content-type doc
-		// handler. The title is the file's name, read purely from the fs node since
-		// SpecCtx is {args, fs}.
+		// sliced by prefix length, unambiguous either way). The title is the file's
+		// name, read purely from the fs node since SpecCtx is {args, fs}.
 		windows: [
 			{
 				match: { kind: 'prefix', prefix: 'textedit:', arg: 'fileId' },
 				role: 'app',
 				title: ({ args, fs }) => fs.peekNode(args.fileId)?.name ?? 'Untitled.txt',
 				size: () => ({ w: 420, h: 400 }),
-				component: () => import('$lib/apps/textedit/TextEditWindow.svelte')
+				component: () => import('$lib/apps/textedit/TextEditWindow.svelte'),
+				opens: { fileTypes: ['text'] }
 			}
 		],
 		aboutSpec: {
@@ -495,8 +494,7 @@ export const MANIFESTS = [
 		iconKind: 'stickies',
 		// Each note is a flat prefix window `sticky:<noteId>`. chromeless: true is
 		// spec-driven (Desktop reads it off the resolved spec) — stickies draw their
-		// own chrome, so the title is cosmetic. No `opens`: notes are launched, not
-		// a document handler.
+		// own chrome, so the title is cosmetic.
 		windows: [
 			{
 				match: { kind: 'prefix', prefix: 'sticky:', arg: 'noteId' },
@@ -504,7 +502,8 @@ export const MANIFESTS = [
 				chromeless: true,
 				title: () => 'Stickies',
 				size: () => ({ w: 240, h: 220 }),
-				component: () => import('$lib/apps/stickies/StickiesNote.svelte')
+				component: () => import('$lib/apps/stickies/StickiesNote.svelte'),
+				opens: { fileTypes: ['sticky'] }
 			}
 		],
 		aboutSpec: {


### PR DESCRIPTION
## Summary

- add a shared Finder/Desktop filesystem-open policy
- route non-app files and resolved document aliases through `os.openDocument(file)` / LaunchServices
- keep app-file launching and folder opening as explicit caller callbacks
- remove Finder/Desktop app-specific document-open branches

## Tests

- `pnpm test:unit src/lib/os/filesystem-open.test.ts src/lib/os/filesystem-open-usage.test.ts src/lib/os/window-host.test.ts src/lib/os/os-api.test.ts`
- `pnpm check`
- `pnpm test:unit -- --runInBand`
- `pnpm lint`
- `pnpm build`

Notes:

- The unit suite passes but still prints the existing Vitest delayed-shutdown warning after completion.
- `pnpm lint` passes with two existing unused `no-undef` disable warnings in `src/lib/channel-validation.test.ts` and `src/lib/episode-catalog.test.ts`.
