### PR TITLE
Add TerminalFS GC diagnostics UI

### DIFF
--- a/src/lib/components/BodyGcReportPanel.svelte
+++ b/src/lib/components/BodyGcReportPanel.svelte
@@ -1,0 +1,255 @@
+<script lang="ts">
+	import type { BodyGcReport, FsError } from '$lib/terminalos';
+	import {
+		bodyGcFailedBodyIds,
+		bodyGcReportRows,
+		bodyGcReportStatus,
+		type BodyGcReportStatus
+	} from './body-gc-report';
+
+	let {
+		report = null,
+		error = null,
+		running = false,
+		onrun
+	}: {
+		report?: BodyGcReport | null;
+		error?: FsError | null;
+		running?: boolean;
+		onrun?: () => void;
+	} = $props();
+
+	const idleStatus: BodyGcReportStatus = {
+		label: 'READY',
+		tone: 'idle',
+		detail: 'No scan report.'
+	};
+
+	const rows = $derived(report ? bodyGcReportRows(report) : []);
+	const failedBodyIds = $derived(report ? bodyGcFailedBodyIds(report) : []);
+	const status = $derived(error ? null : report ? bodyGcReportStatus(report) : idleStatus);
+</script>
+
+<section class="gc-report" aria-labelledby="body-gc-title">
+	<div class="gc-head">
+		<div class="gc-title-block">
+			<h3 id="body-gc-title">BODY GARBAGE COLLECTION</h3>
+			{#if status}
+				<div class="gc-status gc-status-{status.tone}" data-testid="body-gc-status">
+					<span>{status.label}</span>
+					<small>{status.detail}</small>
+				</div>
+			{:else if error}
+				<div class="gc-status gc-status-warn" data-testid="body-gc-status">
+					<span>SCAN FAILED</span>
+					<small>{error.code}</small>
+				</div>
+			{/if}
+		</div>
+		<button
+			class="btn primary gc-run"
+			type="button"
+			disabled={running}
+			aria-busy={running}
+			onclick={() => onrun?.()}
+		>
+			{running ? 'Scanning...' : 'Run GC'}
+		</button>
+	</div>
+
+	{#if error}
+		<div class="gc-error" data-testid="body-gc-error">
+			<div class="gc-error-label">error</div>
+			<p>{error.message}</p>
+		</div>
+	{:else if report}
+		<div class="gc-grid" data-testid="body-gc-report">
+			{#each rows as row (row.key)}
+				<div class="gc-metric" data-field={row.key}>
+					<div class="gc-metric-label">{row.label}</div>
+					<div class="gc-metric-value">{row.value.toLocaleString()}</div>
+				</div>
+			{/each}
+		</div>
+
+		<div class="gc-failed-list" data-field="failedBodyIds">
+			<div class="gc-list-label">failedBodyIds</div>
+			{#if failedBodyIds.length === 0}
+				<div class="gc-empty">none</div>
+			{:else}
+				<ul>
+					{#each failedBodyIds as bodyId (bodyId)}
+						<li>{bodyId}</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{:else}
+		<div class="gc-empty-state">Awaiting scan.</div>
+	{/if}
+</section>
+
+<style>
+	.gc-report {
+		display: flex;
+		flex-direction: column;
+		gap: 14px;
+		font-family: var(--brand-font-body, 'VT323', monospace);
+		font-size: 18px;
+		line-height: 1.25;
+	}
+
+	.gc-head {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 12px;
+		padding-bottom: 12px;
+		border-bottom: 2px solid var(--ink);
+	}
+
+	.gc-title-block {
+		min-width: 0;
+	}
+
+	h3 {
+		margin: 0 0 8px;
+		font-family: var(--brand-font-display, 'Press Start 2P', monospace);
+		font-size: 11px;
+		font-weight: normal;
+		line-height: 1.35;
+	}
+
+	.gc-status {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 8px;
+	}
+
+	.gc-status span {
+		font-family: var(--brand-font-display, 'Press Start 2P', monospace);
+		font-size: 8px;
+		letter-spacing: 0.05em;
+		padding: 4px 6px;
+		border: 2px solid var(--ink);
+		background: var(--paper-soft);
+	}
+
+	.gc-status small {
+		font-size: 15px;
+		opacity: 0.75;
+	}
+
+	.gc-status-ok span {
+		background: var(--accent-2);
+	}
+
+	.gc-status-warn span {
+		background: var(--accent);
+		color: var(--paper);
+	}
+
+	.gc-status-idle span {
+		background: var(--paper);
+	}
+
+	.gc-run {
+		flex-shrink: 0;
+		min-width: 92px;
+		text-align: center;
+	}
+
+	.gc-run:disabled {
+		opacity: 0.55;
+		cursor: progress;
+		transform: none;
+		box-shadow: 3px 3px 0 var(--ink);
+	}
+
+	.gc-grid {
+		display: grid;
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+		border: 2px solid var(--ink);
+	}
+
+	.gc-metric {
+		min-width: 0;
+		padding: 10px 8px;
+		border-right: 2px solid var(--ink);
+		background: var(--paper);
+	}
+
+	.gc-metric:last-child {
+		border-right: 0;
+	}
+
+	.gc-metric-label,
+	.gc-list-label,
+	.gc-error-label {
+		font-family: var(--brand-font-display, 'Press Start 2P', monospace);
+		font-size: 8px;
+		line-height: 1.4;
+		overflow-wrap: anywhere;
+	}
+
+	.gc-metric-value {
+		margin-top: 8px;
+		font-size: 26px;
+		line-height: 1;
+	}
+
+	.gc-failed-list,
+	.gc-error,
+	.gc-empty-state {
+		border: 2px solid var(--ink);
+		background: var(--paper);
+		padding: 10px;
+	}
+
+	.gc-failed-list ul {
+		margin: 8px 0 0;
+		padding-left: 18px;
+		max-height: 96px;
+		overflow: auto;
+		font-size: 16px;
+	}
+
+	.gc-failed-list li {
+		font-family: var(--brand-font-body, 'VT323', monospace);
+		word-break: break-all;
+	}
+
+	.gc-empty,
+	.gc-empty-state {
+		margin-top: 8px;
+		opacity: 0.7;
+	}
+
+	.gc-error p {
+		margin: 8px 0 0;
+	}
+
+	@media (max-width: 560px) {
+		.gc-head {
+			flex-direction: column;
+		}
+
+		.gc-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.gc-metric {
+			border-right: 0;
+			border-bottom: 2px solid var(--ink);
+		}
+
+		.gc-metric:nth-child(odd) {
+			border-right: 2px solid var(--ink);
+		}
+
+		.gc-metric:nth-last-child(-n + 1) {
+			border-bottom: 0;
+		}
+	}
+</style>

--- a/src/lib/components/MenuBar.svelte
+++ b/src/lib/components/MenuBar.svelte
@@ -62,6 +62,11 @@
 			shortcut: '⌘,',
 			action: (os) => os.openSystemPreferences()
 		},
+		{
+			type: 'action',
+			label: 'System Maintenance…',
+			action: (os) => os.openSystemMaintenance()
+		},
 		{ type: 'separator' },
 		{
 			type: 'action',

--- a/src/lib/components/SystemMaintenance.svelte
+++ b/src/lib/components/SystemMaintenance.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { getSystem } from '$lib/os/os-context';
+	import type { BodyGcReport, FsError } from '$lib/terminalos';
+	import BodyGcReportPanel from './BodyGcReportPanel.svelte';
+
+	const { os } = getSystem();
+
+	let report = $state<BodyGcReport | null>(null);
+	let error = $state<FsError | null>(null);
+	let running = $state(false);
+
+	async function runGarbageCollection(): Promise<void> {
+		if (running) return;
+
+		running = true;
+		error = null;
+
+		try {
+			const result = await os.collectFilesystemGarbage();
+			if (result.ok) {
+				report = result.value;
+			} else {
+				report = null;
+				error = result.error;
+			}
+		} catch (e) {
+			report = null;
+			error = {
+				code: 'corrupt_disk',
+				message: e instanceof Error ? e.message : 'Garbage collection failed unexpectedly.'
+			};
+		} finally {
+			running = false;
+		}
+	}
+</script>
+
+<div class="window-content maintenance-content">
+	<BodyGcReportPanel {report} {error} {running} onrun={runGarbageCollection} />
+</div>
+
+<style>
+	.window-content {
+		padding: 14px;
+	}
+
+	.maintenance-content {
+		height: 100%;
+		overflow: auto;
+	}
+</style>

--- a/src/lib/components/body-gc-report.test.ts
+++ b/src/lib/components/body-gc-report.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import type { BodyGcReport, FsError } from '$lib/terminalos';
+import BodyGcReportPanel from './BodyGcReportPanel.svelte';
+import { bodyGcFailedBodyIds, bodyGcReportRows, bodyGcReportStatus } from './body-gc-report';
+
+function renderPanel(props: {
+	report?: BodyGcReport | null;
+	error?: FsError | null;
+	running?: boolean;
+}): string {
+	return render(BodyGcReportPanel, { props }).body;
+}
+
+describe('body GC report formatting', () => {
+	it('maps every numeric BodyGcReport field to a display row', () => {
+		const report: BodyGcReport = {
+			stored: 7,
+			reachable: 4,
+			unreachable: 3,
+			deleted: 2,
+			failed: 1,
+			failedBodyIds: ['body_failed']
+		};
+
+		expect(bodyGcReportRows(report)).toEqual([
+			{ key: 'stored', label: 'stored', value: 7 },
+			{ key: 'reachable', label: 'reachable', value: 4 },
+			{ key: 'unreachable', label: 'unreachable', value: 3 },
+			{ key: 'deleted', label: 'deleted', value: 2 },
+			{ key: 'failed', label: 'failed', value: 1 }
+		]);
+		expect(bodyGcFailedBodyIds(report)).toEqual(['body_failed']);
+	});
+
+	it('summarizes success reports', () => {
+		expect(
+			bodyGcReportStatus({
+				stored: 4,
+				reachable: 4,
+				unreachable: 0,
+				deleted: 0,
+				failed: 0,
+				failedBodyIds: []
+			})
+		).toEqual({
+			label: 'CLEAN',
+			tone: 'ok',
+			detail: 'No unreachable body records.'
+		});
+	});
+
+	it('summarizes failed body deletions without treating the scan as missing', () => {
+		expect(
+			bodyGcReportStatus({
+				stored: 4,
+				reachable: 2,
+				unreachable: 2,
+				deleted: 1,
+				failed: 1,
+				failedBodyIds: ['body_failed']
+			})
+		).toEqual({
+			label: 'NEEDS ATTENTION',
+			tone: 'warn',
+			detail: '1 body failed deletion.'
+		});
+	});
+});
+
+describe('BodyGcReportPanel rendering', () => {
+	it('renders a successful report with every BodyGcReport field', () => {
+		const html = renderPanel({
+			report: {
+				stored: 12,
+				reachable: 10,
+				unreachable: 2,
+				deleted: 2,
+				failed: 0,
+				failedBodyIds: []
+			}
+		});
+
+		expect(html).toContain('RECLAIMED');
+		for (const label of ['stored', 'reachable', 'unreachable', 'deleted', 'failed']) {
+			expect(html).toContain(label);
+		}
+		for (const value of ['12', '10', '2', '0']) {
+			expect(html).toContain(value);
+		}
+		expect(html).toContain('failedBodyIds');
+		expect(html).toContain('none');
+	});
+
+	it('renders failed delete details with failed body ids', () => {
+		const html = renderPanel({
+			report: {
+				stored: 5,
+				reachable: 2,
+				unreachable: 3,
+				deleted: 1,
+				failed: 2,
+				failedBodyIds: ['body_alpha', 'body_beta']
+			}
+		});
+
+		expect(html).toContain('NEEDS ATTENTION');
+		expect(html).toContain('failedBodyIds');
+		expect(html).toContain('body_alpha');
+		expect(html).toContain('body_beta');
+	});
+
+	it('renders collectGarbage errors separately from report failures', () => {
+		const html = renderPanel({
+			error: {
+				code: 'corrupt_disk',
+				message: 'Failed to list blob bodies for garbage collection'
+			}
+		});
+
+		expect(html).toContain('SCAN FAILED');
+		expect(html).toContain('corrupt_disk');
+		expect(html).toContain('Failed to list blob bodies for garbage collection');
+	});
+});

--- a/src/lib/components/body-gc-report.ts
+++ b/src/lib/components/body-gc-report.ts
@@ -1,0 +1,61 @@
+import type { BodyGcReport, BodyId } from '$lib/terminalos';
+
+export type BodyGcReportRow = {
+	key: Exclude<keyof BodyGcReport, 'failedBodyIds'>;
+	label: string;
+	value: number;
+};
+
+export type BodyGcReportStatus = {
+	label: string;
+	tone: 'idle' | 'ok' | 'warn';
+	detail: string;
+};
+
+const BODY_GC_ROWS: Array<{ key: BodyGcReportRow['key']; label: string }> = [
+	{ key: 'stored', label: 'stored' },
+	{ key: 'reachable', label: 'reachable' },
+	{ key: 'unreachable', label: 'unreachable' },
+	{ key: 'deleted', label: 'deleted' },
+	{ key: 'failed', label: 'failed' }
+];
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+	return `${count.toLocaleString()} ${count === 1 ? singular : plural}`;
+}
+
+export function bodyGcReportRows(report: BodyGcReport): BodyGcReportRow[] {
+	return BODY_GC_ROWS.map(({ key, label }) => ({
+		key,
+		label,
+		value: report[key]
+	}));
+}
+
+export function bodyGcReportStatus(report: BodyGcReport): BodyGcReportStatus {
+	if (report.failed > 0) {
+		return {
+			label: 'NEEDS ATTENTION',
+			tone: 'warn',
+			detail: `${pluralize(report.failed, 'body')} failed deletion.`
+		};
+	}
+
+	if (report.deleted > 0) {
+		return {
+			label: 'RECLAIMED',
+			tone: 'ok',
+			detail: `${pluralize(report.deleted, 'body')} deleted.`
+		};
+	}
+
+	return {
+		label: 'CLEAN',
+		tone: 'ok',
+		detail: 'No unreachable body records.'
+	};
+}
+
+export function bodyGcFailedBodyIds(report: BodyGcReport): BodyId[] {
+	return [...report.failedBodyIds];
+}

--- a/src/lib/os/os-api.svelte.ts
+++ b/src/lib/os/os-api.svelte.ts
@@ -23,7 +23,7 @@ import {
 	matchWindow
 } from '$lib/terminalos/apps/app-catalog';
 import { resolveOpenTarget } from './window-host';
-import type { TerminalFS, FsFile } from '$lib/terminalos';
+import type { BodyGcReport, FsResult, TerminalFS, FsFile } from '$lib/terminalos';
 
 const RESTORE_RECOVERY_HINT =
 	'Your current disk should be unchanged. Try the restore again from the same backup file. If Terminal OS will not boot cleanly after a crash or tab kill, reinstall or clear Terminal OS site data, then restore from the backup file again.';
@@ -380,6 +380,10 @@ export class OsApiClass implements OsApi {
 		this.openWindow('terminal-prefs');
 	}
 
+	openSystemMaintenance(): void {
+		this.openWindow('system-maintenance');
+	}
+
 	openPreferences(appId: string): void {
 		// The prefs window-id comes straight from the app's manifest (prefs.id),
 		// or null when the app has no Preferences dialog.
@@ -449,6 +453,10 @@ export class OsApiClass implements OsApi {
 
 	async emptyTrash(): Promise<void> {
 		await this.fs.emptyTrash();
+	}
+
+	async collectFilesystemGarbage(): Promise<FsResult<BodyGcReport>> {
+		return this.fs.collectGarbage();
 	}
 
 	exportBackup(): void {

--- a/src/lib/os/os-api.test.ts
+++ b/src/lib/os/os-api.test.ts
@@ -260,6 +260,28 @@ describe('system actions', () => {
 		expect(spy).toHaveBeenCalledOnce();
 	});
 
+	it('collectFilesystemGarbage delegates to fs.collectGarbage', async () => {
+		const { os, fs } = createOs();
+		const report = {
+			stored: 3,
+			reachable: 1,
+			unreachable: 2,
+			deleted: 1,
+			failed: 1,
+			failedBodyIds: ['body_failed']
+		};
+		const spy = vi.spyOn(fs, 'collectGarbage').mockResolvedValue({
+			ok: true,
+			value: report
+		});
+
+		await expect(os.collectFilesystemGarbage()).resolves.toEqual({
+			ok: true,
+			value: report
+		});
+		expect(spy).toHaveBeenCalledOnce();
+	});
+
 	it('exportBackup collects preferences and passes them to fs', async () => {
 		const { os, fs } = createOs();
 		const spy = vi.spyOn(fs, 'exportBackup');
@@ -504,6 +526,7 @@ describe('isKnownWindowId', () => {
 			'welcome',
 			'about',
 			'terminal-prefs',
+			'system-maintenance',
 			'tv-guide',
 			'tvguide-prefs',
 			'chatrbot-prefs',
@@ -590,6 +613,12 @@ describe('navigation routing', () => {
 		const { os } = createOs();
 		os.openSystemPreferences();
 		expect(os.windows.some((w) => w.id === 'terminal-prefs')).toBe(true);
+	});
+
+	it('openSystemMaintenance opens system-maintenance window', () => {
+		const { os } = createOs();
+		os.openSystemMaintenance();
+		expect(os.windows.some((w) => w.id === 'system-maintenance')).toBe(true);
 	});
 
 	it('closeFocused closes the active window', () => {
@@ -716,6 +745,12 @@ describe('derived state', () => {
 	it('activeAppId returns system for System Preferences', () => {
 		const { os } = createOs();
 		os.openSystemPreferences();
+		expect(os.activeAppId).toBe('system');
+	});
+
+	it('activeAppId returns system for System Maintenance', () => {
+		const { os } = createOs();
+		os.openSystemMaintenance();
 		expect(os.activeAppId).toBe('system');
 	});
 
@@ -874,6 +909,7 @@ describe('windowAppId', () => {
 		expect(windowAppId('about:vcr')).toBe('system');
 		expect(windowAppId('about:chatrbot')).toBe('system');
 		expect(windowAppId('about:tvguide')).toBe('system');
+		expect(windowAppId('system-maintenance')).toBe('system');
 	});
 
 	it('falls back to finder for unknown IDs', () => {

--- a/src/lib/os/os-api.ts
+++ b/src/lib/os/os-api.ts
@@ -1,5 +1,5 @@
 import type { WindowState, TweaksState, GroupMeta } from '$lib/types';
-import type { FsFile } from '$lib/terminalos';
+import type { BodyGcReport, FsFile, FsResult } from '$lib/terminalos';
 import { synthWindowAppMap, synthWindowAppId } from '$lib/terminalos/apps/app-catalog';
 
 export interface AboutSection {
@@ -97,6 +97,7 @@ export interface OsApi {
 	openDocument: (file: FsFile) => void;
 
 	openSystemPreferences: () => void;
+	openSystemMaintenance: () => void;
 	openPreferences: (appId: string) => void;
 	openAbout: (appId: string | null) => void;
 
@@ -115,6 +116,7 @@ export interface OsApi {
 	startNewConversation: () => void;
 
 	emptyTrash: () => Promise<void>;
+	collectFilesystemGarbage: () => Promise<FsResult<BodyGcReport>>;
 	exportBackup: () => void;
 	restoreBackup: () => void;
 	reinstallOS: () => void;

--- a/src/lib/terminalos/apps/manifests.ts
+++ b/src/lib/terminalos/apps/manifests.ts
@@ -170,17 +170,17 @@ export const MANIFESTS = [
 	}),
 
 	// The system app owns the OS chrome dialogs — Welcome, About This Terminal,
-	// the per-app About boxes (about:<id>), and System Preferences. They render
-	// through the flat Window Host like any other window, and the menu bar reads
-	// this app's name ("Terminal") whenever one of them is focused. It folds away
-	// the old `system-prefs` + `about-terminal` pseudo-manifests. None of its
-	// windows declare `opens`, so the system app is not a document handler.
+	// the per-app About boxes (about:<id>), System Preferences, and maintenance.
+	// They render through the flat Window Host like any other window, and the menu
+	// bar reads this app's name ("Terminal") whenever one of them is focused. It
+	// folds away the old `system-prefs` + `about-terminal` pseudo-manifests. None
+	// of its windows declare `opens`, so the system app is not a document handler.
 	defineApp({
 		id: 'system',
 		name: 'Terminal',
 		fileName: 'Terminal',
 		category: 'system',
-		description: 'System chrome — About, Welcome, System Preferences',
+		description: 'System chrome — About, Welcome, System Preferences, Maintenance',
 		icon: ':)',
 		removable: false,
 		desktopAliasByDefault: false,
@@ -220,6 +220,13 @@ export const MANIFESTS = [
 				title: () => 'System Preferences',
 				size: () => ({ w: 380, h: 360 }),
 				component: () => import('$lib/components/TerminalPrefs.svelte')
+			},
+			{
+				match: { kind: 'exact', id: 'system-maintenance' },
+				role: 'chrome',
+				title: () => 'System Maintenance',
+				size: () => ({ w: 520, h: 460, minW: 460, minH: 390 }),
+				component: () => import('$lib/components/SystemMaintenance.svelte')
 			}
 		],
 		// A non-empty aboutSpec.title is what puts an app in APPS (the hasRegistryEntry


### PR DESCRIPTION
## Summary
- Add a Terminal-owned System Maintenance window for explicit TerminalFS garbage collection diagnostics.
- Route GC through OsApi.collectFilesystemGarbage(), delegating to TerminalFS.collectGarbage().
- Render BodyGcReport fields, including failedBodyIds, with focused formatter/rendering tests.

## Test plan
- pnpm exec vitest run src/lib/os/os-api.test.ts src/lib/components/body-gc-report.test.ts
- pnpm check
- pnpm test:unit -- --runInBand
- pnpm lint
- pnpm build
- Headless Playwright smoke test: open System Maintenance and run GC