### PR TITLE
Implement blob body replacement lifecycle

### DIFF
--- a/src/lib/terminalos/filesystem/backup.test.ts
+++ b/src/lib/terminalos/filesystem/backup.test.ts
@@ -121,16 +121,12 @@ describe('blob body round-trip', () => {
 	it('export captures blob bytes as base64 keyed by bodyId', async () => {
 		const fs = TerminalFS.createCleanDisk();
 		const bytes = new TextEncoder().encode('binary clip').buffer as ArrayBuffer;
-		const bodyId = 'body_test_1';
-		await fs.writeBody(bodyId, bytes);
-
-		// No public API to make a blob-backed file yet (later phase), so attach
-		// the ref directly to the live node.
-		const created = await fs.createFile(DOCUMENTS_ID, 'clip.webm', { fileType: 'recording' });
+		const created = await fs.createBlobFile(DOCUMENTS_ID, 'clip.webm', bytes, {
+			fileType: 'recording'
+		});
 		if (!created.ok) throw new Error('createFile failed');
-		const node = fs.getAllNodes().get(created.value.id);
-		if (!node || node.kind !== 'file') throw new Error('node missing');
-		node.bodyRef = { kind: 'indexeddb-blob', bodyId, size: bytes.byteLength };
+		const bodyId =
+			created.value.bodyRef?.kind === 'indexeddb-blob' ? created.value.bodyRef.bodyId : '';
 
 		const result = await fs.exportBackup();
 		expect(result.ok).toBe(true);
@@ -144,14 +140,12 @@ describe('blob body round-trip', () => {
 	it('round-trip restores blob bytes into a fresh disk', async () => {
 		const fs = TerminalFS.createCleanDisk();
 		const bytes = new TextEncoder().encode('binary clip').buffer as ArrayBuffer;
-		const bodyId = 'body_test_1';
-		await fs.writeBody(bodyId, bytes);
-
-		const created = await fs.createFile(DOCUMENTS_ID, 'clip.webm', { fileType: 'recording' });
+		const created = await fs.createBlobFile(DOCUMENTS_ID, 'clip.webm', bytes, {
+			fileType: 'recording'
+		});
 		if (!created.ok) throw new Error('createFile failed');
-		const node = fs.getAllNodes().get(created.value.id);
-		if (!node || node.kind !== 'file') throw new Error('node missing');
-		node.bodyRef = { kind: 'indexeddb-blob', bodyId, size: bytes.byteLength };
+		const bodyId =
+			created.value.bodyRef?.kind === 'indexeddb-blob' ? created.value.bodyRef.bodyId : '';
 
 		const exported = await fs.exportBackup();
 		if (!exported.ok) throw new Error('export failed');
@@ -203,10 +197,11 @@ describe('blob body round-trip', () => {
 	});
 
 	it('restoring an older v1/v2 backup clears pre-existing blob bodies', async () => {
-		const fs = TerminalFS.createCleanDisk();
+		const bodies = new InMemoryBodyStore();
+		const fs = TerminalFS.createCleanDisk(undefined, bodies);
 		// A blob written under the current (v3) world.
 		const bodyId = 'body_stale';
-		await fs.writeBody(bodyId, new TextEncoder().encode('stale clip').buffer as ArrayBuffer);
+		await bodies.write(bodyId, new TextEncoder().encode('stale clip').buffer as ArrayBuffer);
 		expect((await fs.readBody(bodyId)).ok).toBe(true);
 
 		// Restore a v2 backup — predates blobs, references none. Restore is a full
@@ -422,7 +417,7 @@ describe('restoreBackup', () => {
 		const bodies = new InMemoryBodyStore();
 		const fs = TerminalFS.createCleanDisk(manifest, bodies);
 		await fs.createTextFile(DOCUMENTS_ID, 'keep.txt', 'keep');
-		await fs.writeBody('body_keep', new TextEncoder().encode('old clip').buffer as ArrayBuffer);
+		await bodies.write('body_keep', new TextEncoder().encode('old clip').buffer as ArrayBuffer);
 
 		const source = TerminalFS.createCleanDisk();
 		const badFile = {

--- a/src/lib/terminalos/filesystem/body-gc.test.ts
+++ b/src/lib/terminalos/filesystem/body-gc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { TerminalFS, DOCUMENTS_ID, RECORDINGS_ID } from './terminal-fs';
-import { InMemoryBodyStore } from './storage/storage-types';
+import { InMemoryBodyStore, InMemoryManifestStore } from './storage/storage-types';
 import type { BodyId, FsFile } from './types';
 
 function blobBodyId(file: FsFile): BodyId {
@@ -8,6 +8,17 @@ function blobBodyId(file: FsFile): BodyId {
 		throw new Error(`Expected "${file.name}" to be blob-backed`);
 	}
 	return file.bodyRef.bodyId;
+}
+
+function bytes(text: string): ArrayBuffer {
+	return new TextEncoder().encode(text).buffer as ArrayBuffer;
+}
+
+async function expectBodyText(fs: TerminalFS, bodyId: BodyId, expected: string): Promise<void> {
+	const read = await fs.readBody(bodyId);
+	expect(read.ok).toBe(true);
+	if (!read.ok) return;
+	expect(new TextDecoder().decode(read.value)).toBe(expected);
 }
 
 async function createRecording(
@@ -36,7 +47,222 @@ class FailingDeleteBodyStore extends InMemoryBodyStore {
 	}
 }
 
+class FailingWriteBodyStore extends InMemoryBodyStore {
+	failWrites = false;
+
+	async write(bodyId: BodyId, data: ArrayBuffer) {
+		if (this.failWrites) {
+			return {
+				ok: false as const,
+				error: { code: 'quota_exceeded' as const, message: `No space for ${bodyId}` }
+			};
+		}
+		return super.write(bodyId, data);
+	}
+}
+
+class ObservableBodyStore extends InMemoryBodyStore {
+	readonly deleteCalls: BodyId[] = [];
+
+	async delete(bodyId: BodyId): Promise<void> {
+		this.deleteCalls.push(bodyId);
+		await super.delete(bodyId);
+	}
+}
+
+class FailingManifestStore extends InMemoryManifestStore {
+	failSaves = false;
+
+	async save(...args: Parameters<InMemoryManifestStore['save']>) {
+		if (this.failSaves) {
+			return {
+				ok: false as const,
+				error: { code: 'quota_exceeded' as const, message: 'Manifest quota exceeded' }
+			};
+		}
+		return super.save(...args);
+	}
+}
+
+class OrderedBodyStore extends InMemoryBodyStore {
+	constructor(private readonly events: string[]) {
+		super();
+	}
+
+	async write(bodyId: BodyId, data: ArrayBuffer) {
+		this.events.push(`write:${bodyId}`);
+		return super.write(bodyId, data);
+	}
+
+	async listBodyIds() {
+		this.events.push('listBodyIds');
+		return super.listBodyIds();
+	}
+
+	async delete(bodyId: BodyId): Promise<void> {
+		this.events.push(`delete:${bodyId}`);
+		await super.delete(bodyId);
+	}
+}
+
+class OrderedManifestStore extends InMemoryManifestStore {
+	constructor(private readonly events: string[]) {
+		super();
+	}
+
+	async save(...args: Parameters<InMemoryManifestStore['save']>) {
+		this.events.push('saveManifest');
+		return super.save(...args);
+	}
+}
+
 describe('blob body garbage collection', () => {
+	it('replaces a blob-backed file by writing a new body before committing the manifest', async () => {
+		const events: string[] = [];
+		const manifest = new OrderedManifestStore(events);
+		const bodies = new OrderedBodyStore(events);
+		const fs = TerminalFS.createCleanDisk(manifest, bodies);
+		const file = await createRecording(fs, 'Replace.webm', bytes('old'));
+		const oldBodyId = blobBodyId(file);
+		events.length = 0;
+
+		const result = await fs.replaceBlobFileBody(file.id, bytes('new'), {
+			contentType: 'video/mp4'
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+
+		const newBodyId = blobBodyId(result.value);
+		expect(newBodyId).not.toBe(oldBodyId);
+		expect(result.value.bodyRef).toMatchObject({
+			kind: 'indexeddb-blob',
+			bodyId: newBodyId,
+			size: 3,
+			contentType: 'video/mp4'
+		});
+		await expectBodyText(fs, newBodyId, 'new');
+
+		const writeIndex = events.findIndex((event) => event.startsWith(`write:${newBodyId}`));
+		const saveIndex = events.indexOf('saveManifest');
+		const scanIndex = events.indexOf('listBodyIds');
+		const deleteIndex = events.indexOf(`delete:${oldBodyId}`);
+		expect(writeIndex).toBeGreaterThanOrEqual(0);
+		expect(saveIndex).toBeGreaterThan(writeIndex);
+		expect(scanIndex).toBeGreaterThan(saveIndex);
+		expect(deleteIndex).toBeGreaterThan(scanIndex);
+
+		const oldBody = await fs.readBody(oldBodyId);
+		expect(oldBody.ok).toBe(false);
+	});
+
+	it('leaves the manifest unchanged when replacement body writing fails', async () => {
+		const bodies = new FailingWriteBodyStore();
+		const fs = TerminalFS.createCleanDisk(undefined, bodies);
+		const file = await createRecording(fs, 'Body-write-fails.webm', bytes('old'));
+		const oldBodyId = blobBodyId(file);
+
+		bodies.failWrites = true;
+		const result = await fs.replaceBlobFileBody(file.id, bytes('new'));
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe('quota_exceeded');
+		}
+
+		const current = await fs.getNode(file.id);
+		expect(current.ok).toBe(true);
+		if (!current.ok || current.value.kind !== 'file') return;
+		expect(blobBodyId(current.value)).toBe(oldBodyId);
+		await expectBodyText(fs, oldBodyId, 'old');
+		expect(await bodies.listBodyIds()).toEqual([oldBodyId]);
+	});
+
+	it('rolls the in-memory file back and skips GC when replacement manifest commit fails', async () => {
+		const manifest = new FailingManifestStore();
+		const bodies = new ObservableBodyStore();
+		const fs = TerminalFS.createCleanDisk(manifest, bodies);
+		const file = await createRecording(fs, 'Manifest-fails.webm', bytes('old'));
+		const oldBodyId = blobBodyId(file);
+
+		manifest.failSaves = true;
+		const result = await fs.replaceBlobFileBody(file.id, bytes('new'));
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error.code).toBe('quota_exceeded');
+		}
+
+		const current = await fs.getNode(file.id);
+		expect(current.ok).toBe(true);
+		if (!current.ok || current.value.kind !== 'file') return;
+		expect(blobBodyId(current.value)).toBe(oldBodyId);
+		await expectBodyText(fs, oldBodyId, 'old');
+		expect(bodies.deleteCalls).toEqual([]);
+		expect((await bodies.listBodyIds()).length).toBe(2);
+
+		manifest.failSaves = false;
+		const reopened = await TerminalFS.open(manifest, bodies);
+		const persisted = await reopened.getNode(file.id);
+		expect(persisted.ok).toBe(true);
+		if (persisted.ok && persisted.value.kind === 'file') {
+			expect(blobBodyId(persisted.value)).toBe(oldBodyId);
+		}
+	});
+
+	it('uses copy-on-write when replacing one file that shares a body with a duplicate', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const original = await createRecording(fs, 'Shared-replace.webm', bytes('old'));
+		const oldBodyId = blobBodyId(original);
+		const duplicate = await fs.duplicate(original.id);
+		expect(duplicate.ok).toBe(true);
+		if (!duplicate.ok || duplicate.value.kind !== 'file') return;
+		expect(blobBodyId(duplicate.value)).toBe(oldBodyId);
+
+		const replaced = await fs.replaceBlobFileBody(original.id, bytes('new'));
+		expect(replaced.ok).toBe(true);
+		if (!replaced.ok) return;
+
+		const newBodyId = blobBodyId(replaced.value);
+		expect(newBodyId).not.toBe(oldBodyId);
+		await expectBodyText(fs, newBodyId, 'new');
+		await expectBodyText(fs, oldBodyId, 'old');
+
+		const duplicateAfterReplace = await fs.getNode(duplicate.value.id);
+		expect(duplicateAfterReplace.ok).toBe(true);
+		if (duplicateAfterReplace.ok && duplicateAfterReplace.value.kind === 'file') {
+			expect(blobBodyId(duplicateAfterReplace.value)).toBe(oldBodyId);
+		}
+	});
+
+	it('retains an old replaced body while pending undo can restore it', async () => {
+		const fs = TerminalFS.createCleanDisk();
+		const original = await createRecording(fs, 'Undo-retained-replace.webm', bytes('old'));
+		const oldBodyId = blobBodyId(original);
+		const duplicate = await fs.duplicate(original.id);
+		expect(duplicate.ok).toBe(true);
+		if (!duplicate.ok || duplicate.value.kind !== 'file') return;
+
+		const deleted = await fs.deleteNode(duplicate.value.id);
+		expect(deleted.ok).toBe(true);
+
+		const replaced = await fs.replaceBlobFileBody(original.id, bytes('new'));
+		expect(replaced.ok).toBe(true);
+		if (!replaced.ok) return;
+		await expectBodyText(fs, blobBodyId(replaced.value), 'new');
+
+		await expectBodyText(fs, oldBodyId, 'old');
+
+		const replacementUndo = await fs.createFolder(DOCUMENTS_ID, 'Clear replacement undo');
+		expect(replacementUndo.ok).toBe(true);
+
+		const collected = await fs.readBody(oldBodyId);
+		expect(collected.ok).toBe(false);
+		if (!collected.ok) {
+			expect(collected.error.code).toBe('not_found');
+		}
+	});
+
 	it('duplicates blob-backed files by sharing the same body id', async () => {
 		const fs = TerminalFS.createCleanDisk();
 		const original = await createRecording(fs, 'Shared.webm');

--- a/src/lib/terminalos/filesystem/storage/storage-types.ts
+++ b/src/lib/terminalos/filesystem/storage/storage-types.ts
@@ -28,7 +28,7 @@ export class InMemoryManifestStore implements ManifestStore {
 	async load() {
 		return this.data;
 	}
-	async save(volume: TerminalVolume, nodes: FsNode[]) {
+	async save(volume: TerminalVolume, nodes: FsNode[]): Promise<FsResult<void>> {
 		this.data = { volume, nodes };
 		return { ok: true as const, value: undefined };
 	}
@@ -43,7 +43,7 @@ export class InMemoryBodyStore implements BodyStore {
 	async read(bodyId: BodyId) {
 		return this.bodies.get(bodyId) ?? null;
 	}
-	async write(bodyId: BodyId, data: ArrayBuffer) {
+	async write(bodyId: BodyId, data: ArrayBuffer): Promise<FsResult<void>> {
 		this.bodies.set(bodyId, data);
 		return { ok: true as const, value: undefined };
 	}

--- a/src/lib/terminalos/filesystem/storage/storage.test.ts
+++ b/src/lib/terminalos/filesystem/storage/storage.test.ts
@@ -105,7 +105,7 @@ describe('body store', () => {
 		const fs = TerminalFS.createCleanDisk(undefined, bodies);
 
 		const data = new TextEncoder().encode('Hello World').buffer;
-		const writeResult = await fs.writeBody('body-1', data);
+		const writeResult = await bodies.write('body-1', data);
 		expect(writeResult.ok).toBe(true);
 
 		const readResult = await fs.readBody('body-1');

--- a/src/lib/terminalos/filesystem/terminal-fs.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.ts
@@ -915,6 +915,50 @@ export class TerminalFS {
 		return ok(file);
 	}
 
+	async replaceBlobFileBody(
+		fileId: NodeId,
+		data: ArrayBuffer,
+		opts: { contentType?: string | null } = {}
+	): Promise<FsResult<FsFile>> {
+		const node = this.nodes.get(fileId);
+		if (!node) return fail('not_found', `Node "${fileId}" not found`);
+		if (node.kind !== 'file') return fail('not_found', `Node "${fileId}" is not a file`);
+
+		const previousBodyRef = node.bodyRef;
+		const bodyId: BodyId = `body_${generateUniqueId()}`;
+
+		// Write the new immutable body before the manifest points at it.
+		const writeResult = await this.bodies.write(bodyId, data);
+		if (!writeResult.ok) return writeResult as FsResult<FsFile>;
+
+		const preservedContentType =
+			previousBodyRef?.kind === 'indexeddb-blob' ? previousBodyRef.contentType : undefined;
+		const contentType = opts.contentType === undefined ? preservedContentType : opts.contentType;
+		const bodyRef: BodyRef = {
+			kind: 'indexeddb-blob',
+			bodyId,
+			size: data.byteLength,
+			...(contentType != null ? { contentType } : {})
+		};
+		const updated: FsFile = {
+			...node,
+			bodyRef,
+			updatedAt: Date.now()
+		};
+		this.nodes.set(fileId, updated);
+
+		const shouldCollectGarbage = previousBodyRef?.kind === 'indexeddb-blob';
+		const persistResult = await this.debouncedPersist();
+		if (!persistResult.ok) {
+			this.nodes.set(fileId, node);
+			return persistResult as FsResult<FsFile>;
+		}
+		await this.collectGarbageAfterCommit(shouldCollectGarbage);
+
+		this.notifyChange([fileId], [node.parentId], 'write');
+		return ok(updated);
+	}
+
 	async writeText(fileId: NodeId, text: string): Promise<FsResult<FsFile>> {
 		const node = this.nodes.get(fileId);
 		if (!node) return fail('not_found', `Node "${fileId}" not found`);
@@ -1532,10 +1576,6 @@ export class TerminalFS {
 		const data = await this.bodies.read(bodyId);
 		if (!data) return fail('not_found', `Body "${bodyId}" not found`);
 		return ok(data);
-	}
-
-	async writeBody(bodyId: BodyId, data: ArrayBuffer): Promise<FsResult<void>> {
-		return this.bodies.write(bodyId, data);
 	}
 
 	// --- Disk usage ---


### PR DESCRIPTION
Summary:
- Add TerminalFS.replaceBlobFileBody for immutable copy-on-write blob replacement.
- Remove raw TerminalFS.writeBody usage from tests and keep direct body writes limited to injected BodyStore setup.
- Cover success ordering, body write failure, manifest failure, shared-body copy-on-write, undo retention, and post-commit GC.

Verification:
- pnpm test:unit src/lib/terminalos/filesystem/body-gc.test.ts -- --runInBand
- pnpm test:unit src/lib/terminalos/filesystem/backup.test.ts src/lib/terminalos/filesystem/storage/storage.test.ts -- --runInBand
- pnpm check
- pnpm test:unit -- --runInBand
- pnpm lint
- pnpm build

Notes:
- Vitest still prints the known delayed-shutdown warning after successful test exits.
- No production app call sites currently replace blob bodies; no non-test raw body mutation remains.