### PR TITLE
Make TerminalFS manifest failures command-atomic

### DIFF
--- a/src/lib/channel-validation.test.ts
+++ b/src/lib/channel-validation.test.ts
@@ -3,7 +3,6 @@ import { readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import type { Channel, ChannelSlot } from './types';
 
-/* eslint-disable no-undef */
 const CHANNELS_DIR = join(process.cwd(), 'channels');
 const BOTS_DIR = join(process.cwd(), 'bots');
 

--- a/src/lib/episode-catalog.test.ts
+++ b/src/lib/episode-catalog.test.ts
@@ -17,7 +17,7 @@ interface Meta {
 }
 
 function loadAllMetas(): Meta[] {
-	const botsDir = resolve(process.cwd(), 'bots'); // eslint-disable-line no-undef
+	const botsDir = resolve(process.cwd(), 'bots');
 	const dirs = readdirSync(botsDir).filter((d) => statSync(join(botsDir, d)).isDirectory());
 	return dirs.map((d) => JSON.parse(readFileSync(join(botsDir, d, '_meta.json'), 'utf-8')));
 }

--- a/src/lib/terminalos/filesystem/command-atomicity.test.ts
+++ b/src/lib/terminalos/filesystem/command-atomicity.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect } from 'vitest';
+import { TerminalFS, APPDATA_ID, DESKTOP_ID, DOCUMENTS_ID, RECORDINGS_ID } from './terminal-fs';
+import { InMemoryBodyStore, InMemoryManifestStore } from './storage/storage-types';
+import type { FsAlias, FsFile, FsNode, FsResult, NodeId, TerminalVolume } from './types';
+
+class FailingManifestStore extends InMemoryManifestStore {
+	failSaves = false;
+
+	async save(volume: TerminalVolume, nodes: FsNode[]): Promise<FsResult<void>> {
+		if (this.failSaves) {
+			return {
+				ok: false,
+				error: { code: 'quota_exceeded', message: 'Manifest save failed' }
+			};
+		}
+		return super.save(volume, nodes);
+	}
+}
+
+function bytes(text: string): ArrayBuffer {
+	return new TextEncoder().encode(text).buffer as ArrayBuffer;
+}
+
+function expectPersistenceFailure(result: FsResult<unknown>): void {
+	expect(result.ok).toBe(false);
+	if (!result.ok) {
+		expect(result.error.code).toBe('quota_exceeded');
+	}
+}
+
+function nodesById(nodes: Iterable<FsNode>): Map<NodeId, FsNode> {
+	return new Map(Array.from(nodes, (node) => [node.id, node]));
+}
+
+async function expectInMemoryMatchesManifest(
+	fs: TerminalFS,
+	manifest: InMemoryManifestStore
+): Promise<void> {
+	const loaded = await manifest.load();
+	expect(loaded).not.toBeNull();
+	if (!loaded) return;
+
+	expect(fs.getVolume()).toEqual(loaded.volume);
+	expect(nodesById(fs.getAllNodes().values())).toEqual(nodesById(loaded.nodes));
+}
+
+async function getCreatedFile(result: Promise<FsResult<FsFile>>): Promise<FsFile> {
+	const created = await result;
+	expect(created.ok).toBe(true);
+	if (!created.ok) throw new Error(created.error.message);
+	return created.value;
+}
+
+async function getCreatedAlias(result: Promise<FsResult<FsAlias>>): Promise<FsAlias> {
+	const created = await result;
+	expect(created.ok).toBe(true);
+	if (!created.ok) throw new Error(created.error.message);
+	return created.value;
+}
+
+type AtomicityScenario = {
+	name: string;
+	prepare: (fs: TerminalFS) => Promise<() => Promise<FsResult<unknown>>>;
+};
+
+async function runFailedSaveScenario(scenario: AtomicityScenario): Promise<void> {
+	const manifest = new FailingManifestStore();
+	const bodies = new InMemoryBodyStore();
+	const fs = await TerminalFS.open(manifest, bodies);
+	const action = await scenario.prepare(fs);
+
+	await expectInMemoryMatchesManifest(fs, manifest);
+
+	manifest.failSaves = true;
+	const result = await action();
+
+	expectPersistenceFailure(result);
+	await expectInMemoryMatchesManifest(fs, manifest);
+}
+
+const rollbackScenarios: AtomicityScenario[] = [
+	{
+		name: 'createFolder',
+		prepare: async (fs) => async () => fs.createFolder(DOCUMENTS_ID, 'Failed folder')
+	},
+	{
+		name: 'getAppDataFolder',
+		prepare: async (fs) => async () => fs.getAppDataFolder('chatrbot')
+	},
+	{
+		name: 'createTextFile',
+		prepare: async (fs) => async () => fs.createTextFile(DOCUMENTS_ID, 'Failed.txt', 'draft')
+	},
+	{
+		name: 'createFile',
+		prepare: async (fs) => async () =>
+			fs.createFile(DOCUMENTS_ID, 'Failed.sticky', {
+				appId: 'stickies',
+				fileType: 'sticky',
+				text: '{}'
+			})
+	},
+	{
+		name: 'createBlobFile',
+		prepare: async (fs) => async () =>
+			fs.createBlobFile(RECORDINGS_ID, 'Failed.webm', bytes('new'), {
+				appId: 'recorder',
+				fileType: 'recording'
+			})
+	},
+	{
+		name: 'replaceBlobFileBody',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(
+				fs.createBlobFile(RECORDINGS_ID, 'Replace.webm', bytes('old'), {
+					appId: 'recorder',
+					fileType: 'recording'
+				})
+			);
+			return async () => fs.replaceBlobFileBody(file.id, bytes('new'));
+		}
+	},
+	{
+		name: 'writeText',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Draft.txt', 'v1'));
+			return async () => fs.writeText(file.id, 'v2');
+		}
+	},
+	{
+		name: 'rename',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Before.txt', 'text'));
+			return async () => fs.rename(file.id, 'After.txt');
+		}
+	},
+	{
+		name: 'move',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Move.txt', 'text'));
+			return async () => fs.move(file.id, DESKTOP_ID);
+		}
+	},
+	{
+		name: 'duplicate',
+		prepare: async (fs) => {
+			const folder = await fs.createFolder(DOCUMENTS_ID, 'Copy source');
+			expect(folder.ok).toBe(true);
+			if (!folder.ok) throw new Error(folder.error.message);
+			await getCreatedFile(fs.createTextFile(folder.value.id, 'child.txt', 'text'));
+			return async () => fs.duplicate(folder.value.id);
+		}
+	},
+	{
+		name: 'trash',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Trash me.txt', 'text'));
+			return async () => fs.trash(file.id);
+		}
+	},
+	{
+		name: 'emptyTrash',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Empty me.txt', 'text'));
+			const trashed = await fs.trash(file.id);
+			expect(trashed.ok).toBe(true);
+			return async () => fs.emptyTrash();
+		}
+	},
+	{
+		name: 'createAlias',
+		prepare: async (fs) => {
+			const target = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Target.txt', 'text'));
+			return async () => fs.createAlias(DESKTOP_ID, target.id, 'Target alias');
+		}
+	},
+	{
+		name: 'resolveAlias repair',
+		prepare: async (fs) => {
+			const firstTarget = await getCreatedFile(
+				fs.createTextFile(DOCUMENTS_ID, 'Repair target.txt', 'old')
+			);
+			const alias = await getCreatedAlias(fs.createAlias(DESKTOP_ID, firstTarget.id));
+			const deleted = await fs.deleteNode(firstTarget.id);
+			expect(deleted.ok).toBe(true);
+			await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Repair target.txt', 'new'));
+			return async () => fs.resolveAlias(alias.id);
+		}
+	},
+	{
+		name: 'undoLast',
+		prepare: async (fs) => {
+			const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Undo move.txt', 'text'));
+			const moved = await fs.move(file.id, DESKTOP_ID);
+			expect(moved.ok).toBe(true);
+			return async () => fs.undoLast();
+		}
+	},
+	{
+		name: 'installApp',
+		prepare: async (fs) => async () => fs.installApp('tvguide')
+	},
+	{
+		name: 'uninstallApp',
+		prepare: async (fs) => {
+			const installed = await fs.installApp('tvguide');
+			expect(installed.ok).toBe(true);
+			return async () => fs.uninstallApp('tvguide');
+		}
+	},
+	{
+		name: 'buyApp',
+		prepare: async (fs) => async () => fs.buyApp('tvguide')
+	},
+	{
+		name: 'returnApp',
+		prepare: async (fs) => {
+			const bought = await fs.buyApp('tvguide');
+			expect(bought.ok).toBe(true);
+			return async () => fs.returnApp('tvguide');
+		}
+	},
+	{
+		name: 'restoreBackup',
+		prepare: async (fs) => {
+			const source = TerminalFS.createCleanDisk();
+			await getCreatedFile(source.createTextFile(DOCUMENTS_ID, 'Restored.txt', 'backup'));
+			const backup = await source.exportBackup();
+			expect(backup.ok).toBe(true);
+			if (!backup.ok) throw new Error(backup.error.message);
+
+			await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Keep.txt', 'current'));
+			return async () => fs.restoreBackup(backup.value);
+		}
+	},
+	{
+		name: 'reinstallOS',
+		prepare: async (fs) => {
+			await getCreatedFile(
+				fs.createTextFile(DOCUMENTS_ID, 'Keep after failed reinstall.txt', 'text')
+			);
+			const bought = await fs.buyApp('tvguide');
+			expect(bought.ok).toBe(true);
+			return async () => fs.reinstallOS();
+		}
+	},
+	{
+		name: 'deleteNode',
+		prepare: async (fs) => {
+			const folder = await fs.createFolder(DOCUMENTS_ID, 'Delete folder');
+			expect(folder.ok).toBe(true);
+			if (!folder.ok) throw new Error(folder.error.message);
+			await getCreatedFile(fs.createTextFile(folder.value.id, 'child.txt', 'text'));
+			return async () => fs.deleteNode(folder.value.id);
+		}
+	}
+];
+
+describe('TerminalFS command atomicity', () => {
+	for (const scenario of rollbackScenarios) {
+		it(`rolls back in-memory state when ${scenario.name} manifest persistence fails`, async () => {
+			await runFailedSaveScenario(scenario);
+		});
+	}
+
+	it('rolls back AppData container self-heal when manifest persistence fails', async () => {
+		const manifest = new FailingManifestStore();
+		await TerminalFS.open(manifest);
+		const loaded = await manifest.load();
+		expect(loaded).not.toBeNull();
+		if (!loaded) return;
+
+		await manifest.save(
+			loaded.volume,
+			loaded.nodes.filter((node) => node.id !== APPDATA_ID)
+		);
+		const oldDisk = await TerminalFS.open(manifest);
+		expect(oldDisk.getAllNodes().has(APPDATA_ID)).toBe(false);
+
+		manifest.failSaves = true;
+		const result = await oldDisk.getAppDataFolder('chatrbot');
+
+		expectPersistenceFailure(result);
+		expect(oldDisk.getAllNodes().has(APPDATA_ID)).toBe(false);
+		await expectInMemoryMatchesManifest(oldDisk, manifest);
+	});
+
+	it('preserves the previous undo record when a replacement undo command fails', async () => {
+		const manifest = new FailingManifestStore();
+		const fs = await TerminalFS.open(manifest);
+		const target = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Rename target.txt', 'x'));
+		const undoAnchor = await fs.createFolder(DOCUMENTS_ID, 'Undo anchor');
+		expect(undoAnchor.ok).toBe(true);
+
+		manifest.failSaves = true;
+		const result = await fs.rename(target.id, 'Renamed.txt');
+
+		expectPersistenceFailure(result);
+		const undoLabel = await fs.getUndoLabel();
+		expect(undoLabel.ok).toBe(true);
+		if (undoLabel.ok) {
+			expect(undoLabel.value).toBe('Create folder "Undo anchor"');
+		}
+	});
+
+	it('preserves undo when a destructive clear-undo command fails', async () => {
+		const manifest = new FailingManifestStore();
+		const fs = await TerminalFS.open(manifest);
+		const file = await getCreatedFile(fs.createTextFile(DOCUMENTS_ID, 'Undoable trash.txt', 'x'));
+		const trashed = await fs.trash(file.id);
+		expect(trashed.ok).toBe(true);
+
+		manifest.failSaves = true;
+		const result = await fs.emptyTrash();
+
+		expectPersistenceFailure(result);
+		const undoLabel = await fs.getUndoLabel();
+		expect(undoLabel.ok).toBe(true);
+		if (undoLabel.ok) {
+			expect(undoLabel.value).toBe('Trash "Undoable trash.txt"');
+		}
+	});
+});

--- a/src/lib/terminalos/filesystem/terminal-fs.ts
+++ b/src/lib/terminalos/filesystem/terminal-fs.ts
@@ -58,6 +58,12 @@ import {
 
 const VOLUME_ID = 'volume_terminal_hd';
 
+type TerminalFsSnapshot = {
+	volume: TerminalVolume;
+	nodes: Map<NodeId, FsNode>;
+	lastUndo: UndoRecord | null;
+};
+
 class InvalidBackupBodyError extends Error {
 	constructor(
 		readonly bodyId: BodyId,
@@ -257,6 +263,25 @@ export class TerminalFS {
 	private async persist(): Promise<FsResult<void>> {
 		const nodes = Array.from(this.nodes.values());
 		return this.manifest.save(this.volume, nodes);
+	}
+
+	private cloneVolume(volume: TerminalVolume): TerminalVolume {
+		if (volume.ownedApps === undefined) return { ...volume };
+		return { ...volume, ownedApps: [...volume.ownedApps] };
+	}
+
+	private snapshotState(): TerminalFsSnapshot {
+		return {
+			volume: this.cloneVolume(this.volume),
+			nodes: new Map(this.nodes),
+			lastUndo: this.lastUndo
+		};
+	}
+
+	private restoreState(snapshot: TerminalFsSnapshot): void {
+		this.volume = this.cloneVolume(snapshot.volume);
+		this.nodes = new Map(snapshot.nodes);
+		this.lastUndo = snapshot.lastUndo;
 	}
 
 	private setLastUndo(record: UndoRecord): boolean {
@@ -699,9 +724,9 @@ export class TerminalFS {
 			createdAt: now,
 			updatedAt: now
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, folder);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'create_folder',
 			label: `Create folder "${name}"`,
@@ -710,7 +735,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsFolder>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -733,6 +758,7 @@ export class TerminalFS {
 	 */
 	async getAppDataFolder(appId: PersistedAppId): Promise<FsResult<NodeId>> {
 		let created = false;
+		const snapshot = this.snapshotState();
 
 		// Ensure the /System/AppData container exists (seeded on clean disks,
 		// recreated here for older disks).
@@ -758,7 +784,13 @@ export class TerminalFS {
 		// Find this app's folder by name within the container.
 		for (const n of this.nodes.values()) {
 			if (n.parentId === APPDATA_ID && n.kind === 'folder' && n.name === appId) {
-				if (created) await this.debouncedPersist();
+				if (created) {
+					const persistResult = await this.debouncedPersist();
+					if (!persistResult.ok) {
+						this.restoreState(snapshot);
+						return persistResult as FsResult<NodeId>;
+					}
+				}
 				return ok(n.id);
 			}
 		}
@@ -778,7 +810,10 @@ export class TerminalFS {
 		this.nodes.set(folderId, folder);
 
 		const persistResult = await this.debouncedPersist();
-		if (!persistResult.ok) return persistResult as FsResult<NodeId>;
+		if (!persistResult.ok) {
+			this.restoreState(snapshot);
+			return persistResult as FsResult<NodeId>;
+		}
 
 		this.notifyChange([folderId], [APPDATA_ID], 'create_folder');
 		return ok(folderId);
@@ -807,9 +842,9 @@ export class TerminalFS {
 			createdAt: now,
 			updatedAt: now
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, file);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'create_file',
 			label: `Create file "${name}"`,
@@ -818,8 +853,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.nodes.delete(nodeId);
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsFile>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -856,9 +890,9 @@ export class TerminalFS {
 			createdAt: now,
 			updatedAt: now
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, file);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'create_file',
 			label: `Create file "${name}"`,
@@ -867,8 +901,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.nodes.delete(nodeId);
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsFile>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -922,9 +955,9 @@ export class TerminalFS {
 			createdAt: now,
 			updatedAt: now
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, file);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'create_file',
 			label: `Create file "${name}"`,
@@ -933,8 +966,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.nodes.delete(nodeId);
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsFile>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -973,12 +1005,13 @@ export class TerminalFS {
 			bodyRef,
 			updatedAt: Date.now()
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(fileId, updated);
 
 		const shouldCollectGarbage = previousBodyRef?.kind === 'indexeddb-blob';
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.nodes.set(fileId, node);
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsFile>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -998,12 +1031,13 @@ export class TerminalFS {
 			bodyRef: { kind: 'inline-text', text },
 			updatedAt: Date.now()
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(fileId, updated);
 
 		// No undo for writes — text editors handle their own undo
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.nodes.set(fileId, node);
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsFile>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1035,9 +1069,9 @@ export class TerminalFS {
 
 		const previousName = node.name;
 		const updated: FsNode = { ...node, name: newName, updatedAt: Date.now() };
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, updated);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'rename',
 			label: `Rename "${previousName}" to "${newName}"`,
@@ -1046,7 +1080,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsNode>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1092,9 +1126,9 @@ export class TerminalFS {
 			parentId: targetFolderId,
 			updatedAt: Date.now()
 		} as FsNode;
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, updated);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'move',
 			label: `Move "${node.name}"`,
@@ -1103,7 +1137,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsNode>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1133,13 +1167,13 @@ export class TerminalFS {
 		(topNode as FsNode & { name: string }).name = copyName;
 
 		// Add all new nodes to the map
+		const snapshot = this.snapshotState();
 		const newIds: NodeId[] = [];
 		for (const n of newNodes) {
 			this.nodes.set(n.id, n);
 			newIds.push(n.id);
 		}
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'duplicate',
 			label: `Duplicate "${node.name}"`,
@@ -1148,7 +1182,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsNode>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1179,9 +1213,9 @@ export class TerminalFS {
 			parentId: TRASH_ID,
 			updatedAt: Date.now()
 		} as FsNode;
+		const snapshot = this.snapshotState();
 		this.nodes.set(nodeId, updated);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'trash',
 			label: `Trash "${node.name}"`,
@@ -1190,7 +1224,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsNode>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1208,12 +1242,12 @@ export class TerminalFS {
 			}
 		}
 
+		const snapshot = this.snapshotState();
 		for (const id of trashChildren) {
 			this.nodes.delete(id);
 		}
 
 		// Clear undo — emptyTrash is destructive and irreversible.
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage =
 			trashChildren.length > 0 || this.undoRecordRetainsBlobBodies(this.lastUndo);
 		this.lastUndo = null;
@@ -1221,7 +1255,7 @@ export class TerminalFS {
 		await this.flushPersist();
 		const persistResult = await this.persist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<{ deletedCount: number }>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1273,9 +1307,9 @@ export class TerminalFS {
 			createdAt: now,
 			updatedAt: now
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(aliasId, alias);
 
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.setLastUndo({
 			kind: 'create_alias',
 			label: `Create alias "${aliasName}"`,
@@ -1284,7 +1318,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<FsAlias>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1305,8 +1339,13 @@ export class TerminalFS {
 				return ok(result.node);
 			case 'repaired': {
 				// Apply the repair — update the alias in the node map
+				const snapshot = this.snapshotState();
 				this.nodes.set(aliasId, result.alias);
-				await this.debouncedPersist();
+				const persistResult = await this.debouncedPersist();
+				if (!persistResult.ok) {
+					this.restoreState(snapshot);
+					return persistResult as FsResult<FsNode>;
+				}
 				this.notifyChange([aliasId], [], 'repair_alias');
 				return ok(result.node);
 			}
@@ -1320,7 +1359,7 @@ export class TerminalFS {
 		if (!undo) return fail('not_found', 'Nothing to undo');
 
 		const { undoData, label } = undo;
-		const previousUndo = this.lastUndo;
+		const snapshot = this.snapshotState();
 		const affectedNodeIds: NodeId[] = [];
 		const affectedFolderIds: NodeId[] = [];
 
@@ -1387,7 +1426,7 @@ export class TerminalFS {
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<string>;
 		}
 		await this.collectGarbageAfterCommit(true);
@@ -1435,6 +1474,7 @@ export class TerminalFS {
 			createdAt: now,
 			updatedAt: now
 		};
+		const snapshot = this.snapshotState();
 		this.nodes.set(fileId, file);
 
 		// Create desktop alias if configured
@@ -1462,7 +1502,10 @@ export class TerminalFS {
 		}
 
 		const persistResult = await this.debouncedPersist();
-		if (!persistResult.ok) return persistResult as FsResult<FsFile>;
+		if (!persistResult.ok) {
+			this.restoreState(snapshot);
+			return persistResult as FsResult<FsFile>;
+		}
 
 		this.notifyChange([fileId], [APPLICATIONS_ID, DESKTOP_ID], 'install_app');
 
@@ -1487,6 +1530,7 @@ export class TerminalFS {
 		}
 
 		// Remove the app file
+		const snapshot = this.snapshotState();
 		this.nodes.delete(appFile.id);
 
 		// Remove desktop aliases that point to this app file
@@ -1501,12 +1545,11 @@ export class TerminalFS {
 		}
 
 		// Clear undo since uninstall involves multiple nodes.
-		const previousUndo = this.lastUndo;
 		const shouldCollectGarbage = this.clearLastUndo() || this.nodeReferencesBlobBody(appFile);
 
 		const persistResult = await this.debouncedPersist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<{ removedFiles: number }>;
 		}
 		await this.collectGarbageAfterCommit(shouldCollectGarbage);
@@ -1559,10 +1602,14 @@ export class TerminalFS {
 		}
 
 		const owned = this.volume.ownedApps ?? [];
+		const snapshot = this.snapshotState();
 		this.volume = { ...this.volume, ownedApps: [...owned, appId] };
 
 		const persistResult = await this.debouncedPersist();
-		if (!persistResult.ok) return persistResult;
+		if (!persistResult.ok) {
+			this.restoreState(snapshot);
+			return persistResult;
+		}
 
 		this.notifyChange([], [], 'buy_app');
 		return ok(undefined);
@@ -1583,10 +1630,14 @@ export class TerminalFS {
 		}
 
 		const owned = this.volume.ownedApps ?? [];
+		const snapshot = this.snapshotState();
 		this.volume = { ...this.volume, ownedApps: owned.filter((id) => id !== appId) };
 
 		const persistResult = await this.debouncedPersist();
-		if (!persistResult.ok) return persistResult;
+		if (!persistResult.ok) {
+			this.restoreState(snapshot);
+			return persistResult;
+		}
 
 		this.notifyChange([], [], 'return_app');
 		return ok(undefined);
@@ -1809,6 +1860,7 @@ export class TerminalFS {
 
 	async reinstallOS(): Promise<FsResult<void>> {
 		await this.flushPersist();
+		const snapshot = this.snapshotState();
 		this.nodes.clear();
 
 		// Rebuild factory defaults by creating a fresh disk and copying its state
@@ -1821,12 +1873,11 @@ export class TerminalFS {
 
 		// Clear undo before the manifest commit. Blob bodies from the previous
 		// disk are reclaimed only after this save succeeds.
-		const previousUndo = this.lastUndo;
 		this.lastUndo = null;
 
 		const persistResult = await this.persist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult;
 		}
 		await this.collectGarbageAfterCommit(true);
@@ -1849,6 +1900,7 @@ export class TerminalFS {
 		const toDelete = this.collectDescendants(nodeId);
 		const parentId = node.parentId;
 
+		const snapshot = this.snapshotState();
 		const deletedNodes: FsNode[] = [];
 		for (const id of toDelete) {
 			const n = this.nodes.get(id);
@@ -1856,7 +1908,6 @@ export class TerminalFS {
 			this.nodes.delete(id);
 		}
 
-		const previousUndo = this.lastUndo;
 		this.lastUndo = {
 			kind: 'trash',
 			label: `Delete "${node.name}"`,
@@ -1866,7 +1917,7 @@ export class TerminalFS {
 		await this.flushPersist();
 		const persistResult = await this.persist();
 		if (!persistResult.ok) {
-			this.lastUndo = previousUndo;
+			this.restoreState(snapshot);
 			return persistResult as FsResult<void>;
 		}
 		await this.collectGarbageAfterCommit(true);


### PR DESCRIPTION
## Summary
- Add TerminalFS-owned state snapshots so returned manifest save failures restore node map, volume, and undo state.
- Apply rollback to public mutators including app data creation, alias repair, undo, install/uninstall, ownership, reinstall, and delete paths.
- Add failing ManifestStore coverage across command atomicity paths while preserving blob lifecycle tests.
- Remove stale ESLint suppression comments so lint is warning-free.

## Risks
- Snapshot rollback assumes TerminalFS mutators keep using immutable node/volume replacement rather than in-place mutation.
- Restore rollback failure behavior remains the ADR 0001 documented exception for body replacement rollback failures.

## Verification
- pnpm exec vitest run src/lib/terminalos/filesystem/command-atomicity.test.ts
- pnpm exec vitest run src/lib/terminalos/filesystem/body-gc.test.ts src/lib/terminalos/filesystem/backup.test.ts
- pnpm check
- pnpm test:unit -- --runInBand
- pnpm lint
- pnpm build

Closes #41