### PR TITLE
Tokenize wallpaper colors and document design-system token layers (#48)

### DIFF
--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -709,10 +709,22 @@
 		z-index: 0;
 	}
 	.desktop[data-wallpaper='teal'] {
-		background-color: #008080;
+		background-color: var(--wallpaper-teal-base);
 		background-image:
-			linear-gradient(45deg, #5e8585 25%, transparent 25%, transparent 75%, #5e8585 75%),
-			linear-gradient(45deg, #5e8585 25%, transparent 25%, transparent 75%, #5e8585 75%);
+			linear-gradient(
+				45deg,
+				var(--wallpaper-teal-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-teal-dither) 75%
+			),
+			linear-gradient(
+				45deg,
+				var(--wallpaper-teal-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-teal-dither) 75%
+			);
 		background-size:
 			4px 4px,
 			4px 4px;
@@ -721,10 +733,10 @@
 			2px 2px;
 	}
 	.desktop[data-wallpaper='speckle'] {
-		background-color: #e8e1d3;
+		background-color: var(--wallpaper-speckle-base);
 		background-image:
-			radial-gradient(circle at 1px 1px, #c8bda6 1px, transparent 1.5px),
-			radial-gradient(circle at 3px 5px, #b8a989 1px, transparent 1.5px);
+			radial-gradient(circle at 1px 1px, var(--wallpaper-speckle-dot-1) 1px, transparent 1.5px),
+			radial-gradient(circle at 3px 5px, var(--wallpaper-speckle-dot-2) 1px, transparent 1.5px);
 		background-size:
 			6px 6px,
 			8px 8px;
@@ -733,10 +745,22 @@
 			2px 3px;
 	}
 	.desktop[data-wallpaper='yellow'] {
-		background-color: #f9bd2b;
+		background-color: var(--wallpaper-yellow-base);
 		background-image:
-			linear-gradient(45deg, #e3aa20 25%, transparent 25%, transparent 75%, #e3aa20 75%),
-			linear-gradient(45deg, #e3aa20 25%, transparent 25%, transparent 75%, #e3aa20 75%);
+			linear-gradient(
+				45deg,
+				var(--wallpaper-yellow-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-yellow-dither) 75%
+			),
+			linear-gradient(
+				45deg,
+				var(--wallpaper-yellow-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-yellow-dither) 75%
+			);
 		background-size:
 			4px 4px,
 			4px 4px;
@@ -745,10 +769,22 @@
 			2px 2px;
 	}
 	.desktop[data-wallpaper='pink'] {
-		background-color: #ff79c6;
+		background-color: var(--wallpaper-pink-base);
 		background-image:
-			linear-gradient(45deg, #ee63b3 25%, transparent 25%, transparent 75%, #ee63b3 75%),
-			linear-gradient(45deg, #ee63b3 25%, transparent 25%, transparent 75%, #ee63b3 75%);
+			linear-gradient(
+				45deg,
+				var(--wallpaper-pink-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-pink-dither) 75%
+			),
+			linear-gradient(
+				45deg,
+				var(--wallpaper-pink-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-pink-dither) 75%
+			);
 		background-size:
 			4px 4px,
 			4px 4px;
@@ -757,10 +793,22 @@
 			2px 2px;
 	}
 	.desktop[data-wallpaper='navy'] {
-		background-color: #0e1a2b;
+		background-color: var(--wallpaper-navy-base);
 		background-image:
-			linear-gradient(45deg, #16243a 25%, transparent 25%, transparent 75%, #16243a 75%),
-			linear-gradient(45deg, #16243a 25%, transparent 25%, transparent 75%, #16243a 75%);
+			linear-gradient(
+				45deg,
+				var(--wallpaper-navy-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-navy-dither) 75%
+			),
+			linear-gradient(
+				45deg,
+				var(--wallpaper-navy-dither) 25%,
+				transparent 25%,
+				transparent 75%,
+				var(--wallpaper-navy-dither) 75%
+			);
 		background-size:
 			4px 4px,
 			4px 4px;

--- a/src/lib/components/PixelIcon.svelte
+++ b/src/lib/components/PixelIcon.svelte
@@ -1,4 +1,18 @@
 <script lang="ts">
+	/*
+	 * Pixel-art convention — read before adding fills.
+	 *
+	 * The hex `fill` values below are intentional pixel-art internals, NOT theme
+	 * tokens. Each icon has a fixed retro palette that lives inline. We
+	 * deliberately do NOT drive these from --brand-* / --chrome-* tokens: an
+	 * icon has to read correctly on every wallpaper and theme, so its colors are
+	 * pinned, not themed. Don't tokenize them.
+	 *
+	 * The only theme seam is the props below. Two kinds accept them:
+	 *   - `tv`  uses `color` for its screen fill (defaults to #a6f000).
+	 *   - `doc` uses `accent` to flip its page fill yellow vs white.
+	 * Every other kind ignores both props by design.
+	 */
 	let {
 		kind,
 		color,

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -88,6 +88,8 @@ export function saveWindows(windows: WindowState[]): void {
 
 const TWEAKS_DEFAULTS: TweaksState = {
 	wallpaper: 'teal',
+	// Mirrors --brand-color-orange in brand.css. A TS default can't read a CSS
+	// var, so keep this hex in sync with that token if the brand orange changes.
 	accent: '#f54e00',
 	tvGridLoop: 400,
 	marqueeLoop: 100,

--- a/src/lib/themes/brand.css
+++ b/src/lib/themes/brand.css
@@ -17,6 +17,23 @@
 	--brand-color-paper: #ffffff;
 	--brand-color-paper-soft: #e9e8df;
 
+	/* ── Wallpaper ──
+	   Desktop background palettes. Each pattern is a base fill plus a
+	   dither/speckle overlay. Bases for teal/yellow/pink match the brand
+	   palette above; the dither shades, the speckle base/dots, and navy are
+	   net-new and only used by the desktop wallpaper. */
+	--wallpaper-teal-base: #008080;
+	--wallpaper-teal-dither: #5e8585;
+	--wallpaper-speckle-base: #e8e1d3;
+	--wallpaper-speckle-dot-1: #c8bda6;
+	--wallpaper-speckle-dot-2: #b8a989;
+	--wallpaper-yellow-base: #f9bd2b;
+	--wallpaper-yellow-dither: #e3aa20;
+	--wallpaper-pink-base: #ff79c6;
+	--wallpaper-pink-dither: #ee63b3;
+	--wallpaper-navy-base: #0e1a2b;
+	--wallpaper-navy-dither: #16243a;
+
 	/* ── Show colors ── */
 	--brand-show-seinfeld: #f9bd2b;
 	--brand-show-office: #2b6cb0;

--- a/src/routes/design-system/+page.svelte
+++ b/src/routes/design-system/+page.svelte
@@ -22,6 +22,33 @@
 	];
 
 	const iconKinds = ['hd', 'folder', 'tv', 'doc', 'trash', 'calc', 'floppy', 'guide'];
+
+	const tokenLayers = [
+		{
+			name: 'Brand tokens',
+			prefix: '--brand-*',
+			file: 'brand.css',
+			desc: 'The constants: palette, fonts, the size scale, the 4px spacing scale, radius, and motion easings. Defined once at :root and never overridden by a theme.'
+		},
+		{
+			name: 'Chrome tokens',
+			prefix: '--chrome-*',
+			file: 'chrome.system7.css',
+			desc: 'The per-theme surface — window, title bar, menu, dock, dialog, scrollbar, cursor. A theme sets these; they reference brand tokens as their values/fallbacks. Win95 is a separate chrome file.'
+		},
+		{
+			name: 'Wallpaper tokens',
+			prefix: '--wallpaper-*',
+			file: 'brand.css',
+			desc: 'The desktop background palettes — a base fill plus a dither/speckle overlay per pattern (teal, speckle, yellow, pink, navy). Consumed by Desktop.svelte.'
+		},
+		{
+			name: 'Bridge aliases',
+			prefix: '--ink, --paper, --accent…',
+			file: 'app.css',
+			desc: 'Short ergonomic names mapping straight to brand tokens (--ink → --brand-color-ink, --accent → --brand-color-orange). Most app chrome reaches for these.'
+		}
+	];
 </script>
 
 <svelte:head>
@@ -33,6 +60,59 @@
 		<h1>Design System</h1>
 		<p>Living style guide for Terminal — previously on screens...</p>
 	</header>
+
+	<!-- Token Layers -->
+	<section class="ds-section">
+		<h2>Token Layers</h2>
+		<p class="ds-desc">
+			Design tokens stack in layers. A contributor styling app chrome reaches for the bridge
+			aliases; a theme author sets chrome tokens; both bottom out in the brand constants. Reach for
+			the layer that matches what you're changing.
+		</p>
+		<div class="layer-grid">
+			{#each tokenLayers as layer (layer.name)}
+				<div class="layer-card">
+					<div class="layer-head">
+						<strong class="layer-name">{layer.name}</strong>
+						<code class="layer-prefix">{layer.prefix}</code>
+					</div>
+					<span class="layer-file">{layer.file}</span>
+					<p class="layer-desc">{layer.desc}</p>
+				</div>
+			{/each}
+		</div>
+		<p class="ds-desc layer-notes">
+			<strong>Typography</strong> — reach for <code>--brand-font-*</code> (display / body / ui) and
+			the <code>--brand-text-*</code> size scale. <strong>Spacing</strong> — the
+			<code>--brand-space-*</code> 4px scale (space-1 = 4px … space-12 = 48px).
+			<strong>Motion</strong> — <code>--brand-easing-snap</code> (linear) and
+			<code>--brand-easing-pop</code> (overshoot). <strong>Icons</strong> are intentional pixel art: PixelIcon
+			fills are pinned inline and deliberately not tokenized, so an icon reads on any theme.
+		</p>
+		<h3 class="recipe-title">Adding a themed color</h3>
+		<ol class="recipe">
+			<li>
+				Add the constant to the palette block in <code>brand.css</code>:
+				<code>--brand-color-foo: #abc123;</code>. This is the single source of truth.
+			</li>
+			<li>
+				If app code wants a short name, add a bridge alias in <code>app.css</code>:
+				<code>--foo: var(--brand-color-foo);</code>.
+			</li>
+			<li>
+				If a theme's chrome should use it, point a chrome token at it in the theme file:
+				<code>--chrome-…: var(--brand-color-foo);</code> — never the raw hex.
+			</li>
+			<li>
+				For a new wallpaper, add <code>--wallpaper-foo-base</code> / <code>-dither</code> in
+				<code>brand.css</code> and reference them in <code>Desktop.svelte</code>.
+			</li>
+			<li>
+				A TS default that can't read a CSS var (e.g. a persisted default) carries the hex with a
+				comment naming the token it mirrors — see <code>persistence.ts</code>'s accent default.
+			</li>
+		</ol>
+	</section>
 
 	<!-- Color Palette -->
 	<section class="ds-section">
@@ -275,6 +355,78 @@
 		font-size: 19px;
 		margin: 0 0 16px;
 		opacity: 0.8;
+	}
+
+	/* Token Layers */
+	.layer-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: 12px;
+	}
+	.layer-card {
+		border: 2px solid var(--ink);
+		background: var(--paper-soft);
+		padding: 12px;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.layer-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 8px;
+	}
+	.layer-name {
+		font-family: var(--brand-font-ui);
+		font-size: 16px;
+	}
+	.layer-prefix {
+		font-family: var(--brand-font-body);
+		font-size: 16px;
+		background: var(--paper);
+		padding: 1px 5px;
+		border: 1px solid var(--ink);
+	}
+	.layer-file {
+		font-family: var(--brand-font-display);
+		font-size: 8px;
+		opacity: 0.7;
+	}
+	.layer-desc {
+		font-family: var(--brand-font-body);
+		font-size: 17px;
+		line-height: 1.3;
+		margin: 4px 0 0;
+	}
+	.layer-notes {
+		margin-top: 16px;
+		margin-bottom: 0;
+	}
+	.layer-notes code {
+		background: var(--paper-soft);
+		padding: 1px 4px;
+		border: 1px solid var(--ink);
+	}
+	.recipe-title {
+		font-family: var(--brand-font-ui);
+		font-size: 18px;
+		margin: 20px 0 8px;
+	}
+	.recipe {
+		font-family: var(--brand-font-body);
+		font-size: 17px;
+		line-height: 1.35;
+		margin: 0;
+		padding-left: 20px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.recipe code {
+		background: var(--paper-soft);
+		padding: 1px 4px;
+		border: 1px solid var(--ink);
 	}
 
 	/* Color Palette */


### PR DESCRIPTION
## #48 — Design-system token and documentation cleanup

Cleanup only — no visual change. Theme-owned colors move to named tokens and the
design-system page gains a token-layer reference. Win95 work (#8) is out of scope.

### Changes
- **Tokenize wallpaper colors** — added a `--wallpaper-*` section to `brand.css`
  (11 tokens: base + dither/speckle per pattern). `Desktop.svelte`'s 5 wallpaper
  patterns now reference these tokens instead of inline hex. Every value maps 1:1
  to the original, so the desktop renders identically.
- **Document the accent default** — `persistence.ts`'s `accent: '#f54e00'` carries a
  comment noting it mirrors `--brand-color-orange` (a TS default can't read a CSS var).
- **PixelIcon convention** — header comment declaring the inline SVG fills are
  intentional pixel-art internals, deliberately not theme-tokenized so icons read on
  any theme; names the `tv`/`doc` color seams.
- **Token-layer docs** — new "Token Layers" section on the `/design-system` page
  documenting the brand / chrome / wallpaper / bridge-alias layers plus typography,
  spacing, and motion, and an "Adding a themed color" recipe.

### Verification
- `pnpm run check` — 0 errors, 0 warnings
- Svelte autofixer clean on changed components
- No raw wallpaper hex remains in `Desktop.svelte`; token values confirmed identical
  to originals (no restyle)

Closes #48.