### PR TITLE
Harden the changeset CLI and collapse the reference field to one link

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -23,7 +23,7 @@ a release instead of being deleted.
 ---
 type: minor
 category: Added
-issue: #123
+link: #123
 ---
 
 Add folder-addressable Finder windows
@@ -38,8 +38,7 @@ Add folder-addressable Finder windows
 | ---------- | -------- | -------------------------------------------------------------------------------------------------- |
 | `type`     | Yes      | SemVer impact: `major`, `minor`, or `patch`. Highest pending type wins the release bump.           |
 | `category` | No       | Changelog section. Defaults by type: `minor` -> `Added`, `patch` -> `Fixed`, `major` -> `Changed`. |
-| `issue`    | No       | GitHub issue, PR, or discussion link to include in the changelog entry.                            |
-| `pr`       | No       | Optional separate PR link when useful.                                                             |
+| `link`     | No       | A PR, issue, or discussion link to include in the changelog entry.                                 |
 
 ## Categories
 

--- a/.changeset/add-archived-changeset-workflow.md
+++ b/.changeset/add-archived-changeset-workflow.md
@@ -6,6 +6,7 @@ category: Added
 Add an archived changeset and changelog workflow
 
 - Add a repo-native `pnpm changeset` CLI for creating, validating, previewing, and consuming release notes.
+- Author each changeset with a `type`, a `category`, and an optional `link` to the PR or issue.
 - Add `pnpm start-here` and `pnpm run help` so returning maintainers can rediscover the branch, PR, change-set, and release workflow from the terminal.
 - Generate Keep a Changelog-style release entries from pending `.changeset/*.md` files.
 - Archive consumed changesets under `.changeset/released/<version>/` so release-intent notes remain inspectable after a changelog entry is created.

--- a/docs/changeset-architecture.html
+++ b/docs/changeset-architecture.html
@@ -1121,7 +1121,7 @@ git push origin main --follow-tags</code></pre>
 					<pre><code>---
 type: minor
 category: Added
-issue: #123
+link: #123
 ---
 
 Add folder-addressable Finder windows so Desktop folder aliases open the folder

--- a/docs/changesets.md
+++ b/docs/changesets.md
@@ -79,6 +79,12 @@ pnpm changeset:check-pr
 
 That command validates branch-local changesets and fails if none are present.
 
+It compares the branch against `origin/main`, so that ref must exist locally —
+run `git fetch origin` first. On a shallow clone, a fork, or a remote not named
+`origin`, the diff cannot resolve and the command fails even when a valid
+changeset is present. When this workflow runs in CI, fetch enough history (or
+point it at the right base ref) before calling `check-pr`.
+
 ## Release Maintainer Workflow
 
 Agent workflow:
@@ -111,6 +117,20 @@ This command:
 Review the generated changelog before committing. It is acceptable to edit
 wording and grouping after generation, but keep the archived changesets as the
 source notes that produced the release.
+
+Steps 4–6 are not a single atomic operation. The clean-working-tree requirement
+is the recovery mechanism: if any step fails partway, the only changes on disk
+are the ones this command just made, so
+
+```bash
+git checkout -- CHANGELOG.md package.json .changeset
+git clean -fd .changeset/released
+```
+
+restores the pre-release state. Run the command again once the cause is fixed.
+This is also why you must not re-run `--yes` after a partial failure without
+resetting first — a second run would consume the same changesets again and
+duplicate the changelog entry.
 
 ## Tags and GitHub Releases
 
@@ -162,7 +182,7 @@ is deliberately complete without them.
 ---
 type: minor
 category: Added
-issue: #123
+link: #123
 ---
 
 Add folder-addressable Finder windows

--- a/scripts/changesets.js
+++ b/scripts/changesets.js
@@ -40,7 +40,8 @@ function hasFlag(flag) {
 function getOption(name, fallback) {
 	const index = args.indexOf(name);
 	if (index === -1) return fallback;
-	return args[index + 1] ?? fallback;
+	const value = args[index + 1];
+	return value && !value.startsWith('--') ? value : fallback;
 }
 
 function printValidationErrors(errors) {
@@ -73,7 +74,7 @@ async function addChangeset() {
 			await rl.question(`Category (${CHANGELOG_CATEGORIES.join(', ')}): `)
 		).trim();
 		const summary = (await rl.question('Summary: ')).trim();
-		const issue = (await rl.question('Issue or PR link (optional): ')).trim();
+		const link = (await rl.question('Link (PR, issue, optional): ')).trim();
 		const bodyLines = [];
 
 		output.write('Details, one line at a time. Submit an empty line when done.\n');
@@ -83,7 +84,7 @@ async function addChangeset() {
 			bodyLines.push(line);
 		}
 
-		const defaultFilename = `${slugify(summary)}.md`;
+		const defaultFilename = `${slugify(summary) || 'changeset'}.md`;
 		const filenameAnswer = (await rl.question(`Filename (${defaultFilename}): `)).trim();
 		const filename = filenameAnswer || defaultFilename;
 		const category = categoryAnswer || undefined;
@@ -92,7 +93,7 @@ async function addChangeset() {
 			filename,
 			type,
 			category,
-			issue,
+			link,
 			summary,
 			body: bodyLines.join('\n')
 		});
@@ -144,6 +145,13 @@ function status() {
 }
 
 function version() {
+	if (hasFlag('--branch-only') || args.includes('--since')) {
+		console.error(
+			'--branch-only and --since are not valid for version; releases consume every pending changeset.'
+		);
+		process.exit(1);
+	}
+
 	if (!hasFlag('--dry-run') && !hasFlag('--yes')) {
 		console.error('Refusing to mutate files without --yes. Use --dry-run to preview.');
 		process.exit(1);
@@ -171,6 +179,9 @@ function version() {
 try {
 	if (command === 'help' || command === '--help' || command === '-h') {
 		printHelp();
+	} else if (!existsSync('package.json')) {
+		console.error('Run this command from the repository root.');
+		process.exit(1);
 	} else if (command === 'add') {
 		await addChangeset();
 	} else if (command === 'validate') {
@@ -179,9 +190,6 @@ try {
 		status();
 	} else if (command === 'version') {
 		version();
-	} else if (!existsSync('package.json')) {
-		console.error('Run this command from the repository root.');
-		process.exit(1);
 	} else {
 		console.error(`Unknown command: ${command}`);
 		printHelp();

--- a/scripts/lib/changesets.js
+++ b/scripts/lib/changesets.js
@@ -66,7 +66,8 @@ function parseFrontmatter(frontmatter) {
 }
 
 export function parseChangeset(filename, content) {
-	const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+	const normalized = content.replace(/\r\n/g, '\n');
+	const match = normalized.match(/^---\s*\n([\s\S]*?)\n---\s*(?:\n([\s\S]*))?$/);
 	if (!match) {
 		return {
 			changeset: null,
@@ -75,7 +76,7 @@ export function parseChangeset(filename, content) {
 	}
 
 	const fields = parseFrontmatter(match[1]);
-	const description = match[2].trim();
+	const description = (match[2] ?? '').trim();
 	const type = fields.type?.toLowerCase();
 	const category = fields.category || (type ? DEFAULT_CATEGORY_BY_TYPE[type] : undefined);
 	const summary = description.split('\n')[0]?.trim() ?? '';
@@ -84,8 +85,7 @@ export function parseChangeset(filename, content) {
 		filename,
 		type,
 		category,
-		issue: fields.issue || '',
-		pr: fields.pr || '',
+		link: fields.link || '',
 		summary,
 		body: description.split('\n').slice(1).join('\n').trim(),
 		description
@@ -118,7 +118,7 @@ export function validateChangeset(changeset) {
 		errors.push(`${changeset.filename}: body must start with a one-line summary`);
 	}
 
-	if (changeset.summary.length > 120) {
+	if (changeset.summary && changeset.summary.length > 120) {
 		errors.push(`${changeset.filename}: summary should be 120 characters or less`);
 	}
 
@@ -162,8 +162,7 @@ export function getValidPendingChangesets(options = {}) {
 export function getBranchOnlyChangesetFiles({ root = process.cwd(), since = 'origin/main' } = {}) {
 	const files = [
 		...gitChangedFiles(root, ['diff', `${since}...HEAD`, '--name-only', '--', CHANGESET_DIR]),
-		...gitChangedFiles(root, ['diff', '--name-only', '--', CHANGESET_DIR]),
-		...gitChangedFiles(root, ['diff', '--cached', '--name-only', '--', CHANGESET_DIR]),
+		...gitChangedFiles(root, ['diff', 'HEAD', '--name-only', '--', CHANGESET_DIR]),
 		...gitChangedFiles(root, ['ls-files', '--others', '--exclude-standard', '--', CHANGESET_DIR])
 	];
 
@@ -205,8 +204,7 @@ export function bumpVersion(version, type) {
 
 function formatEntry(changeset) {
 	const lines = [`**${changeset.summary}**`];
-	if (changeset.issue) lines.push('', changeset.issue);
-	if (changeset.pr) lines.push('', changeset.pr);
+	if (changeset.link) lines.push('', changeset.link);
 	if (changeset.body) lines.push('', changeset.body);
 	return lines.join('\n');
 }
@@ -219,7 +217,9 @@ export function generateChangelogEntry(version, changesets, { date = currentDate
 	}
 
 	for (const changeset of changesets) {
-		grouped.get(changeset.category)?.push(changeset);
+		const bucket = grouped.get(changeset.category);
+		if (!bucket) throw new Error(`Unknown changelog category: ${changeset.category}`);
+		bucket.push(changeset);
 	}
 
 	const sections = [];
@@ -359,23 +359,14 @@ export function validatePendingChangesets(options = {}) {
 }
 
 export function createChangesetFile(
-	{
-		filename,
-		type,
-		category = DEFAULT_CATEGORY_BY_TYPE[type],
-		issue = '',
-		pr = '',
-		summary,
-		body = ''
-	},
+	{ filename, type, category = DEFAULT_CATEGORY_BY_TYPE[type], link = '', summary, body = '' },
 	{ root = process.cwd() } = {}
 ) {
 	const changeset = {
 		filename,
 		type,
 		category,
-		issue,
-		pr,
+		link,
 		summary,
 		body,
 		description: [summary, body].filter(Boolean).join('\n')
@@ -396,8 +387,7 @@ export function createChangesetFile(
 	const optionalFields = [
 		`type: ${type}`,
 		`category: ${category}`,
-		issue ? `issue: ${issue}` : '',
-		pr ? `pr: ${pr}` : ''
+		link ? `link: ${link}` : ''
 	].filter(Boolean);
 
 	const content = `---\n${optionalFields.join('\n')}\n---\n\n${changeset.description.trim()}\n`;
@@ -414,7 +404,11 @@ export function slugify(input) {
 }
 
 function currentDate() {
-	return new Date().toISOString().slice(0, 10);
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, '0');
+	const day = String(now.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
 }
 
 function gitChangedFiles(root, args) {

--- a/scripts/lib/changesets.test.js
+++ b/scripts/lib/changesets.test.js
@@ -1,9 +1,9 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
 	assertCanArchiveChangesets,
 	bumpVersion,
@@ -18,8 +18,11 @@ import {
 	validatePendingChangesets
 } from './changesets.js';
 
+const createdRoots = [];
+
 function tempRoot() {
 	const root = mkdtempSync(join(tmpdir(), 'terminal-changesets-'));
+	createdRoots.push(root);
 	writeFileSync(
 		join(root, 'package.json'),
 		JSON.stringify({ name: 'terminal-bli-net', version: '1.0.0', private: true }, null, '\t') +
@@ -28,6 +31,12 @@ function tempRoot() {
 	);
 	return root;
 }
+
+afterEach(() => {
+	while (createdRoots.length) {
+		rmSync(createdRoots.pop(), { recursive: true, force: true });
+	}
+});
 
 function git(root, args) {
 	const result = spawnSync('git', args, {
@@ -62,7 +71,7 @@ describe('parseChangeset', () => {
 			`---
 type: minor
 category: Added
-issue: #12
+link: #12
 ---
 
 Add folder-addressable Finder windows
@@ -75,7 +84,7 @@ Add folder-addressable Finder windows
 			filename: 'add-finder-routing.md',
 			type: 'minor',
 			category: 'Added',
-			issue: '#12',
+			link: '#12',
 			summary: 'Add folder-addressable Finder windows',
 			body: '- Desktop folder aliases preserve their target folder'
 		});
@@ -243,8 +252,7 @@ describe('changelog generation', () => {
 					category: 'Fixed',
 					summary: 'Fix unknown document alerts',
 					body: '',
-					issue: '',
-					pr: ''
+					link: ''
 				},
 				{
 					filename: 'add.md',
@@ -252,8 +260,7 @@ describe('changelog generation', () => {
 					category: 'Added',
 					summary: 'Add release tooling',
 					body: '- Archives consumed changesets',
-					issue: '',
-					pr: ''
+					link: ''
 				}
 			],
 			{ date: '2026-06-03' }


### PR DESCRIPTION
## Summary

Hardens the changeset CLI introduced in #65 and collapses the changeset
frontmatter to a single reference field. Builds on the already-merged
workflow; the only new content vs `main` is this hardening. Supersedes #66
(which conflicted because #65 was squash-merged).

- Return a validation error instead of throwing when a summary is missing,
  and throw on an unknown changelog category instead of silently dropping it.
- Reject `--branch-only`/`--since` on `version` so a release always consumes
  every pending changeset and the dry-run matches the apply.
- Run the repo-root check before `add`/`validate`/`status`/`version`; `help`
  still works anywhere.
- Treat a following flag as no value in `getOption`.
- Normalize CRLF and accept a missing trailing newline when parsing.
- Date changelog entries with the local date; fall back to `changeset.md`
  for an empty slug; look up branch changesets in three git calls, not four.
- Replace the `issue`/`pr` frontmatter pair with a single `link` field across
  the parser, formatter, creator, CLI prompt, docs, and template.
- Clean up test temp directories; document the `origin/main` requirement for
  `check-pr` and the clean-tree recovery path for a partial release.

The pending changeset from #65 is updated in place to describe the final
`link` format rather than adding a second note.

## Testing

- `pnpm test:unit` → 53 files, 833 tests passed.
- `pnpm lint` → prettier + eslint clean.
- `pnpm changeset:check-pr` → "Changesets are valid."

## Change Type

- [ ] Major
- [x] Minor
- [ ] Patch
- [ ] None

## Changeset

- [x] Added or updated `.changeset/*.md`
- [x] Ran `pnpm changeset:check-pr` for a release-worthy PR
- [ ] Not needed because this PR has no release-worthy user, app-author, storage, deploy, or docs change

## Storage / Routing / App Contract

- [x] Not affected
- [ ] Affected, and docs plus in-app copy were updated where needed