### PR TITLE
Exact LLM spend enforcement + Turnstile gate for public chat (#69)

### DIFF
--- a/.changeset/exact-spend-enforcement.md
+++ b/.changeset/exact-spend-enforcement.md
@@ -1,15 +1,16 @@
 ---
 type: minor
 category: Security
-link: #69
+link: #70
 ---
 
 Enforce exact LLM spend on the public chat endpoint behind a proof-of-human gate
 
 - Add a Spend Ledger that makes every configured dollar ceiling exact: a request reserves its worst-case cost before streaming and reconciles to actual cost after, so concurrent requests can never overshoot a cap.
-- Enforce the ceilings in a single global Durable Object (in the reminder Worker, reached over a `SPEND_LEDGER` service binding); the chat route depends only on the `SpendLedger` port, with an in-memory adapter for development.
-- Fail closed in production: if the spend authority is unreachable, requests are refused rather than allowed to spend.
-- Gate chat with Cloudflare Turnstile — verify a token on the first message of a session, then issue a 30-minute signed session token so later messages aren't re-challenged. The gate is config-activated (`PUBLIC_TURNSTILE_SITE_KEY` + the `TURNSTILE_SECRET` Pages secret) and fails open when unconfigured.
+- Enforce the ceilings in a single global Durable Object (in the reminder Worker, reached over a required `SPEND_LEDGER` service binding); the chat route depends only on the `SpendLedger` port, with an in-memory adapter for development.
+- Fail closed in production: if the spend authority is missing, misconfigured, or unreachable, requests are refused rather than allowed to spend.
+- Reserve a full provider fallback plan up front, with cache-aware worst-case input pricing, so transient provider failover cannot create unreserved or cross-provider spend.
+- Gate chat with Cloudflare Turnstile — verify a token on the first message of a session, then issue a 30-minute signed session token so later messages aren't re-challenged. The gate is config-activated (`PUBLIC_TURNSTILE_SITE_KEY` + the `TURNSTILE_SECRET` Pages secret), fails open when unconfigured, and distinguishes invalid tokens from verifier outages.
 - Show a graceful in-voice "off the air" message when a daily or monthly ceiling is hit, instead of a raw error.
 - Emit structured observability events for every ledger decision (reserve, commit, refund, expire, deny).
 - Retire the superseded KV monthly-spend counters; the per-IP rate throttle and the model pricing table are unchanged.

--- a/.changeset/exact-spend-enforcement.md
+++ b/.changeset/exact-spend-enforcement.md
@@ -1,0 +1,15 @@
+---
+type: minor
+category: Security
+link: #69
+---
+
+Enforce exact LLM spend on the public chat endpoint behind a proof-of-human gate
+
+- Add a Spend Ledger that makes every configured dollar ceiling exact: a request reserves its worst-case cost before streaming and reconciles to actual cost after, so concurrent requests can never overshoot a cap.
+- Enforce the ceilings in a single global Durable Object (in the reminder Worker, reached over a `SPEND_LEDGER` service binding); the chat route depends only on the `SpendLedger` port, with an in-memory adapter for development.
+- Fail closed in production: if the spend authority is unreachable, requests are refused rather than allowed to spend.
+- Gate chat with Cloudflare Turnstile — verify a token on the first message of a session, then issue a 30-minute signed session token so later messages aren't re-challenged. The gate is config-activated (`PUBLIC_TURNSTILE_SITE_KEY` + the `TURNSTILE_SECRET` Pages secret) and fails open when unconfigured.
+- Show a graceful in-voice "off the air" message when a daily or monthly ceiling is hit, instead of a raw error.
+- Emit structured observability events for every ledger decision (reserve, commit, refund, expire, deny).
+- Retire the superseded KV monthly-spend counters; the per-IP rate throttle and the model pricing table are unchanged.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,44 @@
+# Context — Ubiquitous Language
+
+This is a glossary, not a spec. It pins the terms the code and docs must use
+consistently. Implementation details live in `docs/adr/` and `docs/prd/`.
+
+## Cost control
+
+The bounded context that protects the owner's LLM budget on the public chat
+endpoint. Its job: a request either gets served within budget, or it is refused
+— spend must never exceed the configured ceilings.
+
+- **Spend Ledger** — the authority that decides whether a chat request may spend
+  money, and records what it spent. It is the single source of truth for every
+  *dollar* limit. Accessed through one interface (a port) with swappable
+  backends; the exact backend lives in a Durable Object. Not to be confused with
+  the per-IP rate throttle, which is a fairness control, not a money authority.
+
+- **Reservation** — a hold the Spend Ledger places against a ceiling at the
+  moment a request is admitted, sized to the request's *worst-case* cost. A
+  reservation makes in-flight, not-yet-spent money visible to concurrent
+  requests, so the ceiling reflects money *committed* rather than only money
+  already spent. Reservations expire on their own if never reconciled.
+
+- **Reconciliation** — replacing a Reservation's worst-case estimate with the
+  request's *actual* token cost once the response finishes: the difference is
+  refunded (actual < reserved) or, rarely, topped up. After reconciliation the
+  ledger reflects true spend.
+
+- **Daily Circuit Breaker** — the global, all-visitors ceiling on spend (and on
+  request count) for one UTC day. The master stop: when tripped, the site stops
+  spending until the next day regardless of who is asking.
+
+- **Monthly Provider Cap** — the per-provider ceiling on spend for one UTC month
+  (e.g. Claude and OpenAI each have their own). A provider over its cap is
+  skipped in the fallback order; when all are over, chat is unavailable.
+
+- **Turnstile Gate** — the Cloudflare Turnstile proof-of-human check the chat
+  endpoint requires before spending money. It removes scripted/automated
+  traffic, which is what keeps a single human's worst case small.
+
+- **Fail Closed** — when the Spend Ledger cannot be reached, a chat request is
+  *refused* (production). The absence of a working money authority is treated as
+  "no budget," never as "unlimited budget." (Development fails *open* via an
+  in-memory ledger so local work needs no deployed authority.)

--- a/docs/adr/0005-exact-spend-enforcement.md
+++ b/docs/adr/0005-exact-spend-enforcement.md
@@ -12,14 +12,14 @@ and rate limits were tracked in Cloudflare KV with read-modify-write counters
 consistent, which produces two failures for a money ceiling:
 
 1. **Lost updates.** Concurrent requests read the same counter and overwrite
-   each other, so recorded spend *undercounts* real spend.
+   each other, so recorded spend _undercounts_ real spend.
 2. **Stale reads under burst.** A flood of requests within KV's propagation
    window all read a pre-cap value and all pass the gate.
 
-The gate also recorded cost *after* the stream finished, so N requests could
+The gate also recorded cost _after_ the stream finished, so N requests could
 pass the check before any of them recorded — overshoot independent of the KV
 weakness above. And `isProviderOverBudget` returned "available" when KV was
-missing, i.e. it failed *open*: an infrastructure problem removed the cap.
+missing, i.e. it failed _open_: an infrastructure problem removed the cap.
 
 The owner's requirement is explicit: the cap must be **exact**, not "probably
 fine." A fuzzy guarantee was rejected. At the same time, this codebase is meant
@@ -38,7 +38,7 @@ Alternatives considered:
   the ceiling stays approximate (±a few dollars), which the owner explicitly
   rejected.
 - **Per-IP sharded counters in many DO instances.** Scales better, but per-IP
-  shards cannot enforce a single *global* dollar ceiling without cross-shard
+  shards cannot enforce a single _global_ dollar ceiling without cross-shard
   aggregation — the opposite of what an exact global cap needs.
 - **Single global DO counter (chosen).** Exact and simple, at the cost of a
   global serialization point.
@@ -60,23 +60,30 @@ behind one port with two adapters.
 - **`InMemorySpendLedger`** (development and tests) — no deployed dependency.
 
 **Reserve-then-reconcile.** On admission the ledger debits the request's
-worst-case cost (derived from `maxTokens` and the model's price) as a
-**Reservation**. When the stream finishes, **Reconciliation** swaps the estimate
-for actual cost. Ceilings therefore reflect money *committed*, not only money
-*spent*, which closes the check-before/record-after gap. The design deliberately
-errs safe: when reservations fill a ceiling, requests are refused even if actual
-spend would have fit. Overshoot is impossible; occasional early refusal is
-accepted.
+worst-case cost (derived from conservative input tokens, `maxTokens`, cache-aware
+input rates, and the model's output price) as a **Reservation**. If the route is
+willing to fail over across providers, the reserve call creates one Reservation
+per fallback candidate that also fits the daily and monthly ceilings; the route
+streams only those reserved providers. When the stream finishes,
+**Reconciliation** swaps each used estimate for actual cost and releases unused
+fallback holds. Ceilings therefore reflect money _committed_, not only money
+_spent_, which closes the check-before/record-after gap. The design deliberately
+errs safe: when reservations fill a ceiling, requests are refused or fallbacks
+are omitted even if actual spend would have fit. Overshoot is impossible;
+occasional early refusal is accepted.
 
 **Reservation expiry.** Each Reservation carries a short TTL (default 60s, well
 above a 300-token stream). A request that dies after reserving but before
 reconciling has its hold auto-refunded, so the ledger cannot drift upward from
 orphaned holds.
 
-**Scope split.** The ledger owns all *dollar* ceilings — the global Daily
-Circuit Breaker and the per-provider Monthly Provider Cap — exactly. The per-IP
-*rate* throttle remains in KV: it is a fairness control, not a money guarantee,
-and approximate counting there is acceptable.
+**Scope split.** The ledger owns all _dollar_ ceilings — the global Daily
+Circuit Breaker and the per-provider Monthly Provider Cap — exactly. Its daily
+request backstop counts every ledger-adjudicated chat attempt, including
+over-budget refusals, so a valid session cannot hammer the global Durable Object
+for free after a dollar cap trips. The per-IP _rate_ throttle remains in KV: it
+is a fairness control, not a money guarantee, and approximate counting there is
+acceptable.
 
 **Fail closed.** If the ledger is unreachable, production refuses the request
 (no authority ⇒ no budget). Development uses the in-memory adapter, so it fails

--- a/docs/adr/0005-exact-spend-enforcement.md
+++ b/docs/adr/0005-exact-spend-enforcement.md
@@ -1,0 +1,108 @@
+# Exact spend enforcement via a Durable Object ledger
+
+The public chat endpoint enforces every dollar ceiling through a single
+authoritative Spend Ledger that reserves worst-case cost before a call and
+reconciles to actual cost after, so configured caps cannot be exceeded.
+
+## Context
+
+The chat endpoint spends real LLM money on behalf of anonymous visitors. Spend
+and rate limits were tracked in Cloudflare KV with read-modify-write counters
+(`src/lib/server/spend.ts`). KV has no atomic increment and is eventually
+consistent, which produces two failures for a money ceiling:
+
+1. **Lost updates.** Concurrent requests read the same counter and overwrite
+   each other, so recorded spend *undercounts* real spend.
+2. **Stale reads under burst.** A flood of requests within KV's propagation
+   window all read a pre-cap value and all pass the gate.
+
+The gate also recorded cost *after* the stream finished, so N requests could
+pass the check before any of them recorded — overshoot independent of the KV
+weakness above. And `isProviderOverBudget` returned "available" when KV was
+missing, i.e. it failed *open*: an infrastructure problem removed the cap.
+
+The owner's requirement is explicit: the cap must be **exact**, not "probably
+fine." A fuzzy guarantee was rejected. At the same time, this codebase is meant
+to read as a reference example, so the design is held to a principal-engineer
+bar: a clean seam, real tests on the invariant, and observability.
+
+Cloudflare Pages cannot host Durable Objects (this is why `ReminderAgent`
+already runs as a separate Worker bound over a `services` binding). So an exact,
+serialized counter cannot live in the Pages app — it must live in a Worker the
+Pages app calls.
+
+Alternatives considered:
+
+- **Keep KV, add a global daily backstop.** Cheaper, no new infrastructure, and
+  with a Turnstile Gate in front the realistic overshoot is a few dollars. But
+  the ceiling stays approximate (±a few dollars), which the owner explicitly
+  rejected.
+- **Per-IP sharded counters in many DO instances.** Scales better, but per-IP
+  shards cannot enforce a single *global* dollar ceiling without cross-shard
+  aggregation — the opposite of what an exact global cap needs.
+- **Single global DO counter (chosen).** Exact and simple, at the cost of a
+  global serialization point.
+
+## Decision
+
+Introduce a **Spend Ledger** as the single authority for every dollar ceiling,
+behind one port with two adapters.
+
+**Port.** `SpendLedger` exposes `reserve`, `commit`/`refund` (reconcile), and
+`status`. The chat route depends only on this interface.
+
+**Adapters.**
+
+- **`DurableObjectSpendLedger`** (production) — backed by one global Durable
+  Object instance living in the existing `terminal-reminder-agent` Worker,
+  reached from the Pages app over the `services` RPC binding. Its single-instance
+  serialization is what makes counts exact.
+- **`InMemorySpendLedger`** (development and tests) — no deployed dependency.
+
+**Reserve-then-reconcile.** On admission the ledger debits the request's
+worst-case cost (derived from `maxTokens` and the model's price) as a
+**Reservation**. When the stream finishes, **Reconciliation** swaps the estimate
+for actual cost. Ceilings therefore reflect money *committed*, not only money
+*spent*, which closes the check-before/record-after gap. The design deliberately
+errs safe: when reservations fill a ceiling, requests are refused even if actual
+spend would have fit. Overshoot is impossible; occasional early refusal is
+accepted.
+
+**Reservation expiry.** Each Reservation carries a short TTL (default 60s, well
+above a 300-token stream). A request that dies after reserving but before
+reconciling has its hold auto-refunded, so the ledger cannot drift upward from
+orphaned holds.
+
+**Scope split.** The ledger owns all *dollar* ceilings — the global Daily
+Circuit Breaker and the per-provider Monthly Provider Cap — exactly. The per-IP
+*rate* throttle remains in KV: it is a fairness control, not a money guarantee,
+and approximate counting there is acceptable.
+
+**Fail closed.** If the ledger is unreachable, production refuses the request
+(no authority ⇒ no budget). Development uses the in-memory adapter, so it fails
+open without special-casing.
+
+**Turnstile.** A Turnstile Gate is required before the ledger is consulted, so
+automated floods never reach the spend path. This is what keeps a single human's
+worst case bounded and lets the per-IP throttle stay approximate.
+
+## Consequences
+
+- Configured caps become true ceilings: spend cannot exceed them under any
+  concurrency. This is the property the owner required.
+- A single global DO instance serializes every chat request through one RPC hop.
+  At hobby traffic this is invisible; it would become a throughput bottleneck at
+  serious scale, at which point the ledger would shard (e.g. time-bucketed
+  instances) — a known, deferred evolution.
+- The chat route gains a hard dependency on the ledger Worker. That dependency is
+  the reason fail-closed and Reservation expiry are part of this decision, not
+  afterthoughts.
+- The `SpendLedger` port makes the money authority swappable and unit-testable
+  without Workers. The load-bearing invariant — concurrent requests can never
+  push committed spend past a ceiling — is covered by concurrency tests against
+  the in-memory adapter, plus a Workers-pool test for the DO adapter.
+- The ledger emits structured reserve/commit/refund/deny events so the cap can be
+  observed working in production.
+- KV remains for the per-IP rate throttle only. The old `spend.ts` dollar logic
+  is superseded by the ledger; its pricing table (`MODEL_PRICING_USD_PER_MILLION`)
+  is retained and reused for worst-case and actual cost.

--- a/docs/prd/cost-abuse-hardening.md
+++ b/docs/prd/cost-abuse-hardening.md
@@ -1,0 +1,203 @@
+# Cost & Abuse Hardening PRD
+
+## Problem Statement
+
+The chat endpoint (`src/routes/api/chat/+server.ts`) calls paid LLM APIs on
+behalf of anonymous visitors on a public site. A pre-public audit found that the
+spend controls can be defeated: the Cloudflare KV counters that track spend and
+rate are non-atomic and eventually consistent, cost is recorded only *after* a
+stream completes, and the budget check fails *open* when KV is unavailable. With
+no proof-of-human in front, a scripted client rotating IPs can drive the owner's
+LLM bill well past the nominal $25-per-provider caps — a realistic worst case of
+roughly $50–150+ in a bad month.
+
+From the owner's perspective the requirement is simple and firm: configured
+dollar ceilings must be **exact** — "shouldn't go too wrong" is not acceptable.
+The site stays a free, anonymous hobby project (no accounts), and this subsystem
+is to be built as a reference example of cost control on Cloudflare that other
+engineers can replicate.
+
+This risk exists on the **already-deployed** site today; it is not created by
+open-sourcing the repo. It should be fixed regardless of repository visibility.
+
+## Goals
+
+1. Make every dollar ceiling a true ceiling that cannot be exceeded under any
+   concurrency.
+2. Remove the scripted-abuse vector with a proof-of-human gate.
+3. Bound the worst possible day with a global circuit breaker.
+4. Fail safe: an unreachable money authority denies spend, never permits it.
+5. Ship it as reference-grade work: a clean port/adapter seam, an ADR, tests on
+   the core invariant, and observability.
+
+## Non-Goals
+
+- No accounts, login, or per-user identity. The site stays anonymous.
+- No per-IP *exact* limiting. The per-IP throttle stays approximate (KV); it is
+  a fairness control, not a money guarantee.
+- No horizontal sharding of the ledger. A single global instance is sufficient
+  at current traffic; sharding is a documented future evolution, not now.
+- No change to the chat product, personas, or streaming UX beyond the gate and
+  the over-budget message.
+
+## Solution
+
+Introduce a **Spend Ledger** (see `CONTEXT.md`, `docs/adr/0005`): the single
+authority for all dollar ceilings, consulted behind a proof-of-human gate.
+
+1. **Turnstile Gate.** The chat endpoint requires a valid Cloudflare Turnstile
+   token before any spend path runs. Automated floods never reach the ledger.
+2. **`SpendLedger` port.** The chat route depends on one interface
+   (`reserve` / `commit` / `refund` / `status`), not on storage. Two adapters:
+   `DurableObjectSpendLedger` (production, exact) and `InMemorySpendLedger`
+   (dev/tests).
+3. **Exact dollar ceilings via one global Durable Object.** Hosted in the
+   existing `terminal-reminder-agent` Worker, reached over the `services` RPC
+   binding. Single-instance serialization makes counts exact.
+4. **Reserve-then-reconcile.** Reserve worst-case cost on admission; reconcile to
+   actual cost when the stream ends. Ceilings reflect committed money, so
+   concurrent requests cannot overshoot. The bias is safe: refuse early rather
+   than overspend.
+5. **Reservation expiry.** Holds self-refund after a short TTL so orphaned
+   reservations cannot lock the site out.
+6. **Daily Circuit Breaker + Monthly Provider Cap** both enforced by the ledger.
+7. **Per-IP rate throttle** stays in KV, unchanged in spirit (approximate).
+8. **Fail closed in production, open in dev** (the in-memory adapter makes dev
+   trivially open).
+9. **Graceful over-budget response** in the app's voice.
+10. **Observability**: structured reserve/commit/refund/deny events.
+
+## Ceiling Values
+
+All values are environment-configurable with these defaults.
+
+| Control | Default | Authority | Notes |
+|---|---|---|---|
+| Global daily spend (Daily Circuit Breaker) | **$3 / UTC day** | Spend Ledger (exact) | Master breaker. Worst possible day. |
+| Global daily request count | **5,000 / UTC day** | Spend Ledger (exact) | Dollar-independent backstop if pricing is ever wrong. |
+| Monthly Provider Cap | **$25 / provider / UTC month** | Spend Ledger (exact) | Per provider (Claude, OpenAI). Total-budget backstop. |
+| Per-IP rate | **30 / clock-hour** | KV (approximate) | Fairness throttle. Unchanged. |
+| Per-request output tokens | **300** | request option | Already enforced; sets the worst-case reservation. |
+
+## Domain Language
+
+Defined in `CONTEXT.md`: Spend Ledger, Reservation, Reconciliation, Daily
+Circuit Breaker, Monthly Provider Cap, Turnstile Gate, Fail Closed. Code, tests,
+commits, and UI copy use these terms.
+
+## Decisions (locked)
+
+These were resolved in a design review and are settled:
+
+1. Dollar ceilings must be **exact**, not approximate. (Rejected: KV + fuzzy
+   backstop.)
+2. Exactness is delivered by a **single global Durable Object** ledger.
+   (Rejected: per-IP sharded DOs — cannot enforce a global cap.)
+3. **Reserve-then-reconcile** is the mechanism; it errs safe (refuse early, never
+   overshoot).
+4. The ledger owns **all dollar ceilings** (global daily + per-provider monthly);
+   the **per-IP rate throttle stays loose on KV**.
+5. **Turnstile** is required on the chat endpoint.
+6. **Production fails closed; development fails open** (in-memory adapter).
+7. **Reservations self-expire** (default 60s TTL) to refund orphans.
+8. Built behind a **`SpendLedger` port** with DO and in-memory adapters; covered
+   by concurrency tests; emits observability events.
+9. Ceiling values per the table above; all env-configurable.
+10. **Turnstile cadence: first-message-per-session + session token.** Turnstile
+    runs in managed/invisible mode and is validated on the first message of a
+    session; on success the endpoint issues a short-lived signed session token
+    (30 min) so subsequent messages are not re-challenged. Safe because, even if
+    a token-holder scripts within their session, the exact Daily Circuit Breaker
+    still stops all spend at the cap. (Rejected: challenge every message — more
+    friction, marginal benefit once dollars are exact.)
+11. **Over-budget UX: graceful in-voice SSE message.** When a ceiling is hit the
+    endpoint returns a normal SSE message the chat window renders — the station
+    is "off the air until tomorrow" (daily) or "this channel is dark this month"
+    (monthly) — never a raw HTTP error. Keeps the retro-OS fiction intact.
+
+## User Stories
+
+1. As the site owner, I want configured dollar caps to be impossible to exceed,
+   so that no concurrency pattern can run up my LLM bill past the ceiling.
+2. As the site owner, I want a global daily spend breaker, so that the worst
+   possible day is a number I chose, not an open-ended risk.
+3. As the site owner, I want a request-count backstop independent of dollars, so
+   that a wrong price constant cannot defeat the dollar cap silently.
+4. As the site owner, I want automated traffic blocked by a proof-of-human gate,
+   so that scripted abuse never reaches the spend path.
+5. As the site owner, I want the system to refuse spend when the money authority
+   is unreachable, so that an outage can never mean unlimited spend.
+6. As a visitor, I want to chat normally after a quick, near-invisible human
+   check, so that protection does not turn into friction.
+7. As a visitor who arrives when a ceiling is hit, I want a clear in-character
+   "off the air" message, so that the site feels intentional rather than broken.
+8. As an engineer, I want the chat route to depend on a `SpendLedger` interface,
+   so that the money authority is swappable and testable without Workers.
+9. As an engineer, I want concurrency tests proving committed spend can never
+   exceed a ceiling, so that the core guarantee is regression-protected.
+10. As an operator, I want structured reserve/commit/refund/deny events, so that
+    I can watch the cap working and diagnose refusals.
+11. As a future maintainer, I want the design and its trade-offs recorded in an
+    ADR and glossary, so that the global-chokepoint choice is not a mystery.
+
+## Implementation Plan
+
+Sequenced so each step is independently reviewable. Tracer-bullet first: a thin
+end-to-end exact path before breadth.
+
+1. **Ledger port + in-memory adapter.** Define `SpendLedger`
+   (`reserve`/`commit`/`refund`/`status`), worst-case cost from `maxTokens` +
+   pricing, Reservation type with TTL. Full unit + concurrency tests against the
+   in-memory adapter (the invariant lives here).
+2. **Wire the chat route to the port.** Replace the `spend.ts` dollar checks with
+   reserve-before-stream / reconcile-after-stream against the injected ledger.
+   Keep the KV per-IP throttle. In-memory adapter in dev.
+3. **Durable Object adapter.** Implement the global-instance DO in
+   `terminal-reminder-agent`; expose RPC; add the `services` binding consumption
+   in the Pages app. Workers-pool test for the DO adapter.
+4. **Fail-closed wiring.** Production refuses on ledger-unreachable; dev uses
+   in-memory. Explicit test for the closed path.
+5. **Turnstile Gate.** Add the widget to the chat UI; validate the token
+   server-side before consulting the ledger; session-token issuance per the
+   confirmed cadence.
+6. **Daily Circuit Breaker + request-count backstop** in the ledger; over-budget
+   in-voice response.
+7. **Observability** events and a short dashboard/log note in `docs/`.
+8. **Retire** the superseded dollar logic in `spend.ts`; leave pricing intact.
+
+## Testing Decisions
+
+- ★ **Invariant test (highest value):** fire many concurrent `reserve` calls at a
+  near-full ceiling against the in-memory adapter; assert committed total never
+  exceeds the cap and that over-cap calls are refused.
+- **Reconciliation test:** reserved worst-case is replaced by actual; the
+  difference is refunded; ledger reflects true spend.
+- **Expiry test:** an un-reconciled reservation is refunded after its TTL.
+- **Fail-closed test:** an unreachable ledger yields refusal in the prod path.
+- **DO adapter test** via `@cloudflare/vitest-pool-workers` (already a dep).
+- **Turnstile test:** missing/invalid token is rejected before any spend path.
+- **Route test:** over-budget returns the graceful in-voice response, not a 500.
+
+## Observability
+
+The ledger emits one structured event per decision: `reserve`, `commit`,
+`refund`, `expire`, `deny` — with ceiling name, amounts (reserved/actual),
+remaining budget, and reason on denial. The reminder Worker already has
+`observability.enabled`; reuse it.
+
+## Out of Scope
+
+- Accounts / identity / cross-device anything.
+- Ledger sharding and high-scale throughput.
+- Reworking the per-IP throttle to be exact.
+- Any change to personas, schedule, or chat streaming beyond the gate and the
+  over-budget message.
+
+## References
+
+- ADR: `docs/adr/0005-exact-spend-enforcement.md`
+- Glossary: `CONTEXT.md` (Cost control)
+- Current code: `src/lib/server/spend.ts`, `src/lib/server/llm.ts`,
+  `src/routes/api/chat/+server.ts`
+- Existing DO Worker pattern: `workers/reminder-agent/`,
+  `src/lib/server/reminder-agent.ts`, root `wrangler.jsonc` (`services` binding)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,8 @@ export default [
 				PointerEvent: 'readonly',
 				DataTransfer: 'readonly',
 				DurableObjectNamespace: 'readonly',
+				DurableObjectState: 'readonly',
+				RequestInit: 'readonly',
 				EmailAddress: 'readonly',
 				EventSource: 'readonly',
 				ExportedHandler: 'readonly',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,6 +42,7 @@ export default [
 				DragEvent: 'readonly',
 				PointerEvent: 'readonly',
 				DataTransfer: 'readonly',
+				FormData: 'readonly',
 				DurableObjectNamespace: 'readonly',
 				DurableObjectState: 'readonly',
 				RequestInit: 'readonly',

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -7,6 +7,7 @@ declare global {
 				KV: KVNamespace;
 				REMINDER_SERVICE?: Fetcher;
 				SPEND_LEDGER?: Fetcher;
+				SPEND_LEDGER_REQUIRED?: string;
 				DAILY_SPEND_CAP_USD?: string;
 				DAILY_REQUEST_CAP?: string;
 				TURNSTILE_SECRET?: string;
@@ -22,6 +23,9 @@ declare global {
 				PROVIDER?: string;
 				MONTHLY_SPEND_CAP?: string;
 				MODEL?: string;
+			};
+			context?: {
+				waitUntil(promise: Promise<unknown>): void;
 			};
 		}
 	}

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,6 +9,7 @@ declare global {
 				SPEND_LEDGER?: Fetcher;
 				DAILY_SPEND_CAP_USD?: string;
 				DAILY_REQUEST_CAP?: string;
+				TURNSTILE_SECRET?: string;
 				REMINDER_SUBSCRIBE_RATE_LIMIT_PER_HOUR?: string;
 				ANTHROPIC_API_KEY?: string;
 				OPENAI_API_KEY?: string;

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -6,6 +6,9 @@ declare global {
 			env: {
 				KV: KVNamespace;
 				REMINDER_SERVICE?: Fetcher;
+				SPEND_LEDGER?: Fetcher;
+				DAILY_SPEND_CAP_USD?: string;
+				DAILY_REQUEST_CAP?: string;
 				REMINDER_SUBSCRIBE_RATE_LIMIT_PER_HOUR?: string;
 				ANTHROPIC_API_KEY?: string;
 				OPENAI_API_KEY?: string;

--- a/src/lib/components/ChatWindow.svelte
+++ b/src/lib/components/ChatWindow.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { ChatMessage, TextChunk } from '$lib/types';
-	import { loadConversations, saveConversation, getSessionId } from '$lib/persistence';
+	import {
+		loadConversations,
+		saveConversation,
+		getSessionId,
+		getChatSessionToken,
+		setChatSessionToken,
+		clearChatSessionToken
+	} from '$lib/persistence';
+	import { getTurnstileToken } from '$lib/turnstile-client';
 	import { formatTimeUntil, isShowOnAir, minutesUntilSlotEnd } from '$lib/schedule';
 	import { getAppContext } from '$lib/os/os-context';
 	import Dropdown from './Dropdown.svelte';
@@ -12,7 +20,7 @@
 	// window-id (`chat:<slug>` → ctx.window.args.slug). Everything else — the cast and
 	// the ticking on-air state — is derived off the live OS, so a window left
 	// open keeps counting down as os.now advances. No props bag ever freezes it.
-	const { os, window: appWindow } = getAppContext();
+	const { os, window: appWindow, turnstileSiteKey } = getAppContext();
 	const showSlug = appWindow.args.slug ?? '';
 
 	const group = $derived(os.groups.find((g) => g.slug === showSlug));
@@ -151,22 +159,42 @@
 		messages = [...messages, userMsg];
 
 		try {
-			const response = await fetch('/api/chat', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					botId: respondingBot.id,
-					messages: messages.slice(-20).map((m) => {
-						if (m.role === 'assistant') {
-							const { text: stripped } = parseResponder(m.content);
-							return { role: m.role, content: stripped };
-						}
-						return m;
-					}),
-					sessionId: getSessionId(),
-					timezone: os.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
-				})
-			});
+			const postChat = (turnstileToken: string | null, sessionToken: string | null) =>
+				fetch('/api/chat', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						botId: respondingBot.id,
+						messages: messages.slice(-20).map((m) => {
+							if (m.role === 'assistant') {
+								const { text: stripped } = parseResponder(m.content);
+								return { role: m.role, content: stripped };
+							}
+							return m;
+						}),
+						sessionId: getSessionId(),
+						timezone: os.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+						...(turnstileToken ? { turnstileToken } : {}),
+						...(sessionToken ? { sessionToken } : {})
+					})
+				});
+
+			// Turnstile Gate: reuse a stored session token, else solve a challenge.
+			const storedSession = getChatSessionToken();
+			let response = await postChat(
+				storedSession ? null : await getTurnstileToken(turnstileSiteKey),
+				storedSession
+			);
+
+			// 401 = no valid session (or it expired) → run the challenge once and retry.
+			if (response.status === 401) {
+				clearChatSessionToken();
+				response = await postChat(await getTurnstileToken(turnstileSiteKey), null);
+			}
+
+			// Persist any freshly minted session token so later messages skip the check.
+			const issuedSession = response.headers.get('X-Chat-Session');
+			if (issuedSession) setChatSessionToken(issuedSession);
 
 			if (!response.ok) {
 				const err = await response.text();

--- a/src/lib/components/Desktop.svelte
+++ b/src/lib/components/Desktop.svelte
@@ -47,6 +47,10 @@
 	// has no app-specific render branch — adding an app is a manifest entry only.
 	const isFlatWindow = (id: string) => matchWindow(id) !== null;
 
+	// Public Turnstile site key, read at the app edge (routes/+page.svelte) and
+	// handed to each WindowHost so the chat window can reach it via context.
+	let { turnstileSiteKey = '' }: { turnstileSiteKey?: string } = $props();
+
 	let booted = $state(false);
 	let os = $state<OsApiClass>(undefined!);
 	let terminalFs = $state<TerminalFS>(undefined!);
@@ -514,7 +518,7 @@
 						     render branches. The {:else} arm is unreachable for any live id
 						     (matchWindow gates isFlatWindow); it only catches a stale/unknown
 						     saved id that slipped past the restore filter. -->
-						<WindowHost win={w} {os} fs={terminalFs} />
+						<WindowHost win={w} {os} fs={terminalFs} {turnstileSiteKey} />
 					{:else}
 						<div class="window-content">
 							<p>Coming soon...</p>

--- a/src/lib/components/WindowHost.svelte
+++ b/src/lib/components/WindowHost.svelte
@@ -5,7 +5,12 @@
 	import { setAppContext, type WindowHandle } from '$lib/os/os-context';
 	import { resolveWindow } from '$lib/os/window-host';
 
-	let { win, os, fs }: { win: WindowState; os: OsApiClass; fs: TerminalFS } = $props();
+	let {
+		win,
+		os,
+		fs,
+		turnstileSiteKey = ''
+	}: { win: WindowState; os: OsApiClass; fs: TerminalFS; turnstileSiteKey?: string } = $props();
 
 	// win.id is the stable key for this window (the {#each} is keyed by it), but
 	// the window object is reassigned on focus/move/resize — so read through it
@@ -44,7 +49,10 @@
 			status: 'reserved'
 		},
 		capabilities: {},
-		lifecycle: {}
+		lifecycle: {},
+		get turnstileSiteKey() {
+			return turnstileSiteKey;
+		}
 	});
 </script>
 

--- a/src/lib/os/os-context.ts
+++ b/src/lib/os/os-context.ts
@@ -58,6 +58,12 @@ export type AppContext = {
 	storage: AppStorageHandle;
 	capabilities?: AppCapabilities;
 	lifecycle?: AppLifecycle;
+	/**
+	 * Public Turnstile site key, read once from `$env/dynamic/public` at the app
+	 * edge and threaded here so leaf windows (the chat) need no env import.
+	 * Empty/undefined → Turnstile not configured (dev); the chat gate is bypassed.
+	 */
+	turnstileSiteKey?: string;
 };
 
 /**

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -35,7 +35,8 @@ const KEYS = {
 	conversations: 'terminal.app.chatrbot.conversations',
 	timezone: 'terminal.os.timezone',
 	sessionId: 'terminal.os.session',
-	firstVisit: 'terminal.os.firstVisit'
+	firstVisit: 'terminal.os.firstVisit',
+	chatSessionToken: 'terminal.app.chatrbot.sessionToken'
 } as const;
 
 const LEGACY_KEYS: Record<string, string> = {
@@ -133,6 +134,23 @@ export function getSessionId(): string {
 	const id = crypto.randomUUID();
 	set(KEYS.sessionId, id);
 	return id;
+}
+
+/**
+ * The signed Turnstile session token (issued by /api/chat for ~30 min). Stored
+ * so subsequent messages — even across reloads — skip the human challenge. An
+ * expired token is harmless: the server rejects it and the client re-challenges.
+ */
+export function getChatSessionToken(): string | null {
+	return get<string | null>(KEYS.chatSessionToken, null) || null;
+}
+
+export function setChatSessionToken(token: string): void {
+	set(KEYS.chatSessionToken, token);
+}
+
+export function clearChatSessionToken(): void {
+	set(KEYS.chatSessionToken, '');
 }
 
 export function isFirstVisit(): boolean {

--- a/src/lib/server/email-composer.ts
+++ b/src/lib/server/email-composer.ts
@@ -1,25 +1,14 @@
 /**
  * Email composition and HMAC-signed unsubscribe helpers for reminder emails.
  */
-/* eslint-disable no-undef */
+import { signHmacBase64Url } from './hmac';
 
 // ---------------------------------------------------------------------------
 // HMAC helpers
 // ---------------------------------------------------------------------------
 
-const ALGO = { name: 'HMAC', hash: 'SHA-256' } as const;
 const TOKEN_BYTES = 24;
 const DOMAIN = 'bli.net';
-
-async function importKey(secret: string): Promise<CryptoKey> {
-	const enc = new TextEncoder();
-	return crypto.subtle.importKey('raw', enc.encode(secret), ALGO, false, ['sign', 'verify']);
-}
-
-function bytesToBase64Url(bytes: Uint8Array): string {
-	const bin = [...bytes].map((byte) => String.fromCharCode(byte)).join('');
-	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
 
 /**
  * Produce a compact deterministic token for email ownership flows.
@@ -28,10 +17,7 @@ function bytesToBase64Url(bytes: Uint8Array): string {
  * accepted again from email routing or confirmation links.
  */
 export async function createEmailActionToken(payload: string, secret: string): Promise<string> {
-	const key = await importKey(secret);
-	const enc = new TextEncoder();
-	const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload));
-	return bytesToBase64Url(new Uint8Array(sig).slice(0, TOKEN_BYTES));
+	return signHmacBase64Url(secret, payload, TOKEN_BYTES);
 }
 
 /**

--- a/src/lib/server/hmac.ts
+++ b/src/lib/server/hmac.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-undef */
+
+const ALGO = { name: 'HMAC', hash: 'SHA-256' } as const;
+const DEFAULT_TOKEN_BYTES = 24;
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+	const bin = [...bytes].map((byte) => String.fromCharCode(byte)).join('');
+	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+	const enc = new TextEncoder();
+	return crypto.subtle.importKey('raw', enc.encode(secret), ALGO, false, ['sign']);
+}
+
+export async function signHmacBase64Url(
+	secret: string,
+	payload: string,
+	bytes = DEFAULT_TOKEN_BYTES
+): Promise<string> {
+	const enc = new TextEncoder();
+	const key = await importHmacKey(secret);
+	const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload));
+	return bytesToBase64Url(new Uint8Array(sig).slice(0, bytes));
+}
+
+/** Constant-time compare of two equal-length strings. */
+export function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let mismatch = 0;
+	for (let i = 0; i < a.length; i += 1) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	return mismatch === 0;
+}

--- a/src/lib/server/llm.test.ts
+++ b/src/lib/server/llm.test.ts
@@ -1,8 +1,5 @@
-/// <reference types="@cloudflare/workers-types" />
-/* eslint-disable no-undef */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { TextChunk } from '$lib/types';
-import { monthlySpendKey } from './spend';
 
 // --- Anthropic mock ---
 const mockAnthropicMessagesStream = vi.fn();
@@ -46,35 +43,6 @@ async function collectChunks(stream: ReadableStream<TextChunk>): Promise<TextChu
 		if (value) chunks.push(value);
 	}
 	return chunks;
-}
-
-function createMockKV(initial?: Record<string, string>): KVNamespace {
-	const store = new Map(Object.entries(initial ?? {}));
-	return {
-		async get(key: string): Promise<string | null> {
-			return store.get(key) ?? null;
-		},
-		async put(key: string, value: string): Promise<void> {
-			store.set(key, value);
-		},
-		async delete(key: string): Promise<void> {
-			store.delete(key);
-		},
-		async list() {
-			return {
-				keys: [],
-				list_complete: true,
-				cacheStatus: null
-			} as unknown as KVNamespaceListResult<unknown, string>;
-		},
-		async getWithMetadata() {
-			return {
-				value: null,
-				metadata: null,
-				cacheStatus: null
-			} as unknown as KVNamespaceGetWithMetadataResult<string, unknown>;
-		}
-	} as unknown as KVNamespace;
 }
 
 describe('streamCompletion', () => {
@@ -275,7 +243,7 @@ describe('streamCompletion', () => {
 			expect(chunks).toHaveLength(1);
 			expect(chunks[0]).toEqual({
 				type: 'error',
-				error: 'All LLM providers are unavailable or over budget'
+				error: 'All LLM providers are unavailable'
 			});
 		});
 
@@ -535,40 +503,6 @@ describe('streamCompletion', () => {
 			]);
 		});
 
-		it('skips a provider that is over its monthly budget', async () => {
-			const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
-			mockAnthropicMessagesStream.mockReturnValue({
-				on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
-					if (!handlers[event]) handlers[event] = [];
-					handlers[event].push(handler);
-				})
-			});
-
-			const { streamCompletion } = await import('./llm');
-
-			const stream = await streamCompletion({
-				systemPrompt: 'Test',
-				messages: [{ role: 'user', content: 'Hi' }],
-				kv: createMockKV({ [monthlySpendKey('openai')]: '25' }),
-				providers: [
-					{ provider: 'openai', apiKey: 'openai-key', model: 'gpt-4o-mini', monthlyBudget: 25 },
-					{ provider: 'claude', apiKey: 'anthropic-key', model: 'claude-haiku-4-5-20251001' }
-				]
-			});
-			const chunksPromise = collectChunks(stream);
-
-			await new Promise((r) => setTimeout(r, 0));
-			for (const h of handlers['text'] ?? []) h('Budget fallback');
-			for (const h of handlers['finalMessage'] ?? [])
-				h({ usage: { input_tokens: 8, output_tokens: 3 } });
-			for (const h of handlers['end'] ?? []) h();
-
-			const chunks = await chunksPromise;
-			expect(mockOpenAIChatCompletionsCreate).not.toHaveBeenCalled();
-			expect(mockAnthropicMessagesStream).toHaveBeenCalled();
-			expect(chunks[0]).toEqual({ type: 'text', text: 'Budget fallback' });
-		});
-
 		it('keeps partial text, appends a notice, and retries once after mid-stream failure', async () => {
 			mockOpenAIChatCompletionsCreate.mockResolvedValue({
 				[Symbol.asyncIterator]: async function* () {
@@ -660,22 +594,21 @@ describe('streamCompletion', () => {
 			expect(chunks).toHaveLength(3);
 		});
 
-		it('returns a clean error when all providers are unavailable or over budget', async () => {
+		it('returns a clean error when every provider attempt fails with a transient error', async () => {
+			mockOpenAIChatCompletionsCreate.mockRejectedValue(
+				Object.assign(new Error('rate limit'), { status: 429 })
+			);
+
 			const { streamCompletion } = await import('./llm');
 
 			const stream = await streamCompletion({
 				systemPrompt: 'Test',
 				messages: [{ role: 'user', content: 'Hi' }],
-				kv: createMockKV({ [monthlySpendKey('openai')]: '25' }),
-				providers: [
-					{ provider: 'openai', apiKey: 'openai-key', model: 'gpt-4o-mini', monthlyBudget: 25 }
-				]
+				providers: [{ provider: 'openai', apiKey: 'openai-key', model: 'gpt-4o-mini' }]
 			});
 
 			const chunks = await collectChunks(stream);
-			expect(chunks).toEqual([
-				{ type: 'error', error: 'All LLM providers are unavailable or over budget' }
-			]);
+			expect(chunks).toEqual([{ type: 'error', error: 'All LLM providers are unavailable' }]);
 		});
 	});
 });

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -49,7 +49,7 @@ interface ProviderStreamParams {
 	};
 }
 
-function defaultModelFor(provider: LlmProvider): string {
+export function defaultModelFor(provider: LlmProvider): string {
 	return provider === 'openai' ? OPENAI_FALLBACK_MODEL : CLAUDE_FALLBACK_MODEL;
 }
 

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -1,11 +1,21 @@
 /* eslint-disable no-undef */
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
-import type { ChatMessage, LlmProvider, LlmTokenUsage, TextChunk } from '$lib/types';
+import {
+	LLM_PROVIDERS,
+	type ChatMessage,
+	type LlmProvider,
+	type LlmTokenUsage,
+	type TextChunk
+} from '$lib/types';
 import { getModelPricing } from './spend';
 
 const CLAUDE_FALLBACK_MODEL = 'claude-haiku-4-5-20251001';
 const OPENAI_FALLBACK_MODEL = 'gpt-4o-mini';
+const DEFAULT_MODELS: Record<LlmProvider, string> = {
+	claude: CLAUDE_FALLBACK_MODEL,
+	openai: OPENAI_FALLBACK_MODEL
+};
 const MID_STREAM_RETRY_NOTICE =
 	'\n\n[signal drops for a beat]\n\nOops, brain fart... let me try that again.\n\n';
 
@@ -47,7 +57,11 @@ interface ProviderStreamParams {
 }
 
 export function defaultModelFor(provider: LlmProvider): string {
-	return provider === 'openai' ? OPENAI_FALLBACK_MODEL : CLAUDE_FALLBACK_MODEL;
+	return DEFAULT_MODELS[provider];
+}
+
+export function isLlmProvider(value: string): value is LlmProvider {
+	return (LLM_PROVIDERS as readonly string[]).includes(value);
 }
 
 function isRetryableProviderError(err: unknown): boolean {
@@ -99,10 +113,12 @@ function usageOnlyChunk(usage: LlmTokenUsage): TextChunk {
 	};
 }
 
-function estimateTokens(text: string): number {
+function estimateTokens(text: string, maxTokens?: number): number {
 	const normalized = text.trim();
 	if (!normalized) return 0;
-	return Math.max(1, Math.ceil(normalized.length / 4));
+	const byteUpperBound = new TextEncoder().encode(normalized).length;
+	const capped = maxTokens === undefined ? byteUpperBound : Math.min(byteUpperBound, maxTokens);
+	return Math.max(1, capped);
 }
 
 function estimateFailedStreamUsage(
@@ -110,18 +126,30 @@ function estimateFailedStreamUsage(
 	attempt: ProviderAttempt,
 	outputText: string
 ): LlmTokenUsage | null {
-	const outputTokens = estimateTokens(outputText);
+	const outputTokens = estimateTokens(outputText, params.options?.maxTokens);
 	if (outputTokens === 0) return null;
 
 	const inputText = [
 		params.systemPrompt,
 		...params.messages.map((message) => `${message.role}: ${message.content}`)
 	].join('\n');
+	const inputTokens = estimateTokens(inputText);
+
+	if (attempt.provider === 'claude') {
+		return {
+			provider: attempt.provider,
+			model: attempt.model,
+			inputTokens: 0,
+			cacheCreationInputTokens: inputTokens,
+			outputTokens,
+			estimated: true
+		};
+	}
 
 	return {
 		provider: attempt.provider,
 		model: attempt.model,
-		inputTokens: estimateTokens(inputText),
+		inputTokens,
 		outputTokens,
 		estimated: true
 	};
@@ -360,10 +388,8 @@ export async function streamCompletion(
 
 	return new ReadableStream<TextChunk>({
 		async start(controller) {
-			// The Spend Ledger already chose the provider by budget, so this loop only
-			// handles transient provider errors: try the given attempts in order, and
-			// after partial output retry once on the next attempt (a no-op when the
-			// route passes a single admitted provider).
+			// The chat route only passes attempts that already have Spend Ledger holds,
+			// so this loop may fail over without opening an unreserved spend path.
 			for (let index = 0; index < attempts.length; index += 1) {
 				const result = await pipeProviderAttempt(controller, params, attempts[index], false);
 				if (result === 'success' || result === 'fatal-pre-token' || result === 'stop') {

--- a/src/lib/server/llm.ts
+++ b/src/lib/server/llm.ts
@@ -2,7 +2,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
 import type { ChatMessage, LlmProvider, LlmTokenUsage, TextChunk } from '$lib/types';
-import { getModelPricing, isProviderOverBudget } from './spend';
+import { getModelPricing } from './spend';
 
 const CLAUDE_FALLBACK_MODEL = 'claude-haiku-4-5-20251001';
 const OPENAI_FALLBACK_MODEL = 'gpt-4o-mini';
@@ -13,7 +13,6 @@ export interface LlmProviderConfig {
 	provider: LlmProvider;
 	apiKey: string;
 	model?: string;
-	monthlyBudget?: number;
 }
 
 export interface StreamCompletionParams {
@@ -27,14 +26,12 @@ export interface StreamCompletionParams {
 		model?: string;
 	};
 	apiKey?: string;
-	kv?: KVNamespace;
 }
 
 interface ProviderAttempt {
 	provider: LlmProvider;
 	model: string;
 	apiKey: string;
-	monthlyBudget?: number;
 }
 
 interface ProviderStreamParams {
@@ -297,28 +294,6 @@ function streamProviderCompletion(
 	return streamAnthropicCompletion(params);
 }
 
-async function isAttemptAvailable(
-	attempt: ProviderAttempt,
-	kv: KVNamespace | undefined
-): Promise<boolean> {
-	if (!kv || attempt.monthlyBudget === undefined) return true;
-	return !(await isProviderOverBudget(kv, attempt.provider, attempt.monthlyBudget));
-}
-
-async function nextAvailableAttempt(
-	attempts: ProviderAttempt[],
-	startIndex: number,
-	kv: KVNamespace | undefined
-): Promise<{ attempt: ProviderAttempt; index: number } | null> {
-	for (let i = startIndex; i < attempts.length; i += 1) {
-		const attempt = attempts[i];
-		if (await isAttemptAvailable(attempt, kv)) {
-			return { attempt, index: i };
-		}
-	}
-	return null;
-}
-
 type PipeResult = 'success' | 'retry-pre-token' | 'fatal-pre-token' | 'retry-mid-stream' | 'stop';
 
 async function pipeProviderAttempt(
@@ -385,20 +360,12 @@ export async function streamCompletion(
 
 	return new ReadableStream<TextChunk>({
 		async start(controller) {
-			let nextIndex = 0;
-
-			while (true) {
-				const next = await nextAvailableAttempt(attempts, nextIndex, params.kv);
-				if (!next) {
-					controller.enqueue({
-						type: 'error',
-						error: 'All LLM providers are unavailable or over budget'
-					});
-					controller.close();
-					return;
-				}
-
-				const result = await pipeProviderAttempt(controller, params, next.attempt, false);
+			// The Spend Ledger already chose the provider by budget, so this loop only
+			// handles transient provider errors: try the given attempts in order, and
+			// after partial output retry once on the next attempt (a no-op when the
+			// route passes a single admitted provider).
+			for (let index = 0; index < attempts.length; index += 1) {
+				const result = await pipeProviderAttempt(controller, params, attempts[index], false);
 				if (result === 'success' || result === 'fatal-pre-token' || result === 'stop') {
 					controller.close();
 					return;
@@ -406,16 +373,18 @@ export async function streamCompletion(
 
 				if (result === 'retry-mid-stream') {
 					controller.enqueue({ type: 'text', text: MID_STREAM_RETRY_NOTICE });
-					const retry = await nextAvailableAttempt(attempts, next.index + 1, params.kv);
+					const retry = attempts[index + 1];
 					if (retry) {
-						await pipeProviderAttempt(controller, params, retry.attempt, true);
+						await pipeProviderAttempt(controller, params, retry, true);
 					}
 					controller.close();
 					return;
 				}
-
-				nextIndex = next.index + 1;
+				// result === 'retry-pre-token' → fall through to the next attempt.
 			}
+
+			controller.enqueue({ type: 'error', error: 'All LLM providers are unavailable' });
+			controller.close();
 		}
 	});
 }

--- a/src/lib/server/spend-ledger/config.ts
+++ b/src/lib/server/spend-ledger/config.ts
@@ -1,4 +1,5 @@
-import type { LedgerCeilings } from './types';
+import { LLM_PROVIDERS, type LlmProvider } from '$lib/types';
+import type { LedgerCeilings, MonthlyProviderCaps } from './types';
 
 /**
  * Ceiling configuration for the Spend Ledger. Lives in its own module so both
@@ -22,6 +23,11 @@ export interface CeilingEnv {
 	OPENAI_MONTHLY_SPEND_CAP?: string;
 }
 
+const MONTHLY_CAP_ENV: Record<LlmProvider, keyof CeilingEnv> = {
+	claude: 'ANTHROPIC_MONTHLY_SPEND_CAP',
+	openai: 'OPENAI_MONTHLY_SPEND_CAP'
+};
+
 function positiveNumber(raw: string | undefined, fallback: number): number {
 	if (raw === undefined || raw.trim() === '') return fallback;
 	const value = Number(raw);
@@ -30,18 +36,16 @@ function positiveNumber(raw: string | undefined, fallback: number): number {
 
 /** Build ceilings from environment variables, falling back to the defaults. */
 export function resolveCeilings(env: CeilingEnv): LedgerCeilings {
+	const monthlyProviderUsd = Object.fromEntries(
+		LLM_PROVIDERS.map((provider) => [
+			provider,
+			positiveNumber(env[MONTHLY_CAP_ENV[provider]], DEFAULT_CEILINGS.monthlyProviderUsd[provider])
+		])
+	) as MonthlyProviderCaps;
+
 	return {
 		dailySpendUsd: positiveNumber(env.DAILY_SPEND_CAP_USD, DEFAULT_CEILINGS.dailySpendUsd),
 		dailyRequests: positiveNumber(env.DAILY_REQUEST_CAP, DEFAULT_CEILINGS.dailyRequests),
-		monthlyProviderUsd: {
-			claude: positiveNumber(
-				env.ANTHROPIC_MONTHLY_SPEND_CAP,
-				DEFAULT_CEILINGS.monthlyProviderUsd.claude
-			),
-			openai: positiveNumber(
-				env.OPENAI_MONTHLY_SPEND_CAP,
-				DEFAULT_CEILINGS.monthlyProviderUsd.openai
-			)
-		}
+		monthlyProviderUsd
 	};
 }

--- a/src/lib/server/spend-ledger/config.ts
+++ b/src/lib/server/spend-ledger/config.ts
@@ -1,0 +1,47 @@
+import type { LedgerCeilings } from './types';
+
+/**
+ * Ceiling configuration for the Spend Ledger. Lives in its own module so both
+ * the public barrel (`index.ts`) and the adapter factory (`factory.ts`) can read
+ * it without an import cycle.
+ */
+
+/** Defaults match docs/prd/cost-abuse-hardening.md. */
+export const DEFAULT_CEILINGS: LedgerCeilings = {
+	dailySpendUsd: 3,
+	dailyRequests: 5000,
+	monthlyProviderUsd: { claude: 25, openai: 25 }
+};
+
+export const DEFAULT_RESERVATION_TTL_MS = 60_000;
+
+export interface CeilingEnv {
+	DAILY_SPEND_CAP_USD?: string;
+	DAILY_REQUEST_CAP?: string;
+	ANTHROPIC_MONTHLY_SPEND_CAP?: string;
+	OPENAI_MONTHLY_SPEND_CAP?: string;
+}
+
+function positiveNumber(raw: string | undefined, fallback: number): number {
+	if (raw === undefined || raw.trim() === '') return fallback;
+	const value = Number(raw);
+	return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+/** Build ceilings from environment variables, falling back to the defaults. */
+export function resolveCeilings(env: CeilingEnv): LedgerCeilings {
+	return {
+		dailySpendUsd: positiveNumber(env.DAILY_SPEND_CAP_USD, DEFAULT_CEILINGS.dailySpendUsd),
+		dailyRequests: positiveNumber(env.DAILY_REQUEST_CAP, DEFAULT_CEILINGS.dailyRequests),
+		monthlyProviderUsd: {
+			claude: positiveNumber(
+				env.ANTHROPIC_MONTHLY_SPEND_CAP,
+				DEFAULT_CEILINGS.monthlyProviderUsd.claude
+			),
+			openai: positiveNumber(
+				env.OPENAI_MONTHLY_SPEND_CAP,
+				DEFAULT_CEILINGS.monthlyProviderUsd.openai
+			)
+		}
+	};
+}

--- a/src/lib/server/spend-ledger/cost.ts
+++ b/src/lib/server/spend-ledger/cost.ts
@@ -8,8 +8,9 @@ import { calculateTokenCostUsd, getModelPricing } from '../spend';
 
 /**
  * Upper-bound dollar cost for a request before it runs. Prices every input and
- * output token at full (non-cached) rate so the reservation can never be too
- * small. Throws on an unknown model — spend must never silently under-reserve.
+ * output token at the most expensive configured input/cache rate so the
+ * reservation can never be too small, including Anthropic prompt-cache writes.
+ * Throws on an unknown model — spend must never silently under-reserve.
  */
 export function worstCaseCostUsd(
 	model: string,
@@ -17,8 +18,14 @@ export function worstCaseCostUsd(
 	maxOutputTokens: number
 ): number {
 	const pricing = getModelPricing(model);
+	const maxInputUnitPrice = Math.max(
+		pricing.input,
+		pricing.cacheCreationInput ?? pricing.input * 1.25,
+		pricing.cacheReadInput ?? pricing.input
+	);
 	return (
-		(maxInputTokens * pricing.input) / 1_000_000 + (maxOutputTokens * pricing.output) / 1_000_000
+		(maxInputTokens * maxInputUnitPrice) / 1_000_000 +
+		(maxOutputTokens * pricing.output) / 1_000_000
 	);
 }
 

--- a/src/lib/server/spend-ledger/cost.ts
+++ b/src/lib/server/spend-ledger/cost.ts
@@ -1,0 +1,28 @@
+import type { LlmTokenUsage } from '$lib/types';
+import { calculateTokenCostUsd, getModelPricing } from '../spend';
+
+/**
+ * Cost helpers for the Spend Ledger. Reuses the canonical pricing table in
+ * `spend.ts` so there is exactly one source of truth for model prices.
+ */
+
+/**
+ * Upper-bound dollar cost for a request before it runs. Prices every input and
+ * output token at full (non-cached) rate so the reservation can never be too
+ * small. Throws on an unknown model — spend must never silently under-reserve.
+ */
+export function worstCaseCostUsd(
+	model: string,
+	maxInputTokens: number,
+	maxOutputTokens: number
+): number {
+	const pricing = getModelPricing(model);
+	return (
+		(maxInputTokens * pricing.input) / 1_000_000 + (maxOutputTokens * pricing.output) / 1_000_000
+	);
+}
+
+/** Actual settled dollar cost from real token usage (cache-aware). */
+export function actualCostUsd(usage: LlmTokenUsage): number {
+	return calculateTokenCostUsd(usage);
+}

--- a/src/lib/server/spend-ledger/do-adapter.test.ts
+++ b/src/lib/server/spend-ledger/do-adapter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DurableObjectSpendLedger, SPEND_LEDGER_ROUTES } from './do-adapter';
+
+// The adapter is a thin RPC client over a service binding, so the tests pin the
+// wire contract: the right path, epoch-ms time, the request echoed through, and
+// a non-2xx reply surfacing as a throw (the hook the factory turns into a
+// fail-closed denial in step 4).
+function fetcherReturning(response: Response) {
+	const fetch = vi.fn(async () => response);
+	return { fetch: { fetch } as unknown as Fetcher, spy: fetch };
+}
+
+describe('DurableObjectSpendLedger', () => {
+	it('posts reserve with epoch-ms time and returns the ledger result', async () => {
+		const { fetch, spy } = fetcherReturning(
+			Response.json({
+				ok: true,
+				reservationId: 'r1',
+				provider: 'openai',
+				model: 'gpt-4o-mini',
+				reservedUsd: 0.05,
+				expiresAt: 123
+			})
+		);
+		const ledger = new DurableObjectSpendLedger(fetch);
+		const now = new Date('2026-01-04T10:00:00Z');
+
+		const result = await ledger.reserve(
+			{
+				candidates: [{ provider: 'openai', model: 'gpt-4o-mini' }],
+				maxInputTokens: 100,
+				maxOutputTokens: 300
+			},
+			now
+		);
+
+		expect(result).toMatchObject({ ok: true, reservationId: 'r1', provider: 'openai' });
+		const [url, init] = spy.mock.calls[0] as unknown as [string, RequestInit];
+		expect(String(url)).toContain(SPEND_LEDGER_ROUTES.reserve);
+		const body = JSON.parse(String(init.body));
+		expect(body.nowMs).toBe(now.getTime());
+		expect(body.req.maxOutputTokens).toBe(300);
+	});
+
+	it('sends reservationId + actual cost on reconcile', async () => {
+		const { fetch, spy } = fetcherReturning(Response.json({ ok: true }));
+		const ledger = new DurableObjectSpendLedger(fetch);
+
+		await ledger.reconcile(
+			'r1',
+			{ provider: 'openai', usd: 0.02 },
+			new Date('2026-01-04T10:00:00Z')
+		);
+
+		const [url, init] = spy.mock.calls[0] as unknown as [string, RequestInit];
+		expect(String(url)).toContain(SPEND_LEDGER_ROUTES.reconcile);
+		const body = JSON.parse(String(init.body));
+		expect(body).toMatchObject({ reservationId: 'r1', actual: { provider: 'openai', usd: 0.02 } });
+	});
+
+	it('throws when the ledger replies non-2xx (basis for fail-closed)', async () => {
+		const { fetch } = fetcherReturning(new Response('nope', { status: 503 }));
+		const ledger = new DurableObjectSpendLedger(fetch);
+
+		await expect(ledger.status(new Date())).rejects.toThrow(/failed: 503/);
+	});
+});

--- a/src/lib/server/spend-ledger/do-adapter.test.ts
+++ b/src/lib/server/spend-ledger/do-adapter.test.ts
@@ -19,7 +19,16 @@ describe('DurableObjectSpendLedger', () => {
 				provider: 'openai',
 				model: 'gpt-4o-mini',
 				reservedUsd: 0.05,
-				expiresAt: 123
+				expiresAt: 123,
+				reservations: [
+					{
+						reservationId: 'r1',
+						provider: 'openai',
+						model: 'gpt-4o-mini',
+						reservedUsd: 0.05,
+						expiresAt: 123
+					}
+				]
 			})
 		);
 		const ledger = new DurableObjectSpendLedger(fetch);

--- a/src/lib/server/spend-ledger/do-adapter.ts
+++ b/src/lib/server/spend-ledger/do-adapter.ts
@@ -1,0 +1,71 @@
+import type {
+	LedgerStatus,
+	ReconcileInput,
+	ReserveRequest,
+	ReserveResult,
+	SpendLedger
+} from './types';
+
+/**
+ * Production `SpendLedger` adapter. Implements the port by calling the global
+ * `SpendLedgerDO` over a Worker `services` binding (a `Fetcher`), mirroring how
+ * the Pages app already reaches `ReminderAgent` via `REMINDER_SERVICE`.
+ *
+ * It holds no rules — it serializes the call, hands off to the DO (where the
+ * exact accounting lives), and parses the reply. A non-2xx reply throws; the
+ * factory wraps that into a fail-closed *denial* in production (step 4), so an
+ * unreachable money authority can never mean unlimited spend.
+ */
+
+/** Wire endpoints, shared with the Worker router so the two can't drift. */
+export const SPEND_LEDGER_ROUTES = {
+	reserve: '/ledger/reserve',
+	reconcile: '/ledger/reconcile',
+	release: '/ledger/release',
+	status: '/ledger/status'
+} as const;
+
+// The host is irrelevant over a service binding; it just has to be a valid URL.
+const BASE = 'https://spend-ledger.internal';
+
+export class DurableObjectSpendLedger implements SpendLedger {
+	constructor(private readonly service: Fetcher) {}
+
+	private async call<T>(path: string, payload: unknown): Promise<T> {
+		const response = await this.service.fetch(`${BASE}${path}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(payload)
+		});
+		if (!response.ok) {
+			throw new Error(`Spend ledger ${path} failed: ${response.status}`);
+		}
+		return (await response.json()) as T;
+	}
+
+	reserve(req: ReserveRequest, now: Date): Promise<ReserveResult> {
+		return this.call<ReserveResult>(SPEND_LEDGER_ROUTES.reserve, {
+			req,
+			nowMs: now.getTime()
+		});
+	}
+
+	async reconcile(reservationId: string, actual: ReconcileInput, now: Date): Promise<void> {
+		await this.call<{ ok: true }>(SPEND_LEDGER_ROUTES.reconcile, {
+			reservationId,
+			actual,
+			nowMs: now.getTime()
+		});
+	}
+
+	async release(reservationId: string, now: Date): Promise<void> {
+		await this.call<{ ok: true }>(SPEND_LEDGER_ROUTES.release, {
+			reservationId,
+			nowMs: now.getTime()
+		});
+	}
+
+	status(now: Date): Promise<LedgerStatus> {
+		return this.call<LedgerStatus>(SPEND_LEDGER_ROUTES.status, { nowMs: now.getTime() });
+	}
+}

--- a/src/lib/server/spend-ledger/do-ledger.ts
+++ b/src/lib/server/spend-ledger/do-ledger.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from 'cloudflare:workers';
 import { LedgerCore, type LedgerState } from './ledger-core';
 import { resolveCeilings, DEFAULT_RESERVATION_TTL_MS, type CeilingEnv } from './config';
+import { logLedgerEvent } from './observability';
 import type { LedgerStatus, ReconcileInput, ReserveRequest, ReserveResult } from './types';
 
 /**
@@ -35,7 +36,9 @@ export class SpendLedgerDO extends DurableObject<SpendLedgerDOEnv> {
 			this.core = new LedgerCore({
 				ceilings: resolveCeilings(env),
 				reservationTtlMs: DEFAULT_RESERVATION_TTL_MS,
-				state
+				state,
+				// Production observability — captured by the Worker's `observability`.
+				emit: logLedgerEvent
 			});
 		});
 	}

--- a/src/lib/server/spend-ledger/do-ledger.ts
+++ b/src/lib/server/spend-ledger/do-ledger.ts
@@ -59,8 +59,7 @@ export class SpendLedgerDO extends DurableObject<SpendLedgerDOEnv> {
 	}
 
 	async release(reservationId: string, nowMs: number): Promise<void> {
-		void nowMs;
-		this.core.release(reservationId);
+		this.core.release(reservationId, new Date(nowMs));
 		await this.persist();
 	}
 

--- a/src/lib/server/spend-ledger/do-ledger.ts
+++ b/src/lib/server/spend-ledger/do-ledger.ts
@@ -1,0 +1,67 @@
+import { DurableObject } from 'cloudflare:workers';
+import { LedgerCore, type LedgerState } from './ledger-core';
+import { resolveCeilings, DEFAULT_RESERVATION_TTL_MS, type CeilingEnv } from './config';
+import type { LedgerStatus, ReconcileInput, ReserveRequest, ReserveResult } from './types';
+
+/**
+ * The single global Spend Ledger, as a Durable Object.
+ *
+ * One instance (`idFromName('global')`) serializes every chat request through a
+ * single authority, which is what makes the dollar ceilings *exact* — concurrent
+ * requests can't race a counter the way they could on KV. The DO owns no rules
+ * of its own: it delegates to the pure `LedgerCore` and persists the core's
+ * snapshot after each mutation so state survives eviction.
+ *
+ * This file imports `cloudflare:workers`, so it is only ever loaded inside the
+ * Worker runtime (the reminder Worker re-exports it). The Pages app talks to it
+ * through the HTTP adapter in `do-adapter.ts`, never by importing this class.
+ *
+ * Time crosses the wire as epoch milliseconds (`nowMs`) rather than `Date`, so
+ * the contract is explicit and JSON-safe.
+ */
+
+const STORAGE_KEY = 'ledger';
+
+export type SpendLedgerDOEnv = CeilingEnv;
+
+export class SpendLedgerDO extends DurableObject<SpendLedgerDOEnv> {
+	private core!: LedgerCore;
+
+	constructor(ctx: DurableObjectState, env: SpendLedgerDOEnv) {
+		super(ctx, env);
+		// Restore committed totals + live reservations before any request runs.
+		ctx.blockConcurrencyWhile(async () => {
+			const state = await ctx.storage.get<LedgerState>(STORAGE_KEY);
+			this.core = new LedgerCore({
+				ceilings: resolveCeilings(env),
+				reservationTtlMs: DEFAULT_RESERVATION_TTL_MS,
+				state
+			});
+		});
+	}
+
+	private persist(): Promise<void> {
+		return this.ctx.storage.put(STORAGE_KEY, this.core.snapshot());
+	}
+
+	async reserve(req: ReserveRequest, nowMs: number): Promise<ReserveResult> {
+		const result = this.core.reserve(req, new Date(nowMs));
+		await this.persist();
+		return result;
+	}
+
+	async reconcile(reservationId: string, actual: ReconcileInput, nowMs: number): Promise<void> {
+		this.core.reconcile(reservationId, actual, new Date(nowMs));
+		await this.persist();
+	}
+
+	async release(reservationId: string, nowMs: number): Promise<void> {
+		void nowMs;
+		this.core.release(reservationId);
+		await this.persist();
+	}
+
+	async status(nowMs: number): Promise<LedgerStatus> {
+		return this.core.status(new Date(nowMs));
+	}
+}

--- a/src/lib/server/spend-ledger/factory.test.ts
+++ b/src/lib/server/spend-ledger/factory.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { getSpendLedger } from './factory';
+
+const REQUEST = {
+	candidates: [{ provider: 'openai' as const, model: 'gpt-4o-mini' }],
+	maxInputTokens: 100,
+	maxOutputTokens: 300
+};
+
+describe('getSpendLedger', () => {
+	it('fails closed in production: an unreachable SPEND_LEDGER binding denies the reserve', async () => {
+		const service = {
+			fetch: vi.fn(async () => new Response('down', { status: 503 }))
+		} as unknown as Fetcher;
+
+		const ledger = getSpendLedger({ SPEND_LEDGER: service });
+		const result = await ledger.reserve(REQUEST, new Date('2026-06-11T12:00:00Z'));
+
+		expect(service.fetch).toHaveBeenCalled();
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toBe('ledger-unavailable');
+	});
+
+	it('uses the in-memory adapter when no binding is present (dev fails open)', async () => {
+		const ledger = getSpendLedger({});
+		const result = await ledger.reserve(REQUEST, new Date('2026-06-11T12:00:00Z'));
+
+		// No external authority to be unreachable — a normal request is admitted.
+		expect(result.ok).toBe(true);
+	});
+});

--- a/src/lib/server/spend-ledger/factory.test.ts
+++ b/src/lib/server/spend-ledger/factory.test.ts
@@ -28,4 +28,12 @@ describe('getSpendLedger', () => {
 		// No external authority to be unreachable — a normal request is admitted.
 		expect(result.ok).toBe(true);
 	});
+
+	it('fails closed when the binding is required but absent', async () => {
+		const ledger = getSpendLedger({ SPEND_LEDGER_REQUIRED: 'true' });
+		const result = await ledger.reserve(REQUEST, new Date('2026-06-11T12:00:00Z'));
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toBe('ledger-unavailable');
+	});
 });

--- a/src/lib/server/spend-ledger/factory.ts
+++ b/src/lib/server/spend-ledger/factory.ts
@@ -2,30 +2,69 @@ import { InMemorySpendLedger } from './in-memory-ledger';
 import { DurableObjectSpendLedger } from './do-adapter';
 import { FailClosedSpendLedger } from './fail-closed-ledger';
 import { resolveCeilings, DEFAULT_RESERVATION_TTL_MS, type CeilingEnv } from './config';
-import type { SpendLedger } from './types';
+import type {
+	LedgerStatus,
+	ReconcileInput,
+	ReserveRequest,
+	ReserveResult,
+	SpendLedger
+} from './types';
 
 /**
  * Chooses which `SpendLedger` adapter the chat route gets. The route depends
  * only on the port, so it never knows which one it holds.
  *
- * - **Production** — the `SPEND_LEDGER` service binding is present, so use the
- *   exact Durable-Object ledger, wrapped to **fail closed**: if the money
- *   authority is unreachable, requests are denied, never permitted (ADR 0005).
- * - **Development / tests** — no binding, so use the in-memory adapter. It has
- *   no deployed dependency, which makes dev trivially **fail open**.
+ * - **Production** — the `SPEND_LEDGER` service binding is required. If it is
+ *   present, use the exact Durable-Object ledger wrapped to **fail closed**; if
+ *   it is missing or unreachable, requests are denied, never permitted (ADR 0005).
+ * - **Development / tests** — no binding may fall back to the in-memory adapter.
+ *   It has no deployed dependency, which makes dev trivially **fail open**.
  */
 
 export interface SpendLedgerEnv extends CeilingEnv {
 	/** RPC service binding to the Worker that hosts the global SpendLedgerDO. */
 	SPEND_LEDGER?: Fetcher;
+	/** Test/deploy override: true means a missing SPEND_LEDGER binding must deny. */
+	SPEND_LEDGER_REQUIRED?: string;
 }
 
 // One in-memory ledger per isolate so concurrent dev requests share state.
 let devLedger: InMemorySpendLedger | undefined;
 
+class MissingSpendLedgerBinding implements SpendLedger {
+	private fail(): never {
+		throw new Error('SPEND_LEDGER service binding is required but missing');
+	}
+
+	reserve(_req: ReserveRequest, _now: Date): Promise<ReserveResult> {
+		this.fail();
+	}
+
+	reconcile(_reservationId: string, _actual: ReconcileInput, _now: Date): Promise<void> {
+		this.fail();
+	}
+
+	release(_reservationId: string, _now: Date): Promise<void> {
+		this.fail();
+	}
+
+	status(_now: Date): Promise<LedgerStatus> {
+		this.fail();
+	}
+}
+
+function allowsInMemoryFallback(env: SpendLedgerEnv): boolean {
+	if (env.SPEND_LEDGER_REQUIRED === 'true') return false;
+	return import.meta.env.DEV || import.meta.env.MODE === 'test';
+}
+
 export function getSpendLedger(env: SpendLedgerEnv): SpendLedger {
 	if (env.SPEND_LEDGER) {
 		return new FailClosedSpendLedger(new DurableObjectSpendLedger(env.SPEND_LEDGER));
+	}
+
+	if (!allowsInMemoryFallback(env)) {
+		return new FailClosedSpendLedger(new MissingSpendLedgerBinding());
 	}
 
 	if (!devLedger) {

--- a/src/lib/server/spend-ledger/factory.ts
+++ b/src/lib/server/spend-ledger/factory.ts
@@ -1,0 +1,32 @@
+import { InMemorySpendLedger } from './in-memory-ledger';
+import { resolveCeilings, DEFAULT_RESERVATION_TTL_MS, type CeilingEnv } from './config';
+import type { SpendLedger } from './types';
+
+/**
+ * Chooses which `SpendLedger` adapter the chat route gets.
+ *
+ * Production binds the single global Durable Object (exact, fails closed); dev
+ * and tests get the in-memory adapter (fails open, no deployed dependency). The
+ * route depends only on the port, so it never knows which one it holds.
+ *
+ * The DO branch is added in step 4 (fail-closed wiring); step 2 wires the
+ * in-memory path end to end first.
+ */
+
+export interface SpendLedgerEnv extends CeilingEnv {
+	/** RPC binding to the `terminal-spend-ledger` Worker; present only in prod. */
+	SPEND_LEDGER?: Fetcher;
+}
+
+// One in-memory ledger per isolate so concurrent dev requests share state.
+let devLedger: InMemorySpendLedger | undefined;
+
+export function getSpendLedger(env: SpendLedgerEnv): SpendLedger {
+	if (!devLedger) {
+		devLedger = new InMemorySpendLedger({
+			ceilings: resolveCeilings(env),
+			reservationTtlMs: DEFAULT_RESERVATION_TTL_MS
+		});
+	}
+	return devLedger;
+}

--- a/src/lib/server/spend-ledger/factory.ts
+++ b/src/lib/server/spend-ledger/factory.ts
@@ -1,20 +1,22 @@
 import { InMemorySpendLedger } from './in-memory-ledger';
+import { DurableObjectSpendLedger } from './do-adapter';
+import { FailClosedSpendLedger } from './fail-closed-ledger';
 import { resolveCeilings, DEFAULT_RESERVATION_TTL_MS, type CeilingEnv } from './config';
 import type { SpendLedger } from './types';
 
 /**
- * Chooses which `SpendLedger` adapter the chat route gets.
+ * Chooses which `SpendLedger` adapter the chat route gets. The route depends
+ * only on the port, so it never knows which one it holds.
  *
- * Production binds the single global Durable Object (exact, fails closed); dev
- * and tests get the in-memory adapter (fails open, no deployed dependency). The
- * route depends only on the port, so it never knows which one it holds.
- *
- * The DO branch is added in step 4 (fail-closed wiring); step 2 wires the
- * in-memory path end to end first.
+ * - **Production** — the `SPEND_LEDGER` service binding is present, so use the
+ *   exact Durable-Object ledger, wrapped to **fail closed**: if the money
+ *   authority is unreachable, requests are denied, never permitted (ADR 0005).
+ * - **Development / tests** — no binding, so use the in-memory adapter. It has
+ *   no deployed dependency, which makes dev trivially **fail open**.
  */
 
 export interface SpendLedgerEnv extends CeilingEnv {
-	/** RPC binding to the `terminal-spend-ledger` Worker; present only in prod. */
+	/** RPC service binding to the Worker that hosts the global SpendLedgerDO. */
 	SPEND_LEDGER?: Fetcher;
 }
 
@@ -22,6 +24,10 @@ export interface SpendLedgerEnv extends CeilingEnv {
 let devLedger: InMemorySpendLedger | undefined;
 
 export function getSpendLedger(env: SpendLedgerEnv): SpendLedger {
+	if (env.SPEND_LEDGER) {
+		return new FailClosedSpendLedger(new DurableObjectSpendLedger(env.SPEND_LEDGER));
+	}
+
 	if (!devLedger) {
 		devLedger = new InMemorySpendLedger({
 			ceilings: resolveCeilings(env),

--- a/src/lib/server/spend-ledger/fail-closed-ledger.test.ts
+++ b/src/lib/server/spend-ledger/fail-closed-ledger.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FailClosedSpendLedger } from './fail-closed-ledger';
+import type { ReserveResult, SpendLedger } from './types';
+
+const OK_RESERVE: ReserveResult = {
+	ok: true,
+	reservationId: 'r1',
+	provider: 'openai',
+	model: 'gpt-4o-mini',
+	reservedUsd: 0.05,
+	expiresAt: 1_000
+};
+
+const REQUEST = {
+	candidates: [{ provider: 'openai' as const, model: 'gpt-4o-mini' }],
+	maxInputTokens: 100,
+	maxOutputTokens: 300
+};
+
+function innerLedger(overrides: Partial<SpendLedger>): SpendLedger {
+	return {
+		reserve: vi.fn(),
+		reconcile: vi.fn(),
+		release: vi.fn(),
+		status: vi.fn(),
+		...overrides
+	} as SpendLedger;
+}
+
+describe('FailClosedSpendLedger', () => {
+	it('passes a successful reservation straight through', async () => {
+		const ledger = new FailClosedSpendLedger(
+			innerLedger({ reserve: vi.fn().mockResolvedValue(OK_RESERVE) })
+		);
+
+		await expect(ledger.reserve(REQUEST, new Date())).resolves.toEqual(OK_RESERVE);
+	});
+
+	it('denies with ledger-unavailable when the inner reserve throws', async () => {
+		const ledger = new FailClosedSpendLedger(
+			innerLedger({ reserve: vi.fn().mockRejectedValue(new Error('unreachable')) })
+		);
+
+		const result = await ledger.reserve(REQUEST, new Date());
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.reason).toBe('ledger-unavailable');
+	});
+
+	it('swallows reconcile failures (the hold self-expires)', async () => {
+		const ledger = new FailClosedSpendLedger(
+			innerLedger({ reconcile: vi.fn().mockRejectedValue(new Error('write failed')) })
+		);
+
+		await expect(
+			ledger.reconcile('r1', { provider: 'openai', usd: 0.01 }, new Date())
+		).resolves.toBeUndefined();
+	});
+
+	it('swallows release failures (the hold self-expires)', async () => {
+		const ledger = new FailClosedSpendLedger(
+			innerLedger({ release: vi.fn().mockRejectedValue(new Error('write failed')) })
+		);
+
+		await expect(ledger.release('r1', new Date())).resolves.toBeUndefined();
+	});
+});

--- a/src/lib/server/spend-ledger/fail-closed-ledger.test.ts
+++ b/src/lib/server/spend-ledger/fail-closed-ledger.test.ts
@@ -8,7 +8,16 @@ const OK_RESERVE: ReserveResult = {
 	provider: 'openai',
 	model: 'gpt-4o-mini',
 	reservedUsd: 0.05,
-	expiresAt: 1_000
+	expiresAt: 1_000,
+	reservations: [
+		{
+			reservationId: 'r1',
+			provider: 'openai',
+			model: 'gpt-4o-mini',
+			reservedUsd: 0.05,
+			expiresAt: 1_000
+		}
+	]
 };
 
 const REQUEST = {

--- a/src/lib/server/spend-ledger/fail-closed-ledger.ts
+++ b/src/lib/server/spend-ledger/fail-closed-ledger.ts
@@ -1,0 +1,58 @@
+import type {
+	LedgerStatus,
+	ReconcileInput,
+	ReserveRequest,
+	ReserveResult,
+	SpendLedger
+} from './types';
+
+/**
+ * Fail-closed decorator around a `SpendLedger`.
+ *
+ * If the underlying ledger — in production, the global Durable Object reached
+ * over a service binding — is unreachable, a *reserve* is denied: no money
+ * authority means no budget, so an outage can never turn into unlimited spend
+ * (docs/adr/0005). That is the whole point of "fail closed".
+ *
+ * Settling calls are different. `reconcile` and `release` only ever *record* or
+ * *free* money that a reserve already authorized, so a failure there can't cause
+ * overspend — the worst case is a worst-case hold that lingers until its TTL
+ * auto-refunds it. Those failures are logged and swallowed so a flaky settle
+ * never tears down a response the user is already reading.
+ */
+export class FailClosedSpendLedger implements SpendLedger {
+	constructor(private readonly inner: SpendLedger) {}
+
+	async reserve(req: ReserveRequest, now: Date): Promise<ReserveResult> {
+		try {
+			return await this.inner.reserve(req, now);
+		} catch (err) {
+			console.error('[spend-ledger] reserve failed; failing closed (denying)', err);
+			return {
+				ok: false,
+				reason: 'ledger-unavailable',
+				detail: 'Spend ledger is unreachable; refusing spend.'
+			};
+		}
+	}
+
+	async reconcile(reservationId: string, actual: ReconcileInput, now: Date): Promise<void> {
+		try {
+			await this.inner.reconcile(reservationId, actual, now);
+		} catch (err) {
+			console.error('[spend-ledger] reconcile failed; hold will self-expire', err);
+		}
+	}
+
+	async release(reservationId: string, now: Date): Promise<void> {
+		try {
+			await this.inner.release(reservationId, now);
+		} catch (err) {
+			console.error('[spend-ledger] release failed; hold will self-expire', err);
+		}
+	}
+
+	status(now: Date): Promise<LedgerStatus> {
+		return this.inner.status(now);
+	}
+}

--- a/src/lib/server/spend-ledger/in-memory-ledger.ts
+++ b/src/lib/server/spend-ledger/in-memory-ledger.ts
@@ -1,0 +1,35 @@
+import { LedgerCore, type LedgerCoreOptions } from './ledger-core';
+import type { ReconcileInput, ReserveRequest, SpendLedger } from './types';
+
+/**
+ * In-memory Spend Ledger adapter for development and tests.
+ *
+ * It holds a single `LedgerCore` in process memory, so it provides the same
+ * exact accounting as production within one runtime — and it is the natural
+ * "fail open" path in dev: there is no external authority to be unreachable.
+ * Production uses the Durable-Object adapter instead.
+ */
+export class InMemorySpendLedger implements SpendLedger {
+	private readonly core: LedgerCore;
+
+	constructor(opts: LedgerCoreOptions) {
+		this.core = new LedgerCore(opts);
+	}
+
+	async reserve(req: ReserveRequest, now: Date) {
+		return this.core.reserve(req, now);
+	}
+
+	async reconcile(reservationId: string, actual: ReconcileInput, now: Date) {
+		this.core.reconcile(reservationId, actual, now);
+	}
+
+	async release(reservationId: string, now: Date) {
+		void now;
+		this.core.release(reservationId);
+	}
+
+	async status(now: Date) {
+		return this.core.status(now);
+	}
+}

--- a/src/lib/server/spend-ledger/in-memory-ledger.ts
+++ b/src/lib/server/spend-ledger/in-memory-ledger.ts
@@ -25,8 +25,7 @@ export class InMemorySpendLedger implements SpendLedger {
 	}
 
 	async release(reservationId: string, now: Date) {
-		void now;
-		this.core.release(reservationId);
+		this.core.release(reservationId, now);
 	}
 
 	async status(now: Date) {

--- a/src/lib/server/spend-ledger/index.ts
+++ b/src/lib/server/spend-ledger/index.ts
@@ -1,6 +1,7 @@
 export type {
 	CandidateProvider,
 	CeilingId,
+	DenialReason,
 	LedgerCeilings,
 	LedgerStatus,
 	MonthlyProviderCaps,
@@ -12,6 +13,7 @@ export type {
 export { LedgerCore, type LedgerState } from './ledger-core';
 export { InMemorySpendLedger } from './in-memory-ledger';
 export { DurableObjectSpendLedger, SPEND_LEDGER_ROUTES } from './do-adapter';
+export { FailClosedSpendLedger } from './fail-closed-ledger';
 export { worstCaseCostUsd, actualCostUsd } from './cost';
 export {
 	DEFAULT_CEILINGS,

--- a/src/lib/server/spend-ledger/index.ts
+++ b/src/lib/server/spend-ledger/index.ts
@@ -1,0 +1,56 @@
+import type { LedgerCeilings } from './types';
+
+export type {
+	CandidateProvider,
+	CeilingId,
+	LedgerCeilings,
+	LedgerStatus,
+	MonthlyProviderCaps,
+	ReconcileInput,
+	ReserveRequest,
+	ReserveResult,
+	SpendLedger
+} from './types';
+export { LedgerCore, type LedgerState } from './ledger-core';
+export { InMemorySpendLedger } from './in-memory-ledger';
+export { worstCaseCostUsd, actualCostUsd } from './cost';
+
+/** Defaults match docs/prd/cost-abuse-hardening.md. */
+export const DEFAULT_CEILINGS: LedgerCeilings = {
+	dailySpendUsd: 3,
+	dailyRequests: 5000,
+	monthlyProviderUsd: { claude: 25, openai: 25 }
+};
+
+export const DEFAULT_RESERVATION_TTL_MS = 60_000;
+
+interface CeilingEnv {
+	DAILY_SPEND_CAP_USD?: string;
+	DAILY_REQUEST_CAP?: string;
+	ANTHROPIC_MONTHLY_SPEND_CAP?: string;
+	OPENAI_MONTHLY_SPEND_CAP?: string;
+}
+
+function positiveNumber(raw: string | undefined, fallback: number): number {
+	if (raw === undefined || raw.trim() === '') return fallback;
+	const value = Number(raw);
+	return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+/** Build ceilings from environment variables, falling back to the defaults. */
+export function resolveCeilings(env: CeilingEnv): LedgerCeilings {
+	return {
+		dailySpendUsd: positiveNumber(env.DAILY_SPEND_CAP_USD, DEFAULT_CEILINGS.dailySpendUsd),
+		dailyRequests: positiveNumber(env.DAILY_REQUEST_CAP, DEFAULT_CEILINGS.dailyRequests),
+		monthlyProviderUsd: {
+			claude: positiveNumber(
+				env.ANTHROPIC_MONTHLY_SPEND_CAP,
+				DEFAULT_CEILINGS.monthlyProviderUsd.claude
+			),
+			openai: positiveNumber(
+				env.OPENAI_MONTHLY_SPEND_CAP,
+				DEFAULT_CEILINGS.monthlyProviderUsd.openai
+			)
+		}
+	};
+}

--- a/src/lib/server/spend-ledger/index.ts
+++ b/src/lib/server/spend-ledger/index.ts
@@ -1,5 +1,3 @@
-import type { LedgerCeilings } from './types';
-
 export type {
 	CandidateProvider,
 	CeilingId,
@@ -14,43 +12,10 @@ export type {
 export { LedgerCore, type LedgerState } from './ledger-core';
 export { InMemorySpendLedger } from './in-memory-ledger';
 export { worstCaseCostUsd, actualCostUsd } from './cost';
-
-/** Defaults match docs/prd/cost-abuse-hardening.md. */
-export const DEFAULT_CEILINGS: LedgerCeilings = {
-	dailySpendUsd: 3,
-	dailyRequests: 5000,
-	monthlyProviderUsd: { claude: 25, openai: 25 }
-};
-
-export const DEFAULT_RESERVATION_TTL_MS = 60_000;
-
-interface CeilingEnv {
-	DAILY_SPEND_CAP_USD?: string;
-	DAILY_REQUEST_CAP?: string;
-	ANTHROPIC_MONTHLY_SPEND_CAP?: string;
-	OPENAI_MONTHLY_SPEND_CAP?: string;
-}
-
-function positiveNumber(raw: string | undefined, fallback: number): number {
-	if (raw === undefined || raw.trim() === '') return fallback;
-	const value = Number(raw);
-	return Number.isFinite(value) && value >= 0 ? value : fallback;
-}
-
-/** Build ceilings from environment variables, falling back to the defaults. */
-export function resolveCeilings(env: CeilingEnv): LedgerCeilings {
-	return {
-		dailySpendUsd: positiveNumber(env.DAILY_SPEND_CAP_USD, DEFAULT_CEILINGS.dailySpendUsd),
-		dailyRequests: positiveNumber(env.DAILY_REQUEST_CAP, DEFAULT_CEILINGS.dailyRequests),
-		monthlyProviderUsd: {
-			claude: positiveNumber(
-				env.ANTHROPIC_MONTHLY_SPEND_CAP,
-				DEFAULT_CEILINGS.monthlyProviderUsd.claude
-			),
-			openai: positiveNumber(
-				env.OPENAI_MONTHLY_SPEND_CAP,
-				DEFAULT_CEILINGS.monthlyProviderUsd.openai
-			)
-		}
-	};
-}
+export {
+	DEFAULT_CEILINGS,
+	DEFAULT_RESERVATION_TTL_MS,
+	resolveCeilings,
+	type CeilingEnv
+} from './config';
+export { getSpendLedger, type SpendLedgerEnv } from './factory';

--- a/src/lib/server/spend-ledger/index.ts
+++ b/src/lib/server/spend-ledger/index.ts
@@ -11,6 +11,7 @@ export type {
 } from './types';
 export { LedgerCore, type LedgerState } from './ledger-core';
 export { InMemorySpendLedger } from './in-memory-ledger';
+export { DurableObjectSpendLedger, SPEND_LEDGER_ROUTES } from './do-adapter';
 export { worstCaseCostUsd, actualCostUsd } from './cost';
 export {
 	DEFAULT_CEILINGS,

--- a/src/lib/server/spend-ledger/index.ts
+++ b/src/lib/server/spend-ledger/index.ts
@@ -14,6 +14,7 @@ export { LedgerCore, type LedgerState } from './ledger-core';
 export { InMemorySpendLedger } from './in-memory-ledger';
 export { DurableObjectSpendLedger, SPEND_LEDGER_ROUTES } from './do-adapter';
 export { FailClosedSpendLedger } from './fail-closed-ledger';
+export { logLedgerEvent, type LedgerEvent, type LedgerEventSink } from './observability';
 export { worstCaseCostUsd, actualCostUsd } from './cost';
 export {
 	DEFAULT_CEILINGS,

--- a/src/lib/server/spend-ledger/index.ts
+++ b/src/lib/server/spend-ledger/index.ts
@@ -5,6 +5,7 @@ export type {
 	LedgerCeilings,
 	LedgerStatus,
 	MonthlyProviderCaps,
+	ProviderReservation,
 	ReconcileInput,
 	ReserveRequest,
 	ReserveResult,

--- a/src/lib/server/spend-ledger/ledger-core.test.ts
+++ b/src/lib/server/spend-ledger/ledger-core.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { LedgerCore, type LedgerCoreOptions } from './ledger-core';
+import type { CandidateProvider, LedgerCeilings } from './types';
+
+// gpt-4o-mini priced at $0.15/1M input → 1,000,000 input + 0 output = exactly
+// $0.15 per reserve, which keeps the ceiling arithmetic easy to reason about.
+const OPENAI: CandidateProvider = { provider: 'openai', model: 'gpt-4o-mini' };
+const CLAUDE: CandidateProvider = { provider: 'claude', model: 'claude-haiku-4-5-20251001' };
+const ONE_M_INPUT = { candidates: [OPENAI], maxInputTokens: 1_000_000, maxOutputTokens: 0 };
+const COST_PER_RESERVE = 0.15;
+
+const NOW = new Date('2026-06-11T12:00:00Z');
+
+function makeCore(ceilings: Partial<LedgerCeilings> = {}, ttlMs = 60_000): LedgerCore {
+	let n = 0;
+	const opts: LedgerCoreOptions = {
+		ceilings: {
+			dailySpendUsd: 100,
+			dailyRequests: 100_000,
+			monthlyProviderUsd: { claude: 100, openai: 100 },
+			...ceilings
+		},
+		reservationTtlMs: ttlMs,
+		idFactory: () => `r${++n}`
+	};
+	return new LedgerCore(opts);
+}
+
+describe('LedgerCore — exactness invariant', () => {
+	it('never lets committed-plus-reserved exceed the daily spend cap under concurrent reservations', () => {
+		// Cap = $0.45 → exactly 3 reservations of $0.15 fit; the 4th must be refused
+		// even though NOTHING has reconciled yet (the holds alone fill the ceiling).
+		const core = makeCore({ dailySpendUsd: 0.45 });
+
+		const results = [
+			core.reserve(ONE_M_INPUT, NOW),
+			core.reserve(ONE_M_INPUT, NOW),
+			core.reserve(ONE_M_INPUT, NOW)
+		];
+		expect(results.every((r) => r.ok)).toBe(true);
+
+		const fourth = core.reserve(ONE_M_INPUT, NOW);
+		expect(fourth.ok).toBe(false);
+		if (!fourth.ok) expect(fourth.ceiling).toBe('daily-spend');
+
+		const status = core.status(NOW);
+		expect(status.daily.reservedUsd).toBeCloseTo(3 * COST_PER_RESERVE, 6);
+		expect(status.daily.spentUsd).toBe(0);
+		// The guarantee: held money never exceeds the cap.
+		expect(status.daily.reservedUsd).toBeLessThanOrEqual(status.daily.spendCapUsd);
+	});
+
+	it('frees exactly the worst-case-minus-actual headroom on reconcile', () => {
+		const core = makeCore({ dailySpendUsd: 0.45 });
+		const r1 = core.reserve(ONE_M_INPUT, NOW);
+		const r2 = core.reserve(ONE_M_INPUT, NOW);
+		core.reserve(ONE_M_INPUT, NOW); // full: 3 holds × $0.15 = $0.45
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(false);
+
+		// Reconcile one request to a tiny actual: its $0.15 hold is replaced by a
+		// $0.01 commit, freeing only $0.14 — less than a full $0.15 request — so a
+		// new request still cannot fit. Worst-case stays held for the other two.
+		if (r1.ok) core.reconcile(r1.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
+		expect(core.status(NOW).daily.spentUsd).toBeCloseTo(0.01, 6);
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(false);
+
+		// Reconcile a second the same way: committed $0.02 + one $0.15 hold = $0.17,
+		// which finally leaves room for a fresh reservation.
+		if (r2.ok) core.reconcile(r2.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
+	});
+
+	it('auto-refunds an expired hold so it stops counting against the cap', () => {
+		const core = makeCore({ dailySpendUsd: 0.15 }, 60_000); // room for exactly one hold
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(false); // full
+
+		const later = new Date(NOW.getTime() + 61_000); // past the 60s TTL
+		const afterExpiry = core.reserve(ONE_M_INPUT, later);
+		expect(afterExpiry.ok).toBe(true); // the orphaned hold expired and refunded
+		expect(core.status(later).daily.reservedUsd).toBeCloseTo(COST_PER_RESERVE, 6);
+	});
+});
+
+describe('LedgerCore — request-count backstop', () => {
+	it('refuses once the daily request cap is hit, independent of dollars', () => {
+		const core = makeCore({ dailyRequests: 2, dailySpendUsd: 1000 });
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
+		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
+		const third = core.reserve(ONE_M_INPUT, NOW);
+		expect(third.ok).toBe(false);
+		if (!third.ok) expect(third.ceiling).toBe('daily-requests');
+	});
+
+	it('counts the request at reserve time and never refunds the count', () => {
+		const core = makeCore();
+		const r = core.reserve(ONE_M_INPUT, NOW);
+		if (r.ok) core.release(r.reservationId, NOW); // dollars refunded...
+		expect(core.status(NOW).daily.requests).toBe(1); // ...but the request still counted
+	});
+});
+
+describe('LedgerCore — monthly provider cap with fallback', () => {
+	it('skips a provider over its monthly cap and admits the next candidate', () => {
+		// claude worst-case here is $1.00 (haiku input $1/1M); its monthly cap is
+		// $0.50 so it cannot fit. openai ($0.15) can, and is the fallback.
+		const core = makeCore({ monthlyProviderUsd: { claude: 0.5, openai: 25 } });
+		const result = core.reserve(
+			{ candidates: [CLAUDE, OPENAI], maxInputTokens: 1_000_000, maxOutputTokens: 0 },
+			NOW
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.provider).toBe('openai');
+	});
+
+	it('refuses with monthly-provider when every candidate is over its monthly cap', () => {
+		const core = makeCore({ monthlyProviderUsd: { claude: 0.5, openai: 0.05 } });
+		const result = core.reserve(
+			{ candidates: [CLAUDE, OPENAI], maxInputTokens: 1_000_000, maxOutputTokens: 0 },
+			NOW
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.ceiling).toBe('monthly-provider');
+	});
+
+	it('settles actual spend against the reserved provider and month', () => {
+		const core = makeCore();
+		const r = core.reserve(ONE_M_INPUT, NOW);
+		if (r.ok) core.reconcile(r.reservationId, { provider: 'openai', usd: 0.0123 }, NOW);
+		const status = core.status(NOW);
+		expect(status.monthly.openai.spentUsd).toBeCloseTo(0.0123, 6);
+		expect(status.monthly.claude.spentUsd).toBe(0);
+	});
+});
+
+describe('LedgerCore — state round-trips for the DO adapter', () => {
+	it('restores committed and reserved state from a snapshot', () => {
+		const core = makeCore({ dailySpendUsd: 0.45 });
+		const first = core.reserve(ONE_M_INPUT, NOW);
+		if (first.ok) core.reconcile(first.reservationId, { provider: 'openai', usd: 0.02 }, NOW);
+		core.reserve(ONE_M_INPUT, NOW); // an outstanding hold
+
+		const restored = new LedgerCore({
+			ceilings: {
+				dailySpendUsd: 0.45,
+				dailyRequests: 100_000,
+				monthlyProviderUsd: { claude: 100, openai: 100 }
+			},
+			reservationTtlMs: 60_000,
+			state: core.snapshot()
+		});
+
+		const a = core.status(NOW);
+		const b = restored.status(NOW);
+		expect(b.daily.spentUsd).toBeCloseTo(a.daily.spentUsd, 6);
+		expect(b.daily.reservedUsd).toBeCloseTo(a.daily.reservedUsd, 6);
+		expect(b.daily.requests).toBe(a.daily.requests);
+		expect(b.activeReservations).toBe(a.activeReservations);
+	});
+});

--- a/src/lib/server/spend-ledger/ledger-core.test.ts
+++ b/src/lib/server/spend-ledger/ledger-core.test.ts
@@ -41,7 +41,7 @@ describe('LedgerCore — exactness invariant', () => {
 
 		const fourth = core.reserve(ONE_M_INPUT, NOW);
 		expect(fourth.ok).toBe(false);
-		if (!fourth.ok) expect(fourth.ceiling).toBe('daily-spend');
+		if (!fourth.ok) expect(fourth.reason).toBe('daily-spend');
 
 		const status = core.status(NOW);
 		expect(status.daily.reservedUsd).toBeCloseTo(3 * COST_PER_RESERVE, 6);
@@ -89,7 +89,7 @@ describe('LedgerCore — request-count backstop', () => {
 		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
 		const third = core.reserve(ONE_M_INPUT, NOW);
 		expect(third.ok).toBe(false);
-		if (!third.ok) expect(third.ceiling).toBe('daily-requests');
+		if (!third.ok) expect(third.reason).toBe('daily-requests');
 	});
 
 	it('counts the request at reserve time and never refunds the count', () => {
@@ -120,7 +120,7 @@ describe('LedgerCore — monthly provider cap with fallback', () => {
 			NOW
 		);
 		expect(result.ok).toBe(false);
-		if (!result.ok) expect(result.ceiling).toBe('monthly-provider');
+		if (!result.ok) expect(result.reason).toBe('monthly-provider');
 	});
 
 	it('settles actual spend against the reserved provider and month', () => {

--- a/src/lib/server/spend-ledger/ledger-core.test.ts
+++ b/src/lib/server/spend-ledger/ledger-core.test.ts
@@ -95,7 +95,7 @@ describe('LedgerCore — request-count backstop', () => {
 	it('counts the request at reserve time and never refunds the count', () => {
 		const core = makeCore();
 		const r = core.reserve(ONE_M_INPUT, NOW);
-		if (r.ok) core.release(r.reservationId, NOW); // dollars refunded...
+		if (r.ok) core.release(r.reservationId); // dollars refunded...
 		expect(core.status(NOW).daily.requests).toBe(1); // ...but the request still counted
 	});
 });

--- a/src/lib/server/spend-ledger/ledger-core.test.ts
+++ b/src/lib/server/spend-ledger/ledger-core.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { LedgerCore, type LedgerCoreOptions } from './ledger-core';
 import type { CandidateProvider, LedgerCeilings } from './types';
 
-// gpt-4o-mini priced at $0.15/1M input → 1,000,000 input + 0 output = exactly
-// $0.15 per reserve, which keeps the ceiling arithmetic easy to reason about.
+// gpt-4o-mini reserves input at its worst-case cache-creation fallback
+// ($0.1875/1M), so 800,000 input + 0 output = exactly $0.15 per reserve.
 const OPENAI: CandidateProvider = { provider: 'openai', model: 'gpt-4o-mini' };
 const CLAUDE: CandidateProvider = { provider: 'claude', model: 'claude-haiku-4-5-20251001' };
-const ONE_M_INPUT = { candidates: [OPENAI], maxInputTokens: 1_000_000, maxOutputTokens: 0 };
+const OPENAI_800K_INPUT = {
+	candidates: [OPENAI],
+	maxInputTokens: 800_000,
+	maxOutputTokens: 0
+};
 const COST_PER_RESERVE = 0.15;
 
 const NOW = new Date('2026-06-11T12:00:00Z');
@@ -33,13 +37,13 @@ describe('LedgerCore — exactness invariant', () => {
 		const core = makeCore({ dailySpendUsd: 0.45 });
 
 		const results = [
-			core.reserve(ONE_M_INPUT, NOW),
-			core.reserve(ONE_M_INPUT, NOW),
-			core.reserve(ONE_M_INPUT, NOW)
+			core.reserve(OPENAI_800K_INPUT, NOW),
+			core.reserve(OPENAI_800K_INPUT, NOW),
+			core.reserve(OPENAI_800K_INPUT, NOW)
 		];
 		expect(results.every((r) => r.ok)).toBe(true);
 
-		const fourth = core.reserve(ONE_M_INPUT, NOW);
+		const fourth = core.reserve(OPENAI_800K_INPUT, NOW);
 		expect(fourth.ok).toBe(false);
 		if (!fourth.ok) expect(fourth.reason).toBe('daily-spend');
 
@@ -52,31 +56,31 @@ describe('LedgerCore — exactness invariant', () => {
 
 	it('frees exactly the worst-case-minus-actual headroom on reconcile', () => {
 		const core = makeCore({ dailySpendUsd: 0.45 });
-		const r1 = core.reserve(ONE_M_INPUT, NOW);
-		const r2 = core.reserve(ONE_M_INPUT, NOW);
-		core.reserve(ONE_M_INPUT, NOW); // full: 3 holds × $0.15 = $0.45
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(false);
+		const r1 = core.reserve(OPENAI_800K_INPUT, NOW);
+		const r2 = core.reserve(OPENAI_800K_INPUT, NOW);
+		core.reserve(OPENAI_800K_INPUT, NOW); // full: 3 holds × $0.15 = $0.45
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(false);
 
 		// Reconcile one request to a tiny actual: its $0.15 hold is replaced by a
 		// $0.01 commit, freeing only $0.14 — less than a full $0.15 request — so a
 		// new request still cannot fit. Worst-case stays held for the other two.
 		if (r1.ok) core.reconcile(r1.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
 		expect(core.status(NOW).daily.spentUsd).toBeCloseTo(0.01, 6);
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(false);
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(false);
 
 		// Reconcile a second the same way: committed $0.02 + one $0.15 hold = $0.17,
 		// which finally leaves room for a fresh reservation.
 		if (r2.ok) core.reconcile(r2.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(true);
 	});
 
 	it('auto-refunds an expired hold so it stops counting against the cap', () => {
 		const core = makeCore({ dailySpendUsd: 0.15 }, 60_000); // room for exactly one hold
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(false); // full
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(true);
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(false); // full
 
 		const later = new Date(NOW.getTime() + 61_000); // past the 60s TTL
-		const afterExpiry = core.reserve(ONE_M_INPUT, later);
+		const afterExpiry = core.reserve(OPENAI_800K_INPUT, later);
 		expect(afterExpiry.ok).toBe(true); // the orphaned hold expired and refunded
 		expect(core.status(later).daily.reservedUsd).toBeCloseTo(COST_PER_RESERVE, 6);
 	});
@@ -85,25 +89,33 @@ describe('LedgerCore — exactness invariant', () => {
 describe('LedgerCore — request-count backstop', () => {
 	it('refuses once the daily request cap is hit, independent of dollars', () => {
 		const core = makeCore({ dailyRequests: 2, dailySpendUsd: 1000 });
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
-		expect(core.reserve(ONE_M_INPUT, NOW).ok).toBe(true);
-		const third = core.reserve(ONE_M_INPUT, NOW);
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(true);
+		expect(core.reserve(OPENAI_800K_INPUT, NOW).ok).toBe(true);
+		const third = core.reserve(OPENAI_800K_INPUT, NOW);
 		expect(third.ok).toBe(false);
 		if (!third.ok) expect(third.reason).toBe('daily-requests');
 	});
 
 	it('counts the request at reserve time and never refunds the count', () => {
 		const core = makeCore();
-		const r = core.reserve(ONE_M_INPUT, NOW);
+		const r = core.reserve(OPENAI_800K_INPUT, NOW);
 		if (r.ok) core.release(r.reservationId); // dollars refunded...
 		expect(core.status(NOW).daily.requests).toBe(1); // ...but the request still counted
+	});
+
+	it('counts over-budget denials against the daily request backstop', () => {
+		const core = makeCore({ dailySpendUsd: 0.01 });
+
+		const denied = core.reserve(OPENAI_800K_INPUT, NOW);
+		expect(denied.ok).toBe(false);
+		expect(core.status(NOW).daily.requests).toBe(1);
 	});
 });
 
 describe('LedgerCore — monthly provider cap with fallback', () => {
 	it('skips a provider over its monthly cap and admits the next candidate', () => {
-		// claude worst-case here is $1.00 (haiku input $1/1M); its monthly cap is
-		// $0.50 so it cannot fit. openai ($0.15) can, and is the fallback.
+		// Claude worst-case here is $1.25 (haiku cache-write input $1.25/1M);
+		// its monthly cap is $0.50 so it cannot fit. OpenAI can, and is the fallback.
 		const core = makeCore({ monthlyProviderUsd: { claude: 0.5, openai: 25 } });
 		const result = core.reserve(
 			{ candidates: [CLAUDE, OPENAI], maxInputTokens: 1_000_000, maxOutputTokens: 0 },
@@ -111,6 +123,22 @@ describe('LedgerCore — monthly provider cap with fallback', () => {
 		);
 		expect(result.ok).toBe(true);
 		if (result.ok) expect(result.provider).toBe('openai');
+	});
+
+	it('reserves each fallback candidate that fits both daily and provider caps', () => {
+		const core = makeCore({ dailySpendUsd: 2, monthlyProviderUsd: { claude: 2, openai: 2 } });
+		const result = core.reserve(
+			{ candidates: [CLAUDE, OPENAI], maxInputTokens: 800_000, maxOutputTokens: 0 },
+			NOW
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.provider).toBe('claude');
+		expect(result.reservations.map((hold) => hold.provider)).toEqual(['claude', 'openai']);
+		expect(core.status(NOW).daily.reservedUsd).toBeCloseTo(1.15, 6);
+		expect(core.status(NOW).monthly.claude.reservedUsd).toBeCloseTo(1, 6);
+		expect(core.status(NOW).monthly.openai.reservedUsd).toBeCloseTo(0.15, 6);
 	});
 
 	it('refuses with monthly-provider when every candidate is over its monthly cap', () => {
@@ -125,7 +153,7 @@ describe('LedgerCore — monthly provider cap with fallback', () => {
 
 	it('settles actual spend against the reserved provider and month', () => {
 		const core = makeCore();
-		const r = core.reserve(ONE_M_INPUT, NOW);
+		const r = core.reserve(OPENAI_800K_INPUT, NOW);
 		if (r.ok) core.reconcile(r.reservationId, { provider: 'openai', usd: 0.0123 }, NOW);
 		const status = core.status(NOW);
 		expect(status.monthly.openai.spentUsd).toBeCloseTo(0.0123, 6);
@@ -136,9 +164,9 @@ describe('LedgerCore — monthly provider cap with fallback', () => {
 describe('LedgerCore — state round-trips for the DO adapter', () => {
 	it('restores committed and reserved state from a snapshot', () => {
 		const core = makeCore({ dailySpendUsd: 0.45 });
-		const first = core.reserve(ONE_M_INPUT, NOW);
+		const first = core.reserve(OPENAI_800K_INPUT, NOW);
 		if (first.ok) core.reconcile(first.reservationId, { provider: 'openai', usd: 0.02 }, NOW);
-		core.reserve(ONE_M_INPUT, NOW); // an outstanding hold
+		core.reserve(OPENAI_800K_INPUT, NOW); // an outstanding hold
 
 		const restored = new LedgerCore({
 			ceilings: {
@@ -156,5 +184,33 @@ describe('LedgerCore — state round-trips for the DO adapter', () => {
 		expect(b.daily.reservedUsd).toBeCloseTo(a.daily.reservedUsd, 6);
 		expect(b.daily.requests).toBe(a.daily.requests);
 		expect(b.activeReservations).toBe(a.activeReservations);
+	});
+
+	it('status excludes expired holds without mutating the snapshot', () => {
+		const core = makeCore({ dailySpendUsd: 0.15 }, 60_000);
+		const result = core.reserve(OPENAI_800K_INPUT, NOW);
+		if (!result.ok) throw new Error('expected reserve to succeed');
+
+		const later = new Date(NOW.getTime() + 61_000);
+		const status = core.status(later);
+		expect(status.daily.reservedUsd).toBe(0);
+		expect(status.activeReservations).toBe(0);
+		expect(Object.keys(core.snapshot().reservations)).toHaveLength(1);
+	});
+
+	it('prunes closed historical buckets on the next mutation', () => {
+		const core = makeCore();
+		const first = core.reserve(OPENAI_800K_INPUT, NOW);
+		if (!first.ok) throw new Error('expected reserve to succeed');
+		core.reconcile(first.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
+
+		const nextMonth = new Date('2026-07-01T00:00:00Z');
+		const second = core.reserve(OPENAI_800K_INPUT, nextMonth);
+		if (!second.ok) throw new Error('expected reserve to succeed');
+		core.reconcile(second.reservationId, { provider: 'openai', usd: 0.02 }, nextMonth);
+
+		const snapshot = core.snapshot();
+		expect(Object.keys(snapshot.committedDaily)).toEqual(['2026-07-01']);
+		expect(Object.keys(snapshot.committedMonthly)).toEqual(['2026-07:openai']);
 	});
 });

--- a/src/lib/server/spend-ledger/ledger-core.ts
+++ b/src/lib/server/spend-ledger/ledger-core.ts
@@ -1,5 +1,6 @@
 import type { LlmProvider } from '$lib/types';
 import { worstCaseCostUsd } from './cost';
+import type { LedgerEventSink } from './observability';
 import type {
 	CeilingId,
 	LedgerCeilings,
@@ -49,6 +50,8 @@ export interface LedgerCoreOptions {
 	idFactory?: () => string;
 	/** Restore prior state (DO adapter). */
 	state?: LedgerState;
+	/** Observability sink, one event per decision; defaults to a no-op. */
+	emit?: LedgerEventSink;
 }
 
 function utcDayKey(now: Date): string {
@@ -72,6 +75,7 @@ export class LedgerCore {
 	private readonly ceilings: LedgerCeilings;
 	private readonly ttlMs: number;
 	private readonly newId: () => string;
+	private readonly emit: LedgerEventSink;
 
 	private committedDaily: Map<string, DailyCommit>;
 	private committedMonthly: Map<string, number>;
@@ -81,6 +85,7 @@ export class LedgerCore {
 		this.ceilings = opts.ceilings;
 		this.ttlMs = opts.reservationTtlMs;
 		this.newId = opts.idFactory ?? (() => crypto.randomUUID());
+		this.emit = opts.emit ?? (() => {});
 		this.committedDaily = new Map(Object.entries(opts.state?.committedDaily ?? {}));
 		this.committedMonthly = new Map(Object.entries(opts.state?.committedMonthly ?? {}));
 		this.reservations = new Map(Object.entries(opts.state?.reservations ?? {}));
@@ -90,7 +95,10 @@ export class LedgerCore {
 	private purgeExpired(now: Date): void {
 		const cutoff = now.getTime();
 		for (const [id, res] of this.reservations) {
-			if (res.expiresAt <= cutoff) this.reservations.delete(id);
+			if (res.expiresAt <= cutoff) {
+				this.reservations.delete(id);
+				this.emit({ type: 'expire', reservationId: id, provider: res.provider, usd: res.usd });
+			}
 		}
 	}
 
@@ -111,6 +119,7 @@ export class LedgerCore {
 	}
 
 	private deny(reason: CeilingId, detail: string): ReserveResult {
+		this.emit({ type: 'deny', reason, detail });
 		return { ok: false, reason, detail };
 	}
 
@@ -165,6 +174,16 @@ export class LedgerCore {
 				expiresAt
 			});
 
+			this.emit({
+				type: 'reserve',
+				reservationId,
+				provider: candidate.provider,
+				model: candidate.model,
+				reservedUsd: worst,
+				day: dayKey,
+				month: monthKey
+			});
+
 			return {
 				ok: true,
 				reservationId,
@@ -197,10 +216,13 @@ export class LedgerCore {
 
 		const mKey = monthlyKey(monthKey, actual.provider);
 		this.committedMonthly.set(mKey, (this.committedMonthly.get(mKey) ?? 0) + actual.usd);
+
+		this.emit({ type: 'commit', reservationId, provider: actual.provider, usd: actual.usd });
 	}
 
 	release(reservationId: string): void {
 		this.reservations.delete(reservationId);
+		this.emit({ type: 'refund', reservationId });
 	}
 
 	status(now: Date): LedgerStatus {

--- a/src/lib/server/spend-ledger/ledger-core.ts
+++ b/src/lib/server/spend-ledger/ledger-core.ts
@@ -1,10 +1,11 @@
-import type { LlmProvider } from '$lib/types';
+import { LLM_PROVIDERS, type LlmProvider } from '$lib/types';
 import { worstCaseCostUsd } from './cost';
 import type { LedgerEventSink } from './observability';
 import type {
 	CeilingId,
 	LedgerCeilings,
 	LedgerStatus,
+	ProviderReservation,
 	ReconcileInput,
 	ReserveRequest,
 	ReserveResult
@@ -71,6 +72,10 @@ function monthlyKey(monthKey: string, provider: LlmProvider): string {
 	return `${monthKey}:${provider}`;
 }
 
+function monthFromMonthlyKey(key: string): string {
+	return key.slice(0, key.indexOf(':'));
+}
+
 export class LedgerCore {
 	private readonly ceilings: LedgerCeilings;
 	private readonly ttlMs: number;
@@ -80,6 +85,8 @@ export class LedgerCore {
 	private committedDaily: Map<string, DailyCommit>;
 	private committedMonthly: Map<string, number>;
 	private reservations: Map<string, Reservation>;
+	private heldDaily: Map<string, number>;
+	private heldMonthly: Map<string, number>;
 
 	constructor(opts: LedgerCoreOptions) {
 		this.ceilings = opts.ceilings;
@@ -89,6 +96,42 @@ export class LedgerCore {
 		this.committedDaily = new Map(Object.entries(opts.state?.committedDaily ?? {}));
 		this.committedMonthly = new Map(Object.entries(opts.state?.committedMonthly ?? {}));
 		this.reservations = new Map(Object.entries(opts.state?.reservations ?? {}));
+		this.heldDaily = new Map();
+		this.heldMonthly = new Map();
+		for (const res of this.reservations.values()) this.addHeld(res);
+	}
+
+	private addTo(map: Map<string, number>, key: string, usd: number): void {
+		map.set(key, (map.get(key) ?? 0) + usd);
+	}
+
+	private subtractFrom(map: Map<string, number>, key: string, usd: number): void {
+		const next = (map.get(key) ?? 0) - usd;
+		if (next <= 1e-12) map.delete(key);
+		else map.set(key, next);
+	}
+
+	private addHeld(res: Reservation): void {
+		this.addTo(this.heldDaily, res.dayKey, res.usd);
+		this.addTo(this.heldMonthly, monthlyKey(res.monthKey, res.provider), res.usd);
+	}
+
+	private removeHeld(res: Reservation): void {
+		this.subtractFrom(this.heldDaily, res.dayKey, res.usd);
+		this.subtractFrom(this.heldMonthly, monthlyKey(res.monthKey, res.provider), res.usd);
+	}
+
+	private putReservation(id: string, res: Reservation): void {
+		this.reservations.set(id, res);
+		this.addHeld(res);
+	}
+
+	private takeReservation(id: string): Reservation | undefined {
+		const res = this.reservations.get(id);
+		if (!res) return undefined;
+		this.reservations.delete(id);
+		this.removeHeld(res);
+		return res;
 	}
 
 	/** Drop expired holds so their dollars stop counting against ceilings. */
@@ -96,26 +139,63 @@ export class LedgerCore {
 		const cutoff = now.getTime();
 		for (const [id, res] of this.reservations) {
 			if (res.expiresAt <= cutoff) {
-				this.reservations.delete(id);
+				this.takeReservation(id);
 				this.emit({ type: 'expire', reservationId: id, provider: res.provider, usd: res.usd });
 			}
 		}
 	}
 
+	private pruneHistory(now: Date): void {
+		const keepDays = new Set([utcDayKey(now)]);
+		const keepMonths = new Set([utcMonthKey(now)]);
+		for (const res of this.reservations.values()) {
+			keepDays.add(res.dayKey);
+			keepMonths.add(res.monthKey);
+		}
+
+		for (const dayKey of this.committedDaily.keys()) {
+			if (!keepDays.has(dayKey)) this.committedDaily.delete(dayKey);
+		}
+		for (const key of this.committedMonthly.keys()) {
+			if (!keepMonths.has(monthFromMonthlyKey(key))) this.committedMonthly.delete(key);
+		}
+	}
+
 	private heldDailyUsd(dayKey: string): number {
+		return this.heldDaily.get(dayKey) ?? 0;
+	}
+
+	private heldMonthlyUsd(monthKey: string, provider: LlmProvider): number {
+		return this.heldMonthly.get(monthlyKey(monthKey, provider)) ?? 0;
+	}
+
+	private heldDailyUsdAt(dayKey: string, now: Date): number {
+		const cutoff = now.getTime();
 		let sum = 0;
 		for (const res of this.reservations.values()) {
-			if (res.dayKey === dayKey) sum += res.usd;
+			if (res.dayKey === dayKey && res.expiresAt > cutoff) sum += res.usd;
 		}
 		return sum;
 	}
 
-	private heldMonthlyUsd(monthKey: string, provider: LlmProvider): number {
+	private heldMonthlyUsdAt(monthKey: string, provider: LlmProvider, now: Date): number {
+		const cutoff = now.getTime();
 		let sum = 0;
 		for (const res of this.reservations.values()) {
-			if (res.monthKey === monthKey && res.provider === provider) sum += res.usd;
+			if (res.monthKey === monthKey && res.provider === provider && res.expiresAt > cutoff) {
+				sum += res.usd;
+			}
 		}
 		return sum;
+	}
+
+	private activeReservationCountAt(now: Date): number {
+		const cutoff = now.getTime();
+		let count = 0;
+		for (const res of this.reservations.values()) {
+			if (res.expiresAt > cutoff) count += 1;
+		}
+		return count;
 	}
 
 	private deny(reason: CeilingId, detail: string): ReserveResult {
@@ -125,6 +205,7 @@ export class LedgerCore {
 
 	reserve(req: ReserveRequest, now: Date): ReserveResult {
 		this.purgeExpired(now);
+		this.pruneHistory(now);
 
 		const dayKey = utcDayKey(now);
 		const monthKey = utcMonthKey(now);
@@ -139,71 +220,89 @@ export class LedgerCore {
 		}
 
 		const heldDaily = this.heldDailyUsd(dayKey);
-		let lastReason: CeilingId = 'monthly-provider';
+		let dailyRemaining = this.ceilings.dailySpendUsd - daily.usd - heldDaily;
+		let sawDailyBlock = false;
+		let sawDailyFit = false;
+		const plannedMonthly = new Map<string, number>();
+		const planned: ProviderReservation[] = [];
 
 		for (const candidate of req.candidates) {
 			const worst = worstCaseCostUsd(candidate.model, req.maxInputTokens, req.maxOutputTokens);
 
-			// Global daily spend — provider-independent, but a cheaper candidate
-			// may still fit, so record and keep trying rather than denying outright.
-			if (daily.usd + heldDaily + worst > this.ceilings.dailySpendUsd) {
-				lastReason = 'daily-spend';
+			// Global daily spend — provider-independent. A later candidate can be
+			// cheaper, so keep scanning rather than failing on the first miss.
+			if (worst > dailyRemaining) {
+				sawDailyBlock = true;
 				continue;
 			}
+			sawDailyFit = true;
 
 			const monthCap = this.ceilings.monthlyProviderUsd[candidate.provider];
-			const committedMonth =
-				this.committedMonthly.get(monthlyKey(monthKey, candidate.provider)) ?? 0;
+			const mKey = monthlyKey(monthKey, candidate.provider);
+			const committedMonth = this.committedMonthly.get(mKey) ?? 0;
 			const heldMonth = this.heldMonthlyUsd(monthKey, candidate.provider);
-			if (committedMonth + heldMonth + worst > monthCap) {
-				lastReason = 'monthly-provider';
+			const alreadyPlanned = plannedMonthly.get(mKey) ?? 0;
+			if (committedMonth + heldMonth + alreadyPlanned + worst > monthCap) {
 				continue;
 			}
 
-			// Admit. Request count commits immediately (the request is happening);
-			// only the dollar amount is held and reconciled later.
-			this.committedDaily.set(dayKey, { usd: daily.usd, requests: daily.requests + 1 });
 			const reservationId = this.newId();
 			const expiresAt = now.getTime() + this.ttlMs;
-			this.reservations.set(reservationId, {
+			planned.push({
+				reservationId,
 				provider: candidate.provider,
 				model: candidate.model,
-				usd: worst,
+				reservedUsd: worst,
+				expiresAt
+			});
+			plannedMonthly.set(mKey, alreadyPlanned + worst);
+			dailyRemaining -= worst;
+		}
+
+		// Count every ledger-adjudicated chat request, including over-budget
+		// refusals, so the global request backstop protects the ledger path too.
+		this.committedDaily.set(dayKey, { usd: daily.usd, requests: daily.requests + 1 });
+
+		if (planned.length === 0) {
+			const reason: CeilingId = !sawDailyFit && sawDailyBlock ? 'daily-spend' : 'monthly-provider';
+			const detail =
+				reason === 'daily-spend'
+					? `Daily spend cap reached ($${this.ceilings.dailySpendUsd}/day).`
+					: 'All candidate providers are over their monthly cap.';
+			return this.deny(reason, detail);
+		}
+
+		for (const hold of planned) {
+			this.putReservation(hold.reservationId, {
+				provider: hold.provider,
+				model: hold.model,
+				usd: hold.reservedUsd,
 				dayKey,
 				monthKey,
-				expiresAt
+				expiresAt: hold.expiresAt
 			});
 
 			this.emit({
 				type: 'reserve',
-				reservationId,
-				provider: candidate.provider,
-				model: candidate.model,
-				reservedUsd: worst,
+				reservationId: hold.reservationId,
+				provider: hold.provider,
+				model: hold.model,
+				reservedUsd: hold.reservedUsd,
 				day: dayKey,
 				month: monthKey
 			});
-
-			return {
-				ok: true,
-				reservationId,
-				provider: candidate.provider,
-				model: candidate.model,
-				reservedUsd: worst,
-				expiresAt
-			};
 		}
 
-		const detail =
-			lastReason === 'daily-spend'
-				? `Daily spend cap reached ($${this.ceilings.dailySpendUsd}/day).`
-				: 'All candidate providers are over their monthly cap.';
-		return this.deny(lastReason, detail);
+		return {
+			ok: true,
+			...planned[0],
+			reservations: planned
+		};
 	}
 
 	reconcile(reservationId: string, actual: ReconcileInput, now: Date): void {
-		const res = this.reservations.get(reservationId);
-		this.reservations.delete(reservationId);
+		const res = this.takeReservation(reservationId);
+		const usd = Math.max(0, actual.usd);
 
 		// Commit actual spend even if the hold already expired — the request did
 		// spend the money. Prefer the reservation's buckets so a request that
@@ -212,31 +311,31 @@ export class LedgerCore {
 		const monthKey = res?.monthKey ?? utcMonthKey(now);
 
 		const daily = this.committedDaily.get(dayKey) ?? { usd: 0, requests: 0 };
-		this.committedDaily.set(dayKey, { usd: daily.usd + actual.usd, requests: daily.requests });
+		this.committedDaily.set(dayKey, { usd: daily.usd + usd, requests: daily.requests });
 
 		const mKey = monthlyKey(monthKey, actual.provider);
-		this.committedMonthly.set(mKey, (this.committedMonthly.get(mKey) ?? 0) + actual.usd);
+		this.committedMonthly.set(mKey, (this.committedMonthly.get(mKey) ?? 0) + usd);
+		this.pruneHistory(now);
 
-		this.emit({ type: 'commit', reservationId, provider: actual.provider, usd: actual.usd });
+		this.emit({ type: 'commit', reservationId, provider: actual.provider, usd });
 	}
 
-	release(reservationId: string): void {
-		this.reservations.delete(reservationId);
+	release(reservationId: string, now?: Date): void {
+		this.takeReservation(reservationId);
+		if (now) this.pruneHistory(now);
 		this.emit({ type: 'refund', reservationId });
 	}
 
 	status(now: Date): LedgerStatus {
-		this.purgeExpired(now);
 		const dayKey = utcDayKey(now);
 		const monthKey = utcMonthKey(now);
 		const daily = this.committedDaily.get(dayKey) ?? { usd: 0, requests: 0 };
 
-		const providers: LlmProvider[] = ['claude', 'openai'];
 		const monthly = {} as LedgerStatus['monthly'];
-		for (const provider of providers) {
+		for (const provider of LLM_PROVIDERS) {
 			monthly[provider] = {
 				spentUsd: this.committedMonthly.get(monthlyKey(monthKey, provider)) ?? 0,
-				reservedUsd: this.heldMonthlyUsd(monthKey, provider),
+				reservedUsd: this.heldMonthlyUsdAt(monthKey, provider, now),
 				capUsd: this.ceilings.monthlyProviderUsd[provider]
 			};
 		}
@@ -246,13 +345,13 @@ export class LedgerCore {
 			month: monthKey,
 			daily: {
 				spentUsd: daily.usd,
-				reservedUsd: this.heldDailyUsd(dayKey),
+				reservedUsd: this.heldDailyUsdAt(dayKey, now),
 				requests: daily.requests,
 				spendCapUsd: this.ceilings.dailySpendUsd,
 				requestCap: this.ceilings.dailyRequests
 			},
 			monthly,
-			activeReservations: this.reservations.size
+			activeReservations: this.activeReservationCountAt(now)
 		};
 	}
 

--- a/src/lib/server/spend-ledger/ledger-core.ts
+++ b/src/lib/server/spend-ledger/ledger-core.ts
@@ -1,0 +1,245 @@
+import type { LlmProvider } from '$lib/types';
+import { worstCaseCostUsd } from './cost';
+import type {
+	CeilingId,
+	LedgerCeilings,
+	LedgerStatus,
+	ReconcileInput,
+	ReserveRequest,
+	ReserveResult
+} from './types';
+
+/**
+ * Pure, storage-agnostic Spend Ledger logic. Both adapters (in-memory and the
+ * Durable Object) delegate here; the DO simply persists this state between
+ * calls. Keeping the rules in one pure object is what makes the load-bearing
+ * invariant — committed-plus-reserved can never exceed a ceiling — unit-testable
+ * without a Workers runtime.
+ *
+ * Time is always passed in (`now`) and ids come from an injected factory, so the
+ * core is deterministic and free of `Date.now()` / `Math.random()`.
+ */
+
+interface Reservation {
+	provider: LlmProvider;
+	model: string;
+	usd: number;
+	dayKey: string;
+	monthKey: string;
+	expiresAt: number;
+}
+
+interface DailyCommit {
+	usd: number;
+	requests: number;
+}
+
+/** Serializable snapshot so the DO adapter can persist/restore core state. */
+export interface LedgerState {
+	committedDaily: Record<string, DailyCommit>;
+	committedMonthly: Record<string, number>;
+	reservations: Record<string, Reservation>;
+}
+
+export interface LedgerCoreOptions {
+	ceilings: LedgerCeilings;
+	/** How long a hold survives without reconciliation before auto-refunding. */
+	reservationTtlMs: number;
+	/** Injectable for deterministic tests; defaults to crypto.randomUUID(). */
+	idFactory?: () => string;
+	/** Restore prior state (DO adapter). */
+	state?: LedgerState;
+}
+
+function utcDayKey(now: Date): string {
+	const yyyy = now.getUTCFullYear();
+	const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+	const dd = String(now.getUTCDate()).padStart(2, '0');
+	return `${yyyy}-${mm}-${dd}`;
+}
+
+function utcMonthKey(now: Date): string {
+	const yyyy = now.getUTCFullYear();
+	const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
+	return `${yyyy}-${mm}`;
+}
+
+function monthlyKey(monthKey: string, provider: LlmProvider): string {
+	return `${monthKey}:${provider}`;
+}
+
+export class LedgerCore {
+	private readonly ceilings: LedgerCeilings;
+	private readonly ttlMs: number;
+	private readonly newId: () => string;
+
+	private committedDaily: Map<string, DailyCommit>;
+	private committedMonthly: Map<string, number>;
+	private reservations: Map<string, Reservation>;
+
+	constructor(opts: LedgerCoreOptions) {
+		this.ceilings = opts.ceilings;
+		this.ttlMs = opts.reservationTtlMs;
+		this.newId = opts.idFactory ?? (() => crypto.randomUUID());
+		this.committedDaily = new Map(Object.entries(opts.state?.committedDaily ?? {}));
+		this.committedMonthly = new Map(Object.entries(opts.state?.committedMonthly ?? {}));
+		this.reservations = new Map(Object.entries(opts.state?.reservations ?? {}));
+	}
+
+	/** Drop expired holds so their dollars stop counting against ceilings. */
+	private purgeExpired(now: Date): void {
+		const cutoff = now.getTime();
+		for (const [id, res] of this.reservations) {
+			if (res.expiresAt <= cutoff) this.reservations.delete(id);
+		}
+	}
+
+	private heldDailyUsd(dayKey: string): number {
+		let sum = 0;
+		for (const res of this.reservations.values()) {
+			if (res.dayKey === dayKey) sum += res.usd;
+		}
+		return sum;
+	}
+
+	private heldMonthlyUsd(monthKey: string, provider: LlmProvider): number {
+		let sum = 0;
+		for (const res of this.reservations.values()) {
+			if (res.monthKey === monthKey && res.provider === provider) sum += res.usd;
+		}
+		return sum;
+	}
+
+	private deny(ceiling: CeilingId, reason: string): ReserveResult {
+		return { ok: false, ceiling, reason };
+	}
+
+	reserve(req: ReserveRequest, now: Date): ReserveResult {
+		this.purgeExpired(now);
+
+		const dayKey = utcDayKey(now);
+		const monthKey = utcMonthKey(now);
+		const daily = this.committedDaily.get(dayKey) ?? { usd: 0, requests: 0 };
+
+		// Daily request count is dollar-independent: if it's full, nothing fits.
+		if (daily.requests + 1 > this.ceilings.dailyRequests) {
+			return this.deny(
+				'daily-requests',
+				`Daily request cap reached (${this.ceilings.dailyRequests}/day).`
+			);
+		}
+
+		const heldDaily = this.heldDailyUsd(dayKey);
+		let lastReason: CeilingId = 'monthly-provider';
+
+		for (const candidate of req.candidates) {
+			const worst = worstCaseCostUsd(candidate.model, req.maxInputTokens, req.maxOutputTokens);
+
+			// Global daily spend — provider-independent, but a cheaper candidate
+			// may still fit, so record and keep trying rather than denying outright.
+			if (daily.usd + heldDaily + worst > this.ceilings.dailySpendUsd) {
+				lastReason = 'daily-spend';
+				continue;
+			}
+
+			const monthCap = this.ceilings.monthlyProviderUsd[candidate.provider];
+			const committedMonth =
+				this.committedMonthly.get(monthlyKey(monthKey, candidate.provider)) ?? 0;
+			const heldMonth = this.heldMonthlyUsd(monthKey, candidate.provider);
+			if (committedMonth + heldMonth + worst > monthCap) {
+				lastReason = 'monthly-provider';
+				continue;
+			}
+
+			// Admit. Request count commits immediately (the request is happening);
+			// only the dollar amount is held and reconciled later.
+			this.committedDaily.set(dayKey, { usd: daily.usd, requests: daily.requests + 1 });
+			const reservationId = this.newId();
+			const expiresAt = now.getTime() + this.ttlMs;
+			this.reservations.set(reservationId, {
+				provider: candidate.provider,
+				model: candidate.model,
+				usd: worst,
+				dayKey,
+				monthKey,
+				expiresAt
+			});
+
+			return {
+				ok: true,
+				reservationId,
+				provider: candidate.provider,
+				model: candidate.model,
+				reservedUsd: worst,
+				expiresAt
+			};
+		}
+
+		const reason =
+			lastReason === 'daily-spend'
+				? `Daily spend cap reached ($${this.ceilings.dailySpendUsd}/day).`
+				: 'All candidate providers are over their monthly cap.';
+		return this.deny(lastReason, reason);
+	}
+
+	reconcile(reservationId: string, actual: ReconcileInput, now: Date): void {
+		const res = this.reservations.get(reservationId);
+		this.reservations.delete(reservationId);
+
+		// Commit actual spend even if the hold already expired — the request did
+		// spend the money. Prefer the reservation's buckets so a request that
+		// crossed a day/month boundary settles where it was admitted.
+		const dayKey = res?.dayKey ?? utcDayKey(now);
+		const monthKey = res?.monthKey ?? utcMonthKey(now);
+
+		const daily = this.committedDaily.get(dayKey) ?? { usd: 0, requests: 0 };
+		this.committedDaily.set(dayKey, { usd: daily.usd + actual.usd, requests: daily.requests });
+
+		const mKey = monthlyKey(monthKey, actual.provider);
+		this.committedMonthly.set(mKey, (this.committedMonthly.get(mKey) ?? 0) + actual.usd);
+	}
+
+	release(reservationId: string): void {
+		this.reservations.delete(reservationId);
+	}
+
+	status(now: Date): LedgerStatus {
+		this.purgeExpired(now);
+		const dayKey = utcDayKey(now);
+		const monthKey = utcMonthKey(now);
+		const daily = this.committedDaily.get(dayKey) ?? { usd: 0, requests: 0 };
+
+		const providers: LlmProvider[] = ['claude', 'openai'];
+		const monthly = {} as LedgerStatus['monthly'];
+		for (const provider of providers) {
+			monthly[provider] = {
+				spentUsd: this.committedMonthly.get(monthlyKey(monthKey, provider)) ?? 0,
+				reservedUsd: this.heldMonthlyUsd(monthKey, provider),
+				capUsd: this.ceilings.monthlyProviderUsd[provider]
+			};
+		}
+
+		return {
+			day: dayKey,
+			month: monthKey,
+			daily: {
+				spentUsd: daily.usd,
+				reservedUsd: this.heldDailyUsd(dayKey),
+				requests: daily.requests,
+				spendCapUsd: this.ceilings.dailySpendUsd,
+				requestCap: this.ceilings.dailyRequests
+			},
+			monthly,
+			activeReservations: this.reservations.size
+		};
+	}
+
+	/** Serialize for the DO adapter to persist. */
+	snapshot(): LedgerState {
+		return {
+			committedDaily: Object.fromEntries(this.committedDaily),
+			committedMonthly: Object.fromEntries(this.committedMonthly),
+			reservations: Object.fromEntries(this.reservations)
+		};
+	}
+}

--- a/src/lib/server/spend-ledger/ledger-core.ts
+++ b/src/lib/server/spend-ledger/ledger-core.ts
@@ -110,8 +110,8 @@ export class LedgerCore {
 		return sum;
 	}
 
-	private deny(ceiling: CeilingId, reason: string): ReserveResult {
-		return { ok: false, ceiling, reason };
+	private deny(reason: CeilingId, detail: string): ReserveResult {
+		return { ok: false, reason, detail };
 	}
 
 	reserve(req: ReserveRequest, now: Date): ReserveResult {
@@ -175,11 +175,11 @@ export class LedgerCore {
 			};
 		}
 
-		const reason =
+		const detail =
 			lastReason === 'daily-spend'
 				? `Daily spend cap reached ($${this.ceilings.dailySpendUsd}/day).`
 				: 'All candidate providers are over their monthly cap.';
-		return this.deny(lastReason, reason);
+		return this.deny(lastReason, detail);
 	}
 
 	reconcile(reservationId: string, actual: ReconcileInput, now: Date): void {

--- a/src/lib/server/spend-ledger/observability.test.ts
+++ b/src/lib/server/spend-ledger/observability.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LedgerCore } from './ledger-core';
+import { logLedgerEvent, type LedgerEvent } from './observability';
+
+const NOW = new Date('2026-06-11T12:00:00Z');
+const OPENAI = { provider: 'openai' as const, model: 'gpt-4o-mini' };
+const ONE_M_INPUT = { candidates: [OPENAI], maxInputTokens: 1_000_000, maxOutputTokens: 0 };
+
+function makeCore(events: LedgerEvent[], dailySpendUsd = 100) {
+	let n = 0;
+	return new LedgerCore({
+		ceilings: {
+			dailySpendUsd,
+			dailyRequests: 100_000,
+			monthlyProviderUsd: { claude: 100, openai: 100 }
+		},
+		reservationTtlMs: 60_000,
+		idFactory: () => `r${++n}`,
+		emit: (event) => events.push(event)
+	});
+}
+
+describe('LedgerCore observability', () => {
+	it('emits reserve on admission with the bucket keys', () => {
+		const events: LedgerEvent[] = [];
+		makeCore(events).reserve(ONE_M_INPUT, NOW);
+
+		expect(events).toEqual([
+			{
+				type: 'reserve',
+				reservationId: 'r1',
+				provider: 'openai',
+				model: 'gpt-4o-mini',
+				reservedUsd: 0.15,
+				day: '2026-06-11',
+				month: '2026-06'
+			}
+		]);
+	});
+
+	it('emits commit on reconcile and refund on release', () => {
+		const events: LedgerEvent[] = [];
+		const core = makeCore(events);
+		const r = core.reserve(ONE_M_INPUT, NOW);
+		if (!r.ok) throw new Error('expected reserve to succeed');
+		core.reconcile(r.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
+
+		const second = core.reserve(ONE_M_INPUT, NOW);
+		if (!second.ok) throw new Error('expected reserve to succeed');
+		core.release(second.reservationId);
+
+		expect(events.map((e) => e.type)).toEqual(['reserve', 'commit', 'reserve', 'refund']);
+	});
+
+	it('emits deny when a ceiling refuses the request', () => {
+		const events: LedgerEvent[] = [];
+		makeCore(events, 0.05).reserve(ONE_M_INPUT, NOW); // worst-case $0.15 > $0.05 cap
+
+		expect(events).toEqual([{ type: 'deny', reason: 'daily-spend', detail: expect.any(String) }]);
+	});
+
+	it('emits expire when an orphaned hold ages out', () => {
+		const events: LedgerEvent[] = [];
+		const core = makeCore(events);
+		const r = core.reserve(ONE_M_INPUT, NOW);
+		if (!r.ok) throw new Error('expected reserve to succeed');
+
+		// A later reserve triggers purgeExpired, which ages out the orphaned hold.
+		core.reserve(ONE_M_INPUT, new Date(NOW.getTime() + 61_000));
+
+		expect(events.some((e) => e.type === 'expire' && e.reservationId === r.reservationId)).toBe(
+			true
+		);
+	});
+});
+
+describe('logLedgerEvent', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it('writes one queryable JSON line per event', () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		logLedgerEvent({ type: 'deny', reason: 'monthly-provider', detail: 'over cap' });
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		const logged = JSON.parse(spy.mock.calls[0][0] as string);
+		expect(logged).toMatchObject({
+			event: 'spend-ledger',
+			decision: 'deny',
+			reason: 'monthly-provider'
+		});
+	});
+});

--- a/src/lib/server/spend-ledger/observability.test.ts
+++ b/src/lib/server/spend-ledger/observability.test.ts
@@ -31,7 +31,7 @@ describe('LedgerCore observability', () => {
 				reservationId: 'r1',
 				provider: 'openai',
 				model: 'gpt-4o-mini',
-				reservedUsd: 0.15,
+				reservedUsd: 0.1875,
 				day: '2026-06-11',
 				month: '2026-06'
 			}

--- a/src/lib/server/spend-ledger/observability.ts
+++ b/src/lib/server/spend-ledger/observability.ts
@@ -1,0 +1,40 @@
+import type { LlmProvider } from '$lib/types';
+import type { DenialReason } from './types';
+
+/**
+ * One structured event per ledger decision, so the cap can be watched working
+ * in production and refusals can be diagnosed (docs/prd/cost-abuse-hardening.md).
+ *
+ * The pure `LedgerCore` takes an `emit` sink (default no-op, to stay
+ * deterministic in tests); the production Durable Object wires it to
+ * `logLedgerEvent`, which the reminder Worker's `observability` captures.
+ */
+export type LedgerEvent =
+	| {
+			type: 'reserve';
+			reservationId: string;
+			provider: LlmProvider;
+			model: string;
+			reservedUsd: number;
+			day: string;
+			month: string;
+	  }
+	| { type: 'deny'; reason: DenialReason; detail: string }
+	| { type: 'commit'; reservationId: string; provider: LlmProvider; usd: number }
+	| { type: 'refund'; reservationId: string }
+	| { type: 'expire'; reservationId: string; provider: LlmProvider; usd: number };
+
+export type LedgerEventSink = (event: LedgerEvent) => void;
+
+/**
+ * Default sink: emit one JSON line per event. Cloudflare's Workers Logs index
+ * the fields, so `event:"spend-ledger"` + `decision` are queryable. Logging must
+ * never break a chat response, so a failing sink is swallowed.
+ */
+export function logLedgerEvent(event: LedgerEvent): void {
+	try {
+		console.log(JSON.stringify({ event: 'spend-ledger', decision: event.type, ...event }));
+	} catch {
+		// Never let observability throw into the request path.
+	}
+}

--- a/src/lib/server/spend-ledger/types.ts
+++ b/src/lib/server/spend-ledger/types.ts
@@ -7,7 +7,9 @@ import type { LlmProvider } from '$lib/types';
  * The ledger works by reserve-then-reconcile: a request reserves its worst-case
  * cost before streaming, then reconciles to the actual cost once the stream
  * finishes. Reservations count against the ceilings immediately, so concurrent
- * requests can never push committed-plus-reserved spend past a cap.
+ * requests can never push committed-plus-reserved spend past a cap. When the
+ * route is willing to fail over across providers, the reserve call returns one
+ * hold per fallback candidate that also fits the configured ceilings.
  */
 
 /** A ceiling the ledger can refuse against. Used for denial reasons + metrics. */
@@ -28,7 +30,7 @@ export interface CandidateProvider {
 }
 
 export interface ReserveRequest {
-	/** Ordered provider/model preferences. The ledger admits the first that fits. */
+	/** Ordered provider/model preferences. The ledger reserves each candidate that fits. */
 	candidates: CandidateProvider[];
 	/** Upper-bound input tokens for this request (used for the worst-case hold). */
 	maxInputTokens: number;
@@ -36,19 +38,28 @@ export interface ReserveRequest {
 	maxOutputTokens: number;
 }
 
+export interface ProviderReservation {
+	/** Opaque id passed back to reconcile/release. */
+	reservationId: string;
+	/** Provider/model covered by this hold. */
+	provider: LlmProvider;
+	model: string;
+	/** Worst-case dollars held against the ceilings until reconciled. */
+	reservedUsd: number;
+	/** Epoch ms after which an un-reconciled hold auto-refunds. */
+	expiresAt: number;
+}
+
 export type ReserveResult =
-	| {
+	| ({
 			ok: true;
-			/** Opaque id passed back to reconcile/release. */
-			reservationId: string;
-			/** The provider/model the ledger admitted (first candidate that fit). */
-			provider: LlmProvider;
-			model: string;
-			/** Worst-case dollars held against the ceilings until reconciled. */
-			reservedUsd: number;
-			/** Epoch ms after which an un-reconciled hold auto-refunds. */
-			expiresAt: number;
-	  }
+			/**
+			 * Provider holds reserved up front for operational failover. The first
+			 * entry is the preferred provider; later entries are fallbacks that also
+			 * fit their monthly cap and the remaining daily spend headroom.
+			 */
+			reservations: ProviderReservation[];
+	  } & ProviderReservation)
 	| {
 			ok: false;
 			/** Why the request was refused (a ceiling, or the ledger being unreachable). */
@@ -83,7 +94,7 @@ export interface LedgerStatus {
  * in-memory adapter.
  */
 export interface SpendLedger {
-	/** Reserve worst-case cost and admit a provider, or refuse with a ceiling. */
+	/** Reserve worst-case cost for the provider fallback plan, or refuse with a ceiling. */
 	reserve(req: ReserveRequest, now: Date): Promise<ReserveResult>;
 	/** Settle a completed request to its actual cost (releases the hold). */
 	reconcile(reservationId: string, actual: ReconcileInput, now: Date): Promise<void>;

--- a/src/lib/server/spend-ledger/types.ts
+++ b/src/lib/server/spend-ledger/types.ts
@@ -1,0 +1,98 @@
+import type { LlmProvider } from '$lib/types';
+
+/**
+ * Spend Ledger — the single authority for every *dollar* ceiling on the chat
+ * endpoint. See CONTEXT.md (Cost control) and docs/adr/0005-exact-spend-enforcement.md.
+ *
+ * The ledger works by reserve-then-reconcile: a request reserves its worst-case
+ * cost before streaming, then reconciles to the actual cost once the stream
+ * finishes. Reservations count against the ceilings immediately, so concurrent
+ * requests can never push committed-plus-reserved spend past a cap.
+ */
+
+/** A ceiling the ledger can refuse against. Used for denial reasons + metrics. */
+export type CeilingId = 'daily-spend' | 'daily-requests' | 'monthly-provider';
+
+/** One provider/model the request is willing to use, in preference order. */
+export interface CandidateProvider {
+	provider: LlmProvider;
+	model: string;
+}
+
+export interface ReserveRequest {
+	/** Ordered provider/model preferences. The ledger admits the first that fits. */
+	candidates: CandidateProvider[];
+	/** Upper-bound input tokens for this request (used for the worst-case hold). */
+	maxInputTokens: number;
+	/** Hard output-token cap for this request (used for the worst-case hold). */
+	maxOutputTokens: number;
+}
+
+export type ReserveResult =
+	| {
+			ok: true;
+			/** Opaque id passed back to reconcile/release. */
+			reservationId: string;
+			/** The provider/model the ledger admitted (first candidate that fit). */
+			provider: LlmProvider;
+			model: string;
+			/** Worst-case dollars held against the ceilings until reconciled. */
+			reservedUsd: number;
+			/** Epoch ms after which an un-reconciled hold auto-refunds. */
+			expiresAt: number;
+	  }
+	| {
+			ok: false;
+			/** Which ceiling refused the request. */
+			ceiling: CeilingId;
+			/** Human-readable reason, safe to log. */
+			reason: string;
+	  };
+
+/** Actual settled cost for a completed request, from real token usage. */
+export interface ReconcileInput {
+	provider: LlmProvider;
+	usd: number;
+}
+
+export interface LedgerStatus {
+	day: string;
+	month: string;
+	daily: {
+		spentUsd: number;
+		reservedUsd: number;
+		requests: number;
+		spendCapUsd: number;
+		requestCap: number;
+	};
+	monthly: Record<LlmProvider, { spentUsd: number; reservedUsd: number; capUsd: number }>;
+	activeReservations: number;
+}
+
+/**
+ * The port. The chat route depends on this interface, never on a concrete store.
+ * Production binds the Durable-Object-backed adapter; dev/tests bind the
+ * in-memory adapter.
+ */
+export interface SpendLedger {
+	/** Reserve worst-case cost and admit a provider, or refuse with a ceiling. */
+	reserve(req: ReserveRequest, now: Date): Promise<ReserveResult>;
+	/** Settle a completed request to its actual cost (releases the hold). */
+	reconcile(reservationId: string, actual: ReconcileInput, now: Date): Promise<void>;
+	/** Refund an un-spent hold (request produced no billable usage). */
+	release(reservationId: string, now: Date): Promise<void>;
+	/** Snapshot for observability and tests. */
+	status(now: Date): Promise<LedgerStatus>;
+}
+
+/** Per-provider monthly dollar caps. */
+export type MonthlyProviderCaps = Record<LlmProvider, number>;
+
+export interface LedgerCeilings {
+	/** Global all-visitors spend cap per UTC day (the Daily Circuit Breaker). */
+	dailySpendUsd: number;
+	/** Global all-visitors request cap per UTC day (dollar-independent backstop). */
+	dailyRequests: number;
+	/** Per-provider spend cap per UTC month (the Monthly Provider Cap). */
+	monthlyProviderUsd: MonthlyProviderCaps;
+}

--- a/src/lib/server/spend-ledger/types.ts
+++ b/src/lib/server/spend-ledger/types.ts
@@ -13,6 +13,14 @@ import type { LlmProvider } from '$lib/types';
 /** A ceiling the ledger can refuse against. Used for denial reasons + metrics. */
 export type CeilingId = 'daily-spend' | 'daily-requests' | 'monthly-provider';
 
+/**
+ * Why a reservation was refused: a specific ceiling, or the ledger being
+ * unreachable. `ledger-unavailable` is the fail-closed path — when the money
+ * authority can't be reached in production, the request is denied, never
+ * permitted (see the adapter factory).
+ */
+export type DenialReason = CeilingId | 'ledger-unavailable';
+
 /** One provider/model the request is willing to use, in preference order. */
 export interface CandidateProvider {
 	provider: LlmProvider;
@@ -43,10 +51,10 @@ export type ReserveResult =
 	  }
 	| {
 			ok: false;
-			/** Which ceiling refused the request. */
-			ceiling: CeilingId;
-			/** Human-readable reason, safe to log. */
-			reason: string;
+			/** Why the request was refused (a ceiling, or the ledger being unreachable). */
+			reason: DenialReason;
+			/** Human-readable detail, safe to log. */
+			detail: string;
 	  };
 
 /** Actual settled cost for a completed request, from real token usage. */

--- a/src/lib/server/spend.test.ts
+++ b/src/lib/server/spend.test.ts
@@ -4,12 +4,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
 	canRespond,
 	calculateTokenCostUsd,
-	getMonthlySpend,
-	isProviderOverBudget,
-	monthlySpendKey,
 	rateLimitKey,
 	recordMessage,
-	recordTokens,
 	type SpendConfig
 } from './spend';
 import type { LlmTokenUsage } from '$lib/types';
@@ -73,18 +69,6 @@ function usage(overrides?: Partial<LlmTokenUsage>): LlmTokenUsage {
 
 const TEST_IP = '203.0.113.42';
 
-describe('monthlySpendKey', () => {
-	it('formats as spend:provider:YYYY-MM', () => {
-		const key = monthlySpendKey('openai', new Date('2026-05-23T14:00:00Z'));
-		expect(key).toBe('spend:openai:2026-05');
-	});
-
-	it('zero-pads single-digit months', () => {
-		const key = monthlySpendKey('claude', new Date('2026-01-05T00:00:00Z'));
-		expect(key).toBe('spend:claude:2026-01');
-	});
-});
-
 describe('rateLimitKey', () => {
 	it('formats as rate:IP:YYYY-MM-DD-HH', () => {
 		const key = rateLimitKey(TEST_IP, new Date('2026-05-23T14:30:00Z'));
@@ -116,13 +100,6 @@ describe('canRespond', () => {
 		const result = await canRespond(config, TEST_IP);
 		expect(result.allowed).toBe(false);
 		expect(result.reason).toContain('Rate limit exceeded');
-	});
-
-	it('does not treat monthly spend as a global kill switch', async () => {
-		const config = defaultConfig(kv);
-		kv._store.set(monthlySpendKey('openai'), '1000');
-		const result = await canRespond(config, TEST_IP);
-		expect(result.allowed).toBe(true);
 	});
 });
 
@@ -178,58 +155,6 @@ describe('calculateTokenCostUsd', () => {
 	});
 });
 
-describe('recordTokens', () => {
-	let kv: MockKV;
-
-	beforeEach(() => {
-		kv = createMockKV();
-	});
-
-	it('creates the provider monthly key when none exists', async () => {
-		await recordTokens(kv, usage());
-		const spend = await getMonthlySpend(kv, 'openai');
-		expect(spend).toBeCloseTo(1.35, 5);
-	});
-
-	it('increments an existing provider monthly spend', async () => {
-		kv._store.set(monthlySpendKey('openai'), '10');
-		await recordTokens(kv, usage());
-		const spend = await getMonthlySpend(kv, 'openai');
-		expect(spend).toBeCloseTo(11.35, 5);
-	});
-
-	it('records spend against the provider actually used', async () => {
-		await recordTokens(kv, usage({ provider: 'claude', model: 'claude-haiku-4-5-20251001' }));
-
-		expect(await getMonthlySpend(kv, 'openai')).toBe(0);
-		expect(await getMonthlySpend(kv, 'claude')).toBeCloseTo(11, 5);
-	});
-
-	it('handles zero tokens gracefully', async () => {
-		await recordTokens(kv, usage({ inputTokens: 0, outputTokens: 0 }));
-		const spend = await getMonthlySpend(kv, 'openai');
-		expect(spend).toBe(0);
-	});
-});
-
-describe('isProviderOverBudget', () => {
-	let kv: MockKV;
-
-	beforeEach(() => {
-		kv = createMockKV();
-	});
-
-	it('returns false below the provider budget', async () => {
-		kv._store.set(monthlySpendKey('openai'), '24.99');
-		await expect(isProviderOverBudget(kv, 'openai', 25)).resolves.toBe(false);
-	});
-
-	it('returns true at the provider budget', async () => {
-		kv._store.set(monthlySpendKey('openai'), '25');
-		await expect(isProviderOverBudget(kv, 'openai', 25)).resolves.toBe(true);
-	});
-});
-
 describe('recordMessage', () => {
 	let kv: MockKV;
 
@@ -258,24 +183,5 @@ describe('recordMessage', () => {
 
 		expect(kv._store.get(rateLimitKey(TEST_IP))).toBe('2');
 		expect(kv._store.get(rateLimitKey(ip2))).toBe('1');
-	});
-});
-
-describe('getMonthlySpend', () => {
-	let kv: MockKV;
-
-	beforeEach(() => {
-		kv = createMockKV();
-	});
-
-	it('returns 0 when no spend has been recorded', async () => {
-		const spend = await getMonthlySpend(kv, 'openai');
-		expect(spend).toBe(0);
-	});
-
-	it('returns the stored provider spend value', async () => {
-		kv._store.set(monthlySpendKey('openai'), '42.75');
-		const spend = await getMonthlySpend(kv, 'openai');
-		expect(spend).toBe(42.75);
 	});
 });

--- a/src/lib/server/spend.ts
+++ b/src/lib/server/spend.ts
@@ -1,14 +1,16 @@
 /// <reference types="@cloudflare/workers-types" />
 
 /**
- * Spend control / kill-switch module.
+ * Per-IP rate throttle + model pricing.
  *
- * Tracks per-provider monthly token spend and per-IP hourly rate limits via
- * Cloudflare KV. Provider budgets are soft fallback controls: once a provider
- * reaches its monthly cap, callers should skip it and try the next provider.
+ * Dollar ceilings are owned by the Spend Ledger now (see
+ * `src/lib/server/spend-ledger/`, docs/adr/0005); the superseded KV monthly
+ * spend counters were removed. What remains here is the approximate per-IP
+ * hourly rate throttle (a fairness control, not a money guarantee) and the
+ * canonical model pricing table the ledger reuses for cost.
  */
 
-import type { LlmProvider, LlmTokenUsage } from '$lib/types';
+import type { LlmTokenUsage } from '$lib/types';
 
 // ---------------------------------------------------------------------------
 // Cost constants
@@ -68,13 +70,6 @@ export interface CanRespondResult {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** "spend:openai:2026-05" */
-export function monthlySpendKey(provider: LlmProvider, now: Date = new Date()): string {
-	const yyyy = now.getUTCFullYear();
-	const mm = String(now.getUTCMonth() + 1).padStart(2, '0');
-	return `spend:${provider}:${yyyy}-${mm}`;
-}
 
 /** "rate:203.0.113.42:2026-05-23-14" */
 export function rateLimitKey(ip: string, now: Date = new Date()): string {
@@ -150,35 +145,4 @@ export function calculateTokenCostUsd(usage: LlmTokenUsage): number {
 		((usage.cacheReadInputTokens ?? 0) * (pricing.cacheReadInput ?? pricing.input * 0.1)) /
 			1_000_000
 	);
-}
-
-/**
- * Record tokens consumed after a response has been generated.
- * Converts the token count to USD and adds it to the monthly spend counter.
- */
-export async function recordTokens(kv: KVNamespace, usage: LlmTokenUsage): Promise<number> {
-	const key = monthlySpendKey(usage.provider);
-	const raw = await kv.get(key);
-	const current = raw ? parseFloat(raw) : 0;
-	const cost = calculateTokenCostUsd(usage);
-	await kv.put(key, String(current + cost));
-	return cost;
-}
-
-/**
- * Return the current monthly spend in USD for a provider.
- */
-export async function getMonthlySpend(kv: KVNamespace, provider: LlmProvider): Promise<number> {
-	const raw = await kv.get(monthlySpendKey(provider));
-	return raw ? parseFloat(raw) : 0;
-}
-
-export async function isProviderOverBudget(
-	kv: KVNamespace,
-	provider: LlmProvider,
-	monthlyBudget: number
-): Promise<boolean> {
-	if (!Number.isFinite(monthlyBudget)) return false;
-	const spend = await getMonthlySpend(kv, provider);
-	return spend >= monthlyBudget;
 }

--- a/src/lib/server/turnstile.test.ts
+++ b/src/lib/server/turnstile.test.ts
@@ -3,7 +3,8 @@ import {
 	evaluateChatGate,
 	issueSessionToken,
 	verifySessionToken,
-	verifyTurnstileToken
+	verifyTurnstileToken,
+	verifyTurnstileTokenResult
 } from './turnstile';
 
 const SECRET = 'test-turnstile-secret';
@@ -62,8 +63,17 @@ describe('verifyTurnstileToken', () => {
 	});
 
 	it('returns false on a non-2xx siteverify response', async () => {
-		expect(await verifyTurnstileToken(SECRET, 'tok', undefined, siteverify(true, false))).toBe(
-			false
+		const fetchImpl = siteverify(true, false);
+		expect(await verifyTurnstileToken(SECRET, 'tok', undefined, fetchImpl)).toBe(false);
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+	});
+
+	it('distinguishes verifier outages from invalid tokens', async () => {
+		expect(
+			await verifyTurnstileTokenResult(SECRET, 'tok', undefined, siteverify(true, false))
+		).toBe('unavailable');
+		expect(await verifyTurnstileTokenResult(SECRET, 'tok', undefined, siteverify(false))).toBe(
+			'invalid'
 		);
 	});
 });
@@ -96,6 +106,21 @@ describe('evaluateChatGate', () => {
 			NOW,
 			siteverify(false)
 		);
+		expect(result).toEqual({ ok: false });
+	});
+
+	it('soft-admits a token-bearing request when siteverify is unavailable', async () => {
+		const result = await evaluateChatGate(
+			SECRET,
+			{ turnstileToken: 'tok' },
+			NOW,
+			siteverify(true, false)
+		);
+		expect(result).toEqual({ ok: true });
+	});
+
+	it('does not soft-admit siteverify outages without a token', async () => {
+		const result = await evaluateChatGate(SECRET, {}, NOW, siteverify(true, false));
 		expect(result).toEqual({ ok: false });
 	});
 });

--- a/src/lib/server/turnstile.test.ts
+++ b/src/lib/server/turnstile.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	evaluateChatGate,
+	issueSessionToken,
+	verifySessionToken,
+	verifyTurnstileToken
+} from './turnstile';
+
+const SECRET = 'test-turnstile-secret';
+const NOW = new Date('2026-06-11T12:00:00Z');
+
+function siteverify(success: boolean, ok = true): typeof fetch {
+	return vi.fn(
+		async () => new Response(JSON.stringify({ success }), { status: ok ? 200 : 500 })
+	) as unknown as typeof fetch;
+}
+
+describe('session token', () => {
+	it('round-trips a freshly issued token', async () => {
+		const token = await issueSessionToken(SECRET, NOW);
+		expect(await verifySessionToken(SECRET, token, NOW)).toBe(true);
+	});
+
+	it('rejects a token past its 30-minute window', async () => {
+		const token = await issueSessionToken(SECRET, NOW);
+		const later = new Date(NOW.getTime() + 30 * 60 * 1000 + 1);
+		expect(await verifySessionToken(SECRET, token, later)).toBe(false);
+	});
+
+	it('rejects a tampered signature', async () => {
+		const token = await issueSessionToken(SECRET, NOW);
+		const tampered = token.slice(0, -1) + (token.endsWith('A') ? 'B' : 'A');
+		expect(await verifySessionToken(SECRET, tampered, NOW)).toBe(false);
+	});
+
+	it('rejects a token signed with a different secret', async () => {
+		const token = await issueSessionToken('other-secret', NOW);
+		expect(await verifySessionToken(SECRET, token, NOW)).toBe(false);
+	});
+
+	it('rejects malformed tokens', async () => {
+		expect(await verifySessionToken(SECRET, 'garbage', NOW)).toBe(false);
+		expect(await verifySessionToken(SECRET, '.sig', NOW)).toBe(false);
+		expect(await verifySessionToken(SECRET, 'notanumber.sig', NOW)).toBe(false);
+	});
+});
+
+describe('verifyTurnstileToken', () => {
+	it('posts the secret + token and returns success', async () => {
+		const fetchImpl = siteverify(true);
+		const result = await verifyTurnstileToken(SECRET, 'tok', '203.0.113.7', fetchImpl);
+		expect(result).toBe(true);
+		const [, init] = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+			.calls[0];
+		expect((init.body as FormData).get('secret')).toBe(SECRET);
+		expect((init.body as FormData).get('response')).toBe('tok');
+		expect((init.body as FormData).get('remoteip')).toBe('203.0.113.7');
+	});
+
+	it('returns false when siteverify says failure', async () => {
+		expect(await verifyTurnstileToken(SECRET, 'tok', undefined, siteverify(false))).toBe(false);
+	});
+
+	it('returns false on a non-2xx siteverify response', async () => {
+		expect(await verifyTurnstileToken(SECRET, 'tok', undefined, siteverify(true, false))).toBe(
+			false
+		);
+	});
+});
+
+describe('evaluateChatGate', () => {
+	it('admits everything when no secret is configured (dev fail-open)', async () => {
+		const result = await evaluateChatGate(undefined, { turnstileToken: 'x' }, NOW);
+		expect(result).toEqual({ ok: true });
+	});
+
+	it('admits a valid session token without minting a new one', async () => {
+		const sessionToken = await issueSessionToken(SECRET, NOW);
+		const result = await evaluateChatGate(SECRET, { sessionToken }, NOW, siteverify(false));
+		expect(result).toEqual({ ok: true });
+	});
+
+	it('admits a valid Turnstile token and mints a session token', async () => {
+		const result = await evaluateChatGate(SECRET, { turnstileToken: 'tok' }, NOW, siteverify(true));
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.issuedSessionToken).toBeDefined();
+			expect(await verifySessionToken(SECRET, result.issuedSessionToken!, NOW)).toBe(true);
+		}
+	});
+
+	it('refuses when neither token is valid', async () => {
+		const result = await evaluateChatGate(
+			SECRET,
+			{ turnstileToken: 'bad', sessionToken: 'expired' },
+			NOW,
+			siteverify(false)
+		);
+		expect(result).toEqual({ ok: false });
+	});
+});

--- a/src/lib/server/turnstile.ts
+++ b/src/lib/server/turnstile.ts
@@ -1,0 +1,151 @@
+/**
+ * Turnstile Gate — the proof-of-human check in front of the chat spend path.
+ *
+ * Cadence (PRD decision 10): validate a Cloudflare Turnstile token on the first
+ * message of a session, then issue a short-lived (30 min) signed **session
+ * token** so later messages aren't re-challenged. The gate runs before the Spend
+ * Ledger, so automated floods never reach the money path.
+ *
+ * The session token is stateless: `"<expiryMs>.<hmac>"`, signed with
+ * TURNSTILE_SECRET. There is no per-user identity (the site is anonymous) — the
+ * token only proves "passed Turnstile within the last 30 min". Even a shared
+ * token is bounded by the exact Daily Circuit Breaker, so this is safe.
+ *
+ * Fail-open when unconfigured: with no TURNSTILE_SECRET (dev), the gate admits
+ * everything, so local development needs no Turnstile keys.
+ */
+
+const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+const SESSION_TTL_MS = 30 * 60 * 1000;
+const SESSION_PREFIX = 'chat-session';
+const ALGO = { name: 'HMAC', hash: 'SHA-256' } as const;
+const SIG_BYTES = 24;
+
+// ---------------------------------------------------------------------------
+// Crypto (mirrors the HMAC pattern in email-composer.ts)
+// ---------------------------------------------------------------------------
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+	const bin = [...bytes].map((byte) => String.fromCharCode(byte)).join('');
+	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function sign(secret: string, payload: string): Promise<string> {
+	const enc = new TextEncoder();
+	const key = await crypto.subtle.importKey('raw', enc.encode(secret), ALGO, false, ['sign']);
+	const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload));
+	return bytesToBase64Url(new Uint8Array(sig).slice(0, SIG_BYTES));
+}
+
+/** Constant-time compare of two equal-length strings. */
+function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let mismatch = 0;
+	for (let i = 0; i < a.length; i += 1) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	return mismatch === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Session token
+// ---------------------------------------------------------------------------
+
+/** Mint a signed session token valid for 30 minutes from `now`. */
+export async function issueSessionToken(secret: string, now: Date): Promise<string> {
+	const expiry = now.getTime() + SESSION_TTL_MS;
+	const sig = await sign(secret, `${SESSION_PREFIX}:${expiry}`);
+	return `${expiry}.${sig}`;
+}
+
+/** True iff `token` is a well-formed, correctly signed, unexpired session token. */
+export async function verifySessionToken(
+	secret: string,
+	token: string,
+	now: Date
+): Promise<boolean> {
+	const dot = token.indexOf('.');
+	if (dot <= 0) return false;
+	const expiryStr = token.slice(0, dot);
+	const sig = token.slice(dot + 1);
+
+	const expiry = Number(expiryStr);
+	if (!Number.isFinite(expiry) || now.getTime() >= expiry) return false;
+
+	const expected = await sign(secret, `${SESSION_PREFIX}:${expiry}`);
+	return timingSafeEqual(sig, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Turnstile verification
+// ---------------------------------------------------------------------------
+
+interface SiteverifyResponse {
+	success?: boolean;
+}
+
+/** Validate a Turnstile token with Cloudflare's siteverify endpoint. */
+export async function verifyTurnstileToken(
+	secret: string,
+	token: string,
+	remoteIp: string | undefined,
+	fetchImpl: typeof fetch = fetch
+): Promise<boolean> {
+	const body = new FormData();
+	body.append('secret', secret);
+	body.append('response', token);
+	if (remoteIp) body.append('remoteip', remoteIp);
+
+	try {
+		const response = await fetchImpl(SITEVERIFY_URL, { method: 'POST', body });
+		if (!response.ok) return false;
+		const data = (await response.json()) as SiteverifyResponse;
+		return data.success === true;
+	} catch (err) {
+		console.error('[turnstile] siteverify failed', err);
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The gate
+// ---------------------------------------------------------------------------
+
+export interface ChatGateInput {
+	/** Fresh Turnstile token from the widget (first message of a session). */
+	turnstileToken?: string;
+	/** Previously issued session token (subsequent messages). */
+	sessionToken?: string;
+	/** Caller IP, forwarded to siteverify when available. */
+	remoteIp?: string;
+}
+
+export type ChatGateResult = { ok: true; issuedSessionToken?: string } | { ok: false };
+
+/**
+ * Decide whether a chat request may proceed to the spend path.
+ *
+ * - No secret configured → admit (dev fail-open).
+ * - Valid session token → admit, no new token needed.
+ * - Valid Turnstile token → admit and mint a fresh session token.
+ * - Otherwise → refuse; the client must run the challenge and retry.
+ */
+export async function evaluateChatGate(
+	secret: string | undefined,
+	input: ChatGateInput,
+	now: Date,
+	fetchImpl: typeof fetch = fetch
+): Promise<ChatGateResult> {
+	if (!secret) return { ok: true };
+
+	if (input.sessionToken && (await verifySessionToken(secret, input.sessionToken, now))) {
+		return { ok: true };
+	}
+
+	if (
+		input.turnstileToken &&
+		(await verifyTurnstileToken(secret, input.turnstileToken, input.remoteIp, fetchImpl))
+	) {
+		return { ok: true, issuedSessionToken: await issueSessionToken(secret, now) };
+	}
+
+	return { ok: false };
+}

--- a/src/lib/server/turnstile.ts
+++ b/src/lib/server/turnstile.ts
@@ -15,34 +15,15 @@
  * everything, so local development needs no Turnstile keys.
  */
 
+import { signHmacBase64Url, timingSafeEqual } from './hmac';
+
 const SITEVERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 const SESSION_TTL_MS = 30 * 60 * 1000;
 const SESSION_PREFIX = 'chat-session';
-const ALGO = { name: 'HMAC', hash: 'SHA-256' } as const;
 const SIG_BYTES = 24;
 
-// ---------------------------------------------------------------------------
-// Crypto (mirrors the HMAC pattern in email-composer.ts)
-// ---------------------------------------------------------------------------
-
-function bytesToBase64Url(bytes: Uint8Array): string {
-	const bin = [...bytes].map((byte) => String.fromCharCode(byte)).join('');
-	return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
 async function sign(secret: string, payload: string): Promise<string> {
-	const enc = new TextEncoder();
-	const key = await crypto.subtle.importKey('raw', enc.encode(secret), ALGO, false, ['sign']);
-	const sig = await crypto.subtle.sign('HMAC', key, enc.encode(payload));
-	return bytesToBase64Url(new Uint8Array(sig).slice(0, SIG_BYTES));
-}
-
-/** Constant-time compare of two equal-length strings. */
-function timingSafeEqual(a: string, b: string): boolean {
-	if (a.length !== b.length) return false;
-	let mismatch = 0;
-	for (let i = 0; i < a.length; i += 1) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
-	return mismatch === 0;
+	return signHmacBase64Url(secret, payload, SIG_BYTES);
 }
 
 // ---------------------------------------------------------------------------
@@ -82,13 +63,14 @@ interface SiteverifyResponse {
 	success?: boolean;
 }
 
-/** Validate a Turnstile token with Cloudflare's siteverify endpoint. */
-export async function verifyTurnstileToken(
+export type TurnstileVerificationResult = 'valid' | 'invalid' | 'unavailable';
+
+async function verifyTurnstileTokenOnce(
 	secret: string,
 	token: string,
 	remoteIp: string | undefined,
 	fetchImpl: typeof fetch = fetch
-): Promise<boolean> {
+): Promise<TurnstileVerificationResult> {
 	const body = new FormData();
 	body.append('secret', secret);
 	body.append('response', token);
@@ -96,13 +78,35 @@ export async function verifyTurnstileToken(
 
 	try {
 		const response = await fetchImpl(SITEVERIFY_URL, { method: 'POST', body });
-		if (!response.ok) return false;
+		if (!response.ok) return 'unavailable';
 		const data = (await response.json()) as SiteverifyResponse;
-		return data.success === true;
+		return data.success === true ? 'valid' : 'invalid';
 	} catch (err) {
 		console.error('[turnstile] siteverify failed', err);
-		return false;
+		return 'unavailable';
 	}
+}
+
+/** Validate a Turnstile token with Cloudflare's siteverify endpoint. */
+export async function verifyTurnstileTokenResult(
+	secret: string,
+	token: string,
+	remoteIp: string | undefined,
+	fetchImpl: typeof fetch = fetch
+): Promise<TurnstileVerificationResult> {
+	const first = await verifyTurnstileTokenOnce(secret, token, remoteIp, fetchImpl);
+	if (first !== 'unavailable') return first;
+	return verifyTurnstileTokenOnce(secret, token, remoteIp, fetchImpl);
+}
+
+/** Boolean compatibility wrapper for callers that only need valid/invalid. */
+export async function verifyTurnstileToken(
+	secret: string,
+	token: string,
+	remoteIp: string | undefined,
+	fetchImpl: typeof fetch = fetch
+): Promise<boolean> {
+	return (await verifyTurnstileTokenResult(secret, token, remoteIp, fetchImpl)) === 'valid';
 }
 
 // ---------------------------------------------------------------------------
@@ -140,11 +144,20 @@ export async function evaluateChatGate(
 		return { ok: true };
 	}
 
-	if (
-		input.turnstileToken &&
-		(await verifyTurnstileToken(secret, input.turnstileToken, input.remoteIp, fetchImpl))
-	) {
-		return { ok: true, issuedSessionToken: await issueSessionToken(secret, now) };
+	if (input.turnstileToken) {
+		const tokenResult = await verifyTurnstileTokenResult(
+			secret,
+			input.turnstileToken,
+			input.remoteIp,
+			fetchImpl
+		);
+		if (tokenResult === 'valid') {
+			return { ok: true, issuedSessionToken: await issueSessionToken(secret, now) };
+		}
+		if (tokenResult === 'unavailable') {
+			console.error('[turnstile] siteverify unavailable; admitting token-bearing request');
+			return { ok: true };
+		}
 	}
 
 	return { ok: false };

--- a/src/lib/turnstile-client.ts
+++ b/src/lib/turnstile-client.ts
@@ -1,0 +1,102 @@
+/**
+ * Browser-side Turnstile helper for the chat widget.
+ *
+ * Lazy-loads Cloudflare's Turnstile script the first time a token is needed, so
+ * the third-party script is never pulled in when Turnstile is unconfigured (dev)
+ * or before the visitor actually chats. `getTurnstileToken()` renders a one-shot
+ * widget, resolves with its token, and tears it down — no long-lived widget
+ * state to manage. The matching server gate lives in `lib/server/turnstile.ts`.
+ *
+ * The site key is passed in (read once from `$env/dynamic/public` at the app
+ * edge in `routes/+page.svelte` and threaded through the app context), so this
+ * module stays a pure, env-free leaf — easy to test, with no virtual-module
+ * import in the unit graph.
+ */
+
+const SCRIPT_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+
+interface TurnstileRenderOptions {
+	sitekey: string;
+	callback: (token: string) => void;
+	'error-callback'?: () => void;
+	'timeout-callback'?: () => void;
+}
+
+interface TurnstileApi {
+	render(el: HTMLElement, options: TurnstileRenderOptions): string;
+	remove(widgetId: string): void;
+}
+
+declare global {
+	interface Window {
+		turnstile?: TurnstileApi;
+	}
+}
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadScript(): Promise<void> {
+	if (window.turnstile) return Promise.resolve();
+	if (scriptPromise) return scriptPromise;
+
+	scriptPromise = new Promise<void>((resolve, reject) => {
+		const script = document.createElement('script');
+		script.src = SCRIPT_URL;
+		script.async = true;
+		script.defer = true;
+		script.onload = () => resolve();
+		script.onerror = () => {
+			scriptPromise = null;
+			reject(new Error('Turnstile script failed to load'));
+		};
+		document.head.appendChild(script);
+	});
+	return scriptPromise;
+}
+
+/**
+ * Obtain a fresh Turnstile token for `siteKey`, or `null` when no site key is
+ * configured (dev, where the server gate fails open). Renders an unobtrusive
+ * widget bottom-right; managed mode usually solves it without interaction.
+ */
+export async function getTurnstileToken(siteKey: string | undefined): Promise<string | null> {
+	if (!siteKey) return null;
+	await loadScript();
+	const turnstile = window.turnstile;
+	if (!turnstile) return null;
+
+	return new Promise<string>((resolve, reject) => {
+		const container = document.createElement('div');
+		container.style.position = 'fixed';
+		container.style.bottom = '12px';
+		container.style.right = '12px';
+		container.style.zIndex = '9999';
+		document.body.appendChild(container);
+
+		let widgetId = '';
+		const cleanup = () => {
+			try {
+				if (widgetId) turnstile.remove(widgetId);
+			} catch {
+				// widget already gone
+			}
+			container.remove();
+		};
+
+		widgetId = turnstile.render(container, {
+			sitekey: siteKey,
+			callback: (token: string) => {
+				cleanup();
+				resolve(token);
+			},
+			'error-callback': () => {
+				cleanup();
+				reject(new Error('Turnstile challenge failed'));
+			},
+			'timeout-callback': () => {
+				cleanup();
+				reject(new Error('Turnstile challenge timed out'));
+			}
+		});
+	});
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,7 +52,8 @@ export interface ChatMessage {
 	content: string;
 }
 
-export type LlmProvider = 'claude' | 'openai';
+export const LLM_PROVIDERS = ['claude', 'openai'] as const;
+export type LlmProvider = (typeof LLM_PROVIDERS)[number];
 
 export interface LlmTokenUsage {
 	provider: LlmProvider;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
+	import { env } from '$env/dynamic/public';
 	import Desktop from '$lib/components/Desktop.svelte';
+
+	// The one place the public Turnstile site key is read; it's threaded down
+	// through the app context so leaf windows (the chat) stay env-free. Unset →
+	// Turnstile not configured, and the server gate fails open.
+	const turnstileSiteKey = env.PUBLIC_TURNSTILE_SITE_KEY ?? '';
 </script>
 
 <svelte:head>
 	<title>Terminal — Previously on screens…</title>
 </svelte:head>
 
-<Desktop />
+<Desktop {turnstileSiteKey} />

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -4,6 +4,7 @@ import { streamCompletion, defaultModelFor } from '$lib/server/llm';
 import { canRespond, recordMessage } from '$lib/server/spend';
 import { getSpendLedger, actualCostUsd } from '$lib/server/spend-ledger';
 import type { CandidateProvider, DenialReason, SpendLedgerEnv } from '$lib/server/spend-ledger';
+import { evaluateChatGate } from '$lib/server/turnstile';
 import { loadContentCatalog } from '$lib/server/content-catalog';
 import { createChatSession, validateChatTimezone } from '$lib/server/chat-session';
 import type { ChatMessage, LlmProvider, TextChunk } from '$lib/types';
@@ -34,6 +35,8 @@ interface ChatEnv extends SpendLedgerEnv {
 	RATE_LIMIT_PER_HOUR?: string;
 	PROVIDER?: string;
 	MODEL?: string;
+	/** Turnstile secret (a deploy secret). Unset in dev → the gate fails open. */
+	TURNSTILE_SECRET?: string;
 }
 
 function parseProviderOrder(raw: string | undefined): LlmProvider[] {
@@ -137,7 +140,8 @@ function sseResponse(
 	hooks?: {
 		onUsage?: (chunk: TextChunk) => void;
 		onClose?: () => void | Promise<void>;
-	}
+	},
+	extraHeaders?: Record<string, string>
 ): Response {
 	const encoder = new TextEncoder();
 	const stream = new ReadableStream({
@@ -173,7 +177,8 @@ function sseResponse(
 		headers: {
 			'Content-Type': 'text/event-stream',
 			'Cache-Control': 'no-cache',
-			Connection: 'keep-alive'
+			Connection: 'keep-alive',
+			...extraHeaders
 		}
 	});
 }
@@ -208,11 +213,20 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 		throw error(400, 'Request body must be a JSON object');
 	}
 
-	const { botId, messages: rawMessages, timezone: rawTimezone } = body as Record<string, unknown>;
+	const {
+		botId,
+		messages: rawMessages,
+		timezone: rawTimezone,
+		turnstileToken: rawTurnstileToken,
+		sessionToken: rawSessionToken
+	} = body as Record<string, unknown>;
 
 	if (typeof botId !== 'string' || !botId) {
 		throw error(400, 'botId is required');
 	}
+
+	const turnstileToken = typeof rawTurnstileToken === 'string' ? rawTurnstileToken : undefined;
+	const sessionToken = typeof rawSessionToken === 'string' ? rawSessionToken : undefined;
 
 	const messages = validateMessages(rawMessages);
 	let timezone: string;
@@ -249,6 +263,22 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 		throw error(429, gate.reason || 'Rate limited');
 	}
 
+	// Turnstile Gate — proof-of-human before any spend path (PRD decision 10).
+	// A valid session token skips the challenge; a fresh Turnstile token mints one.
+	const humanGate = await evaluateChatGate(
+		env.TURNSTILE_SECRET,
+		{ turnstileToken, sessionToken, remoteIp: ip },
+		new Date()
+	);
+	if (!humanGate.ok) {
+		// Not verified (or session expired) — the client runs the challenge and
+		// retries. A 401 stays invisible to the user, keeping the fiction intact.
+		throw error(401, 'Human verification required');
+	}
+	const sessionHeaders = humanGate.issuedSessionToken
+		? { 'X-Chat-Session': humanGate.issuedSessionToken }
+		: undefined;
+
 	const providers = resolveLlmProviders(env);
 	if (providers.length === 0) {
 		throw error(503, 'No LLM providers are configured');
@@ -268,7 +298,12 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 
 	if (!reservation.ok) {
 		// Ceiling hit — render a graceful in-voice "off the air" turn, not an error.
-		return sseResponse(messageStream(overBudgetMessage(reservation.reason)));
+		// Still return any freshly minted session token so a retry isn't re-challenged.
+		return sseResponse(
+			messageStream(overBudgetMessage(reservation.reason)),
+			undefined,
+			sessionHeaders
+		);
 	}
 
 	const admitted = providers.find((config) => config.provider === reservation.provider);
@@ -291,26 +326,30 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 	// even when the client disconnects mid-stream.
 	let actualUsd = 0;
 	let sawUsage = false;
-	return sseResponse(stream, {
-		onUsage: (chunk) => {
-			if (!chunk.usage) return;
-			sawUsage = true;
-			try {
-				actualUsd += actualCostUsd(chunk.usage);
-			} catch (e) {
-				console.error('[chat SSE] cost calculation failed:', e);
+	return sseResponse(
+		stream,
+		{
+			onUsage: (chunk) => {
+				if (!chunk.usage) return;
+				sawUsage = true;
+				try {
+					actualUsd += actualCostUsd(chunk.usage);
+				} catch (e) {
+					console.error('[chat SSE] cost calculation failed:', e);
+				}
+			},
+			onClose: async () => {
+				if (sawUsage) {
+					await ledger.reconcile(
+						reservation.reservationId,
+						{ provider: reservation.provider, usd: actualUsd },
+						new Date()
+					);
+				} else {
+					await ledger.release(reservation.reservationId, new Date());
+				}
 			}
 		},
-		onClose: async () => {
-			if (sawUsage) {
-				await ledger.reconcile(
-					reservation.reservationId,
-					{ provider: reservation.provider, usd: actualUsd },
-					new Date()
-				);
-			} else {
-				await ledger.release(reservation.reservationId, new Date());
-			}
-		}
-	});
+		sessionHeaders
+	);
 };

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -22,6 +22,8 @@ const MAX_OUTPUT_TOKENS = 300;
  */
 const INPUT_CHARS_PER_TOKEN = 3;
 
+// Monthly spend caps come in via SpendLedgerEnv (the ledger reads them); this
+// interface adds the route's own provider/model + KV throttle vars.
 interface ChatEnv extends SpendLedgerEnv {
 	KV: KVNamespace;
 	ANTHROPIC_API_KEY?: string;
@@ -29,11 +31,8 @@ interface ChatEnv extends SpendLedgerEnv {
 	LLM_PROVIDER_ORDER?: string;
 	ANTHROPIC_MODEL?: string;
 	OPENAI_MODEL?: string;
-	ANTHROPIC_MONTHLY_SPEND_CAP?: string;
-	OPENAI_MONTHLY_SPEND_CAP?: string;
 	RATE_LIMIT_PER_HOUR?: string;
 	PROVIDER?: string;
-	MONTHLY_SPEND_CAP?: string;
 	MODEL?: string;
 }
 
@@ -60,20 +59,14 @@ function parseProviderOrder(raw: string | undefined): LlmProvider[] {
 	return providers;
 }
 
-function parseBudget(raw: string | undefined): number | undefined {
-	if (raw === undefined || raw.trim() === '') return undefined;
-	const budget = Number(raw);
-	if (!Number.isFinite(budget) || budget < 0) {
-		throw error(500, `Invalid LLM monthly spend cap "${raw}"`);
-	}
-	return budget;
-}
-
 function resolveLlmProviders(env: ChatEnv): LlmProviderConfig[] {
 	const legacyProvider =
 		env.PROVIDER === 'claude' || env.PROVIDER === 'openai' ? env.PROVIDER : undefined;
 	const providerOrder = parseProviderOrder(env.LLM_PROVIDER_ORDER ?? legacyProvider);
 
+	// Monthly dollar caps are no longer carried per provider — the Spend Ledger
+	// owns them (resolveCeilings reads ANTHROPIC/OPENAI_MONTHLY_SPEND_CAP). Here we
+	// only resolve which providers are configured and which model each uses.
 	return providerOrder.flatMap((provider) => {
 		const apiKey = provider === 'claude' ? env.ANTHROPIC_API_KEY : env.OPENAI_API_KEY;
 		if (!apiKey) return [];
@@ -82,12 +75,8 @@ function resolveLlmProviders(env: ChatEnv): LlmProviderConfig[] {
 			provider === 'claude'
 				? (env.ANTHROPIC_MODEL ?? (legacyProvider === 'claude' ? env.MODEL : undefined))
 				: (env.OPENAI_MODEL ?? (legacyProvider === 'openai' ? env.MODEL : undefined));
-		const monthlyBudget =
-			provider === 'claude'
-				? parseBudget(env.ANTHROPIC_MONTHLY_SPEND_CAP ?? env.MONTHLY_SPEND_CAP)
-				: parseBudget(env.OPENAI_MONTHLY_SPEND_CAP ?? env.MONTHLY_SPEND_CAP);
 
-		return [{ provider, apiKey, model, monthlyBudget }];
+		return [{ provider, apiKey, model }];
 	});
 }
 

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -1,17 +1,28 @@
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { streamCompletion } from '$lib/server/llm';
-import { canRespond, recordTokens, recordMessage } from '$lib/server/spend';
+import { streamCompletion, defaultModelFor } from '$lib/server/llm';
+import { canRespond, recordMessage } from '$lib/server/spend';
+import { getSpendLedger, actualCostUsd } from '$lib/server/spend-ledger';
+import type { CandidateProvider, CeilingId, SpendLedgerEnv } from '$lib/server/spend-ledger';
 import { loadContentCatalog } from '$lib/server/content-catalog';
 import { createChatSession, validateChatTimezone } from '$lib/server/chat-session';
-import type { ChatMessage, LlmProvider } from '$lib/types';
+import type { ChatMessage, LlmProvider, TextChunk } from '$lib/types';
 import type { LlmProviderConfig } from '$lib/server/llm';
 
 const VALID_ROLES = new Set(['user', 'assistant']);
 const MAX_MESSAGES = 20;
 const MAX_CONTENT_LENGTH = 2000;
+/** Hard per-request output cap; also the worst-case output hold for a Reservation. */
+const MAX_OUTPUT_TOKENS = 300;
+/**
+ * Conservative chars-per-token for the worst-case input hold. Deliberately low
+ * (English averages ~4) so the Reservation can never under-estimate input and
+ * let actual spend slip past a ceiling. Output dominates cost, so over-holding
+ * input only ever errs toward refusing early — the safe direction.
+ */
+const INPUT_CHARS_PER_TOKEN = 3;
 
-interface ChatEnv {
+interface ChatEnv extends SpendLedgerEnv {
 	KV: KVNamespace;
 	ANTHROPIC_API_KEY?: string;
 	OPENAI_API_KEY?: string;
@@ -101,12 +112,97 @@ function validateMessages(raw: unknown): ChatMessage[] {
 	});
 }
 
+/** Worst-case input tokens for the Reservation — a true upper bound, not a guess. */
+function worstCaseInputTokens(systemPrompt: string, messages: ChatMessage[]): number {
+	const chars =
+		systemPrompt.length + messages.reduce((sum, m) => sum + m.role.length + m.content.length, 0);
+	return Math.ceil(chars / INPUT_CHARS_PER_TOKEN);
+}
+
+/** Map the ledger's provider preference order onto concrete candidate models. */
+function toCandidates(providers: LlmProviderConfig[]): CandidateProvider[] {
+	return providers.map((config) => ({
+		provider: config.provider,
+		model: config.model ?? defaultModelFor(config.provider)
+	}));
+}
+
+/**
+ * In-voice "off the air" copy for a ceiling refusal. The chat window renders it
+ * as a normal assistant turn so the retro-OS fiction stays intact — never a raw
+ * HTTP error (see PRD decision 11).
+ */
+function overBudgetMessage(ceiling: CeilingId): string {
+	if (ceiling === 'monthly-provider') {
+		return "[ STATIC ] ...this channel's gone dark for the month — the dial's tapped out. Try another network, or check back when the new month rolls around.";
+	}
+	return "[ STATIC ] ...that's all she wrote for today — we're off the air until the tower fires back up tomorrow. Same station, same dial.";
+}
+
+/** Build an SSE Response from a TextChunk source, hiding internal `usage` chunks. */
+function sseResponse(
+	source: ReadableStream<TextChunk>,
+	hooks?: {
+		onUsage?: (chunk: TextChunk) => void;
+		onClose?: () => void | Promise<void>;
+	}
+): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		async start(controller) {
+			const reader = source.getReader();
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+
+					if (value.type !== 'usage') {
+						controller.enqueue(encoder.encode(`data: ${JSON.stringify(value)}\n\n`));
+					}
+					if (value.usage) hooks?.onUsage?.(value);
+				}
+			} catch (e) {
+				console.error('[chat SSE] stream error:', e);
+				controller.enqueue(
+					encoder.encode(`data: ${JSON.stringify({ type: 'error', error: 'internal error' })}\n\n`)
+				);
+			} finally {
+				try {
+					await hooks?.onClose?.();
+				} catch (e) {
+					console.error('[chat SSE] close hook failed:', e);
+				}
+				controller.close();
+			}
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			Connection: 'keep-alive'
+		}
+	});
+}
+
+/** A one-shot SSE stream of a single in-voice assistant message (the deny path). */
+function messageStream(text: string): ReadableStream<TextChunk> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue({ type: 'text', text });
+			controller.enqueue({ type: 'done', tokenCount: 0 });
+			controller.close();
+		}
+	});
+}
+
 export const POST: RequestHandler = async ({ request, platform, getClientAddress }) => {
 	if (!platform?.env) {
 		throw error(500, 'Platform bindings not available');
 	}
 
-	const env = platform.env;
+	const env = platform.env as ChatEnv;
 	const ip = getClientAddress();
 
 	let body: unknown;
@@ -152,12 +248,11 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 		throw error(chatSession.status, chatSession.reason ?? 'Chat is not available');
 	}
 
-	const spendConfig = {
-		kv: env.KV,
-		rateLimitPerHour: parseInt(env.RATE_LIMIT_PER_HOUR || '30')
-	};
-
-	const gate = await canRespond(spendConfig, ip);
+	// Per-IP fairness throttle (approximate, KV) — unchanged.
+	const gate = await canRespond(
+		{ kv: env.KV, rateLimitPerHour: parseInt(env.RATE_LIMIT_PER_HOUR || '30') },
+		ip
+	);
 	if (!gate.allowed) {
 		throw error(429, gate.reason || 'Rate limited');
 	}
@@ -167,53 +262,63 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 		throw error(503, 'No LLM providers are configured');
 	}
 
-	const stream = await streamCompletion({
-		systemPrompt: chatSession.systemPrompt,
-		messages,
-		providers,
-		kv: env.KV,
-		options: { maxTokens: 300, temperature: 0.8 }
-	});
+	// The Spend Ledger owns every dollar ceiling: reserve worst-case cost and let
+	// it pick the first candidate provider that fits, before any money is spent.
+	const ledger = getSpendLedger(env);
+	const reservation = await ledger.reserve(
+		{
+			candidates: toCandidates(providers),
+			maxInputTokens: worstCaseInputTokens(chatSession.systemPrompt, messages),
+			maxOutputTokens: MAX_OUTPUT_TOKENS
+		},
+		new Date()
+	);
+
+	if (!reservation.ok) {
+		// Ceiling hit — render a graceful in-voice "off the air" turn, not an error.
+		return sseResponse(messageStream(overBudgetMessage(reservation.ceiling)));
+	}
+
+	const admitted = providers.find((config) => config.provider === reservation.provider);
+	if (!admitted) {
+		await ledger.release(reservation.reservationId, new Date());
+		throw error(500, 'Admitted provider is not configured');
+	}
 
 	await recordMessage(env.KV, ip);
 
-	const encoder = new TextEncoder();
-	const sseStream = new ReadableStream({
-		async start(controller) {
-			const reader = stream.getReader();
-			try {
-				while (true) {
-					const { done, value } = await reader.read();
-					if (done) break;
-
-					if (value.type !== 'usage') {
-						const data = `data: ${JSON.stringify(value)}\n\n`;
-						controller.enqueue(encoder.encode(data));
-					}
-
-					if (value.usage) {
-						try {
-							await recordTokens(env.KV, value.usage);
-						} catch (recordError) {
-							console.error('[chat SSE] token accounting failed:', recordError);
-						}
-					}
-				}
-			} catch (e) {
-				console.error('[chat SSE] stream error:', e);
-				const errData = `data: ${JSON.stringify({ type: 'error', error: 'internal error' })}\n\n`;
-				controller.enqueue(encoder.encode(errData));
-			} finally {
-				controller.close();
-			}
-		}
+	const stream = await streamCompletion({
+		systemPrompt: chatSession.systemPrompt,
+		messages,
+		providers: [{ ...admitted, model: reservation.model }],
+		options: { maxTokens: MAX_OUTPUT_TOKENS, temperature: 0.8 }
 	});
 
-	return new Response(sseStream, {
-		headers: {
-			'Content-Type': 'text/event-stream',
-			'Cache-Control': 'no-cache',
-			Connection: 'keep-alive'
+	// Settle the Reservation to actual cost once the stream ends; release it if the
+	// request produced no billable usage. Runs in the SSE close hook so it fires
+	// even when the client disconnects mid-stream.
+	let actualUsd = 0;
+	let sawUsage = false;
+	return sseResponse(stream, {
+		onUsage: (chunk) => {
+			if (!chunk.usage) return;
+			sawUsage = true;
+			try {
+				actualUsd += actualCostUsd(chunk.usage);
+			} catch (e) {
+				console.error('[chat SSE] cost calculation failed:', e);
+			}
+		},
+		onClose: async () => {
+			if (sawUsage) {
+				await ledger.reconcile(
+					reservation.reservationId,
+					{ provider: reservation.provider, usd: actualUsd },
+					new Date()
+				);
+			} else {
+				await ledger.release(reservation.reservationId, new Date());
+			}
 		}
 	});
 };

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -1,13 +1,18 @@
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { streamCompletion, defaultModelFor } from '$lib/server/llm';
+import { streamCompletion, defaultModelFor, isLlmProvider } from '$lib/server/llm';
 import { canRespond, recordMessage } from '$lib/server/spend';
 import { getSpendLedger, actualCostUsd } from '$lib/server/spend-ledger';
-import type { CandidateProvider, DenialReason, SpendLedgerEnv } from '$lib/server/spend-ledger';
+import type {
+	CandidateProvider,
+	DenialReason,
+	ProviderReservation,
+	SpendLedgerEnv
+} from '$lib/server/spend-ledger';
 import { evaluateChatGate } from '$lib/server/turnstile';
 import { loadContentCatalog } from '$lib/server/content-catalog';
 import { createChatSession, validateChatTimezone } from '$lib/server/chat-session';
-import type { ChatMessage, LlmProvider, TextChunk } from '$lib/types';
+import type { ChatMessage, LlmProvider, LlmTokenUsage, TextChunk } from '$lib/types';
 import type { LlmProviderConfig } from '$lib/server/llm';
 
 const VALID_ROLES = new Set(['user', 'assistant']);
@@ -15,13 +20,9 @@ const MAX_MESSAGES = 20;
 const MAX_CONTENT_LENGTH = 2000;
 /** Hard per-request output cap; also the worst-case output hold for a Reservation. */
 const MAX_OUTPUT_TOKENS = 300;
-/**
- * Conservative chars-per-token for the worst-case input hold. Deliberately low
- * (English averages ~4) so the Reservation can never under-estimate input and
- * let actual spend slip past a ceiling. Output dominates cost, so over-holding
- * input only ever errs toward refusing early — the safe direction.
- */
-const INPUT_CHARS_PER_TOKEN = 3;
+const TOKEN_OVERHEAD_FOR_SYSTEM = 64;
+const TOKEN_OVERHEAD_PER_MESSAGE = 64;
+const textEncoder = new TextEncoder();
 
 // Monthly spend caps come in via SpendLedgerEnv (the ledger reads them); this
 // interface adds the route's own provider/model + KV throttle vars.
@@ -39,6 +40,16 @@ interface ChatEnv extends SpendLedgerEnv {
 	TURNSTILE_SECRET?: string;
 }
 
+const PROVIDER_API_KEY_ENV = {
+	claude: 'ANTHROPIC_API_KEY',
+	openai: 'OPENAI_API_KEY'
+} satisfies Record<LlmProvider, 'ANTHROPIC_API_KEY' | 'OPENAI_API_KEY'>;
+
+const PROVIDER_MODEL_ENV = {
+	claude: 'ANTHROPIC_MODEL',
+	openai: 'OPENAI_MODEL'
+} satisfies Record<LlmProvider, 'ANTHROPIC_MODEL' | 'OPENAI_MODEL'>;
+
 function parseProviderOrder(raw: string | undefined): LlmProvider[] {
 	const providerOrder = (raw ?? 'claude')
 		.split(',')
@@ -51,7 +62,7 @@ function parseProviderOrder(raw: string | undefined): LlmProvider[] {
 
 	const providers: LlmProvider[] = [];
 	for (const provider of providerOrder) {
-		if (provider !== 'claude' && provider !== 'openai') {
+		if (!isLlmProvider(provider)) {
 			throw error(500, `Unsupported LLM provider "${provider}"`);
 		}
 		if (!providers.includes(provider)) {
@@ -71,13 +82,11 @@ function resolveLlmProviders(env: ChatEnv): LlmProviderConfig[] {
 	// owns them (resolveCeilings reads ANTHROPIC/OPENAI_MONTHLY_SPEND_CAP). Here we
 	// only resolve which providers are configured and which model each uses.
 	return providerOrder.flatMap((provider) => {
-		const apiKey = provider === 'claude' ? env.ANTHROPIC_API_KEY : env.OPENAI_API_KEY;
+		const apiKey = env[PROVIDER_API_KEY_ENV[provider]];
 		if (!apiKey) return [];
 
 		const model =
-			provider === 'claude'
-				? (env.ANTHROPIC_MODEL ?? (legacyProvider === 'claude' ? env.MODEL : undefined))
-				: (env.OPENAI_MODEL ?? (legacyProvider === 'openai' ? env.MODEL : undefined));
+			env[PROVIDER_MODEL_ENV[provider]] ?? (legacyProvider === provider ? env.MODEL : undefined);
 
 		return [{ provider, apiKey, model }];
 	});
@@ -104,19 +113,62 @@ function validateMessages(raw: unknown): ChatMessage[] {
 	});
 }
 
+function parseRateLimitPerHour(raw: string | undefined): number {
+	if (raw === undefined || raw.trim() === '') return 30;
+	const value = Number(raw);
+	return Number.isFinite(value) && value >= 0 ? value : 30;
+}
+
 /** Worst-case input tokens for the Reservation — a true upper bound, not a guess. */
 function worstCaseInputTokens(systemPrompt: string, messages: ChatMessage[]): number {
-	const chars =
-		systemPrompt.length + messages.reduce((sum, m) => sum + m.role.length + m.content.length, 0);
-	return Math.ceil(chars / INPUT_CHARS_PER_TOKEN);
+	let tokens = textEncoder.encode(systemPrompt).length + TOKEN_OVERHEAD_FOR_SYSTEM;
+	for (const message of messages) {
+		tokens +=
+			textEncoder.encode(message.role).length +
+			textEncoder.encode(message.content).length +
+			TOKEN_OVERHEAD_PER_MESSAGE;
+	}
+	return tokens;
+}
+
+function resolvedModel(config: LlmProviderConfig): string {
+	return config.model ?? defaultModelFor(config.provider);
 }
 
 /** Map the ledger's provider preference order onto concrete candidate models. */
 function toCandidates(providers: LlmProviderConfig[]): CandidateProvider[] {
 	return providers.map((config) => ({
 		provider: config.provider,
-		model: config.model ?? defaultModelFor(config.provider)
+		model: resolvedModel(config)
 	}));
+}
+
+function toReservedProviders(
+	providers: LlmProviderConfig[],
+	reservations: ProviderReservation[]
+): LlmProviderConfig[] {
+	return reservations.flatMap((reservation) => {
+		const config = providers.find(
+			(provider) =>
+				provider.provider === reservation.provider && resolvedModel(provider) === reservation.model
+		);
+		return config ? [{ ...config, model: reservation.model }] : [];
+	});
+}
+
+function reservationForUsage(
+	reservations: ProviderReservation[],
+	usage: LlmTokenUsage
+): ProviderReservation | undefined {
+	const exact = reservations.find(
+		(reservation) => reservation.provider === usage.provider && reservation.model === usage.model
+	);
+	if (exact) return exact;
+
+	const providerMatches = reservations.filter(
+		(reservation) => reservation.provider === usage.provider
+	);
+	return providerMatches.length === 1 ? providerMatches[0] : undefined;
 }
 
 /**
@@ -256,7 +308,7 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 
 	// Per-IP fairness throttle (approximate, KV) — unchanged.
 	const gate = await canRespond(
-		{ kv: env.KV, rateLimitPerHour: parseInt(env.RATE_LIMIT_PER_HOUR || '30') },
+		{ kv: env.KV, rateLimitPerHour: parseRateLimitPerHour(env.RATE_LIMIT_PER_HOUR) },
 		ip
 	);
 	if (!gate.allowed) {
@@ -284,8 +336,10 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 		throw error(503, 'No LLM providers are configured');
 	}
 
-	// The Spend Ledger owns every dollar ceiling: reserve worst-case cost and let
-	// it pick the first candidate provider that fits, before any money is spent.
+	// The Spend Ledger owns every dollar ceiling: reserve worst-case cost for each
+	// fallback candidate that fits before any provider can spend.
+	await recordMessage(env.KV, ip);
+
 	const ledger = getSpendLedger(env);
 	const reservation = await ledger.reserve(
 		{
@@ -306,48 +360,66 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 		);
 	}
 
-	const admitted = providers.find((config) => config.provider === reservation.provider);
-	if (!admitted) {
-		await ledger.release(reservation.reservationId, new Date());
+	const reservations = reservation.reservations;
+	const admittedProviders = toReservedProviders(providers, reservations);
+	if (admittedProviders.length === 0) {
+		await Promise.all(reservations.map((hold) => ledger.release(hold.reservationId, new Date())));
 		throw error(500, 'Admitted provider is not configured');
 	}
-
-	await recordMessage(env.KV, ip);
 
 	const stream = await streamCompletion({
 		systemPrompt: chatSession.systemPrompt,
 		messages,
-		providers: [{ ...admitted, model: reservation.model }],
+		providers: admittedProviders,
 		options: { maxTokens: MAX_OUTPUT_TOKENS, temperature: 0.8 }
 	});
 
-	// Settle the Reservation to actual cost once the stream ends; release it if the
-	// request produced no billable usage. Runs in the SSE close hook so it fires
-	// even when the client disconnects mid-stream.
-	let actualUsd = 0;
-	let sawUsage = false;
+	// Settle each provider Reservation to actual cost once the stream ends; release
+	// unused fallback holds. Runs in the SSE close hook so it fires even when the
+	// client disconnects mid-stream.
+	const actualByReservation = new Map<string, { provider: LlmProvider; usd: number }>();
+	function settleLedger(): Promise<void> {
+		const now = new Date();
+		return Promise.all(
+			reservations.map((hold) => {
+				const actual = actualByReservation.get(hold.reservationId);
+				if (actual) {
+					return ledger.reconcile(hold.reservationId, actual, now);
+				}
+				return ledger.release(hold.reservationId, now);
+			})
+		).then(() => undefined);
+	}
+
 	return sseResponse(
 		stream,
 		{
 			onUsage: (chunk) => {
 				if (!chunk.usage) return;
-				sawUsage = true;
 				try {
-					actualUsd += actualCostUsd(chunk.usage);
+					const hold = reservationForUsage(reservations, chunk.usage);
+					if (!hold) {
+						console.error('[chat SSE] usage reported for an unreserved provider:', chunk.usage);
+						return;
+					}
+					const previous = actualByReservation.get(hold.reservationId);
+					actualByReservation.set(hold.reservationId, {
+						provider: chunk.usage.provider,
+						usd: (previous?.usd ?? 0) + actualCostUsd(chunk.usage)
+					});
 				} catch (e) {
 					console.error('[chat SSE] cost calculation failed:', e);
 				}
 			},
-			onClose: async () => {
-				if (sawUsage) {
-					await ledger.reconcile(
-						reservation.reservationId,
-						{ provider: reservation.provider, usd: actualUsd },
-						new Date()
-					);
-				} else {
-					await ledger.release(reservation.reservationId, new Date());
+			onClose: () => {
+				const settlement = settleLedger().catch((e) => {
+					console.error('[chat SSE] ledger settlement failed:', e);
+				});
+				if (platform.context?.waitUntil) {
+					platform.context.waitUntil(settlement);
+					return;
 				}
+				return settlement;
 			}
 		},
 		sessionHeaders

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -3,7 +3,7 @@ import type { RequestHandler } from './$types';
 import { streamCompletion, defaultModelFor } from '$lib/server/llm';
 import { canRespond, recordMessage } from '$lib/server/spend';
 import { getSpendLedger, actualCostUsd } from '$lib/server/spend-ledger';
-import type { CandidateProvider, CeilingId, SpendLedgerEnv } from '$lib/server/spend-ledger';
+import type { CandidateProvider, DenialReason, SpendLedgerEnv } from '$lib/server/spend-ledger';
 import { loadContentCatalog } from '$lib/server/content-catalog';
 import { createChatSession, validateChatTimezone } from '$lib/server/chat-session';
 import type { ChatMessage, LlmProvider, TextChunk } from '$lib/types';
@@ -128,12 +128,15 @@ function toCandidates(providers: LlmProviderConfig[]): CandidateProvider[] {
 }
 
 /**
- * In-voice "off the air" copy for a ceiling refusal. The chat window renders it
+ * In-voice "off the air" copy for a refused request. The chat window renders it
  * as a normal assistant turn so the retro-OS fiction stays intact — never a raw
  * HTTP error (see PRD decision 11).
  */
-function overBudgetMessage(ceiling: CeilingId): string {
-	if (ceiling === 'monthly-provider') {
+function overBudgetMessage(reason: DenialReason): string {
+	if (reason === 'ledger-unavailable') {
+		return '[ STATIC ] ...technical difficulties — the transmitter dropped out for a sec. Give it a moment and try again.';
+	}
+	if (reason === 'monthly-provider') {
 		return "[ STATIC ] ...this channel's gone dark for the month — the dial's tapped out. Try another network, or check back when the new month rolls around.";
 	}
 	return "[ STATIC ] ...that's all she wrote for today — we're off the air until the tower fires back up tomorrow. Same station, same dial.";
@@ -276,7 +279,7 @@ export const POST: RequestHandler = async ({ request, platform, getClientAddress
 
 	if (!reservation.ok) {
 		// Ceiling hit — render a graceful in-voice "off the air" turn, not an error.
-		return sseResponse(messageStream(overBudgetMessage(reservation.ceiling)));
+		return sseResponse(messageStream(overBudgetMessage(reservation.reason)));
 	}
 
 	const admitted = providers.find((config) => config.provider === reservation.provider);

--- a/src/routes/api/chat/server.test.ts
+++ b/src/routes/api/chat/server.test.ts
@@ -337,6 +337,33 @@ describe('POST /api/chat', () => {
 		expect(releaseMock).not.toHaveBeenCalled();
 	});
 
+	it('renders the monthly "channel dark" message when every provider is over its monthly cap', async () => {
+		reserveMock.mockResolvedValueOnce({
+			ok: false,
+			reason: 'monthly-provider',
+			detail: 'All candidate providers are over their monthly cap.'
+		});
+
+		const text = await (await POST(makeEvent(makeBody('Asia/Kathmandu')))).text();
+		expect(text).toContain('gone dark for the month');
+		expect(streamCompletionMock).not.toHaveBeenCalled();
+	});
+
+	it('renders the "transmitter dropped out" message when the ledger fails closed', async () => {
+		reserveMock.mockResolvedValueOnce({
+			ok: false,
+			reason: 'ledger-unavailable',
+			detail: 'Spend ledger is unreachable; refusing spend.'
+		});
+
+		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
+		const text = await response.text();
+		expect(response.status).toBe(200);
+		expect(text).toContain('transmitter');
+		expect(text).not.toContain('"type":"error"');
+		expect(streamCompletionMock).not.toHaveBeenCalled();
+	});
+
 	it('rejects an invalid timezone before spend or LLM calls', async () => {
 		await expect(POST(makeEvent(makeBody('Not/A_Zone')))).rejects.toMatchObject({
 			status: 400

--- a/src/routes/api/chat/server.test.ts
+++ b/src/routes/api/chat/server.test.ts
@@ -12,7 +12,8 @@ import type { SpendLedger } from '$lib/server/spend-ledger';
 vi.mock('$lib/server/llm', () => ({
 	streamCompletion: vi.fn(),
 	defaultModelFor: (provider: 'claude' | 'openai') =>
-		provider === 'openai' ? 'gpt-4o-mini' : 'claude-haiku-4-5-20251001'
+		provider === 'openai' ? 'gpt-4o-mini' : 'claude-haiku-4-5-20251001',
+	isLlmProvider: (provider: string) => provider === 'claude' || provider === 'openai'
 }));
 
 vi.mock('$lib/server/spend', () => ({
@@ -131,7 +132,7 @@ function makeCatalog(channels: Channel[]): ContentCatalog {
 	};
 }
 
-function makeEvent(body: Record<string, unknown>) {
+function makeEvent(body: Record<string, unknown>, envOverrides: Record<string, unknown> = {}) {
 	return {
 		request: new Request('http://localhost/api/chat', {
 			method: 'POST',
@@ -144,7 +145,8 @@ function makeEvent(body: Record<string, unknown>) {
 				LLM_PROVIDER_ORDER: 'openai',
 				OPENAI_API_KEY: 'test-openai-key',
 				OPENAI_MODEL: 'gpt-4o-mini',
-				OPENAI_MONTHLY_SPEND_CAP: '25'
+				OPENAI_MONTHLY_SPEND_CAP: '25',
+				...envOverrides
 			}
 		},
 		getClientAddress: () => '127.0.0.1'
@@ -183,7 +185,16 @@ describe('POST /api/chat', () => {
 			provider: 'openai',
 			model: 'gpt-4o-mini',
 			reservedUsd: 0.05,
-			expiresAt: Date.now() + 60_000
+			expiresAt: Date.now() + 60_000,
+			reservations: [
+				{
+					reservationId: 'res-1',
+					provider: 'openai',
+					model: 'gpt-4o-mini',
+					reservedUsd: 0.05,
+					expiresAt: Date.now() + 60_000
+				}
+			]
 		});
 		reconcileMock.mockResolvedValue();
 		releaseMock.mockResolvedValue();
@@ -300,6 +311,136 @@ describe('POST /api/chat', () => {
 		expect(reconcileMock.mock.calls[0][1]).toEqual({ provider: 'openai', usd: 0.05 });
 	});
 
+	it('streams all reserved fallback providers and settles spend to the provider that emitted usage', async () => {
+		const event = makeEvent(makeBody('Asia/Kathmandu'), {
+			LLM_PROVIDER_ORDER: 'openai,claude',
+			ANTHROPIC_API_KEY: 'test-anthropic-key',
+			ANTHROPIC_MODEL: 'claude-haiku-4-5-20251001'
+		});
+		reserveMock.mockResolvedValueOnce({
+			ok: true,
+			reservationId: 'res-openai',
+			provider: 'openai',
+			model: 'gpt-4o-mini',
+			reservedUsd: 0.05,
+			expiresAt: Date.now() + 60_000,
+			reservations: [
+				{
+					reservationId: 'res-openai',
+					provider: 'openai',
+					model: 'gpt-4o-mini',
+					reservedUsd: 0.05,
+					expiresAt: Date.now() + 60_000
+				},
+				{
+					reservationId: 'res-claude',
+					provider: 'claude',
+					model: 'claude-haiku-4-5-20251001',
+					reservedUsd: 0.08,
+					expiresAt: Date.now() + 60_000
+				}
+			]
+		});
+		streamCompletionMock.mockResolvedValueOnce(
+			makeTokenStream([
+				{
+					type: 'usage',
+					tokenCount: 9,
+					usage: {
+						provider: 'openai',
+						model: 'gpt-4o-mini',
+						inputTokens: 5,
+						outputTokens: 4,
+						estimated: true
+					}
+				},
+				{ type: 'text', text: 'Fallback answer.' },
+				{
+					type: 'done',
+					tokenCount: 7,
+					usage: {
+						provider: 'claude',
+						model: 'claude-haiku-4-5-20251001',
+						inputTokens: 5,
+						outputTokens: 2
+					}
+				}
+			])
+		);
+		actualCostUsdMock.mockReturnValueOnce(0.02).mockReturnValueOnce(0.03);
+
+		const response = await POST(event);
+		await response.text();
+
+		expect(streamCompletionMock.mock.calls[0][0].providers).toEqual([
+			{
+				provider: 'openai',
+				apiKey: 'test-openai-key',
+				model: 'gpt-4o-mini'
+			},
+			{
+				provider: 'claude',
+				apiKey: 'test-anthropic-key',
+				model: 'claude-haiku-4-5-20251001'
+			}
+		]);
+		expect(reconcileMock).toHaveBeenCalledTimes(2);
+		expect(reconcileMock).toHaveBeenCalledWith(
+			'res-openai',
+			{ provider: 'openai', usd: 0.02 },
+			expect.any(Date)
+		);
+		expect(reconcileMock).toHaveBeenCalledWith(
+			'res-claude',
+			{ provider: 'claude', usd: 0.03 },
+			expect.any(Date)
+		);
+		expect(releaseMock).not.toHaveBeenCalled();
+	});
+
+	it('releases reserved fallback holds that never emit usage', async () => {
+		const event = makeEvent(makeBody('Asia/Kathmandu'), {
+			LLM_PROVIDER_ORDER: 'openai,claude',
+			ANTHROPIC_API_KEY: 'test-anthropic-key',
+			ANTHROPIC_MODEL: 'claude-haiku-4-5-20251001'
+		});
+		reserveMock.mockResolvedValueOnce({
+			ok: true,
+			reservationId: 'res-openai',
+			provider: 'openai',
+			model: 'gpt-4o-mini',
+			reservedUsd: 0.05,
+			expiresAt: Date.now() + 60_000,
+			reservations: [
+				{
+					reservationId: 'res-openai',
+					provider: 'openai',
+					model: 'gpt-4o-mini',
+					reservedUsd: 0.05,
+					expiresAt: Date.now() + 60_000
+				},
+				{
+					reservationId: 'res-claude',
+					provider: 'claude',
+					model: 'claude-haiku-4-5-20251001',
+					reservedUsd: 0.08,
+					expiresAt: Date.now() + 60_000
+				}
+			]
+		});
+
+		const response = await POST(event);
+		await response.text();
+
+		expect(reconcileMock).toHaveBeenCalledTimes(1);
+		expect(reconcileMock).toHaveBeenCalledWith(
+			'res-openai',
+			{ provider: 'openai', usd: 0.01 },
+			expect.any(Date)
+		);
+		expect(releaseMock).toHaveBeenCalledWith('res-claude', expect.any(Date));
+	});
+
 	it('releases the reservation when the stream produces no billable usage', async () => {
 		streamCompletionMock.mockResolvedValueOnce(
 			makeTokenStream([{ type: 'text', text: 'silence' }])
@@ -338,7 +479,7 @@ describe('POST /api/chat', () => {
 		expect(text).not.toContain('"type":"error"');
 
 		expect(streamCompletionMock).not.toHaveBeenCalled();
-		expect(recordMessageMock).not.toHaveBeenCalled();
+		expect(recordMessageMock).toHaveBeenCalledWith({}, '127.0.0.1');
 		expect(reconcileMock).not.toHaveBeenCalled();
 		expect(releaseMock).not.toHaveBeenCalled();
 	});

--- a/src/routes/api/chat/server.test.ts
+++ b/src/routes/api/chat/server.test.ts
@@ -3,6 +3,7 @@ import { POST } from './+server';
 import { streamCompletion } from '$lib/server/llm';
 import { canRespond, recordMessage } from '$lib/server/spend';
 import { getSpendLedger, actualCostUsd } from '$lib/server/spend-ledger';
+import { evaluateChatGate } from '$lib/server/turnstile';
 import { loadContentCatalog } from '$lib/server/content-catalog';
 import type { Bot, Channel, Show, TextChunk } from '$lib/types';
 import type { ContentCatalog } from '$lib/server/content-catalog';
@@ -24,6 +25,10 @@ vi.mock('$lib/server/spend-ledger', () => ({
 	actualCostUsd: vi.fn()
 }));
 
+vi.mock('$lib/server/turnstile', () => ({
+	evaluateChatGate: vi.fn()
+}));
+
 vi.mock('$lib/server/content-catalog', () => ({
 	loadContentCatalog: vi.fn()
 }));
@@ -33,6 +38,7 @@ const canRespondMock = vi.mocked(canRespond);
 const recordMessageMock = vi.mocked(recordMessage);
 const getSpendLedgerMock = vi.mocked(getSpendLedger);
 const actualCostUsdMock = vi.mocked(actualCostUsd);
+const evaluateChatGateMock = vi.mocked(evaluateChatGate);
 const loadContentCatalogMock = vi.mocked(loadContentCatalog);
 
 const reserveMock = vi.fn<SpendLedger['reserve']>();
@@ -169,6 +175,7 @@ describe('POST /api/chat', () => {
 		);
 		canRespondMock.mockResolvedValue({ allowed: true });
 		recordMessageMock.mockResolvedValue();
+		evaluateChatGateMock.mockResolvedValue({ ok: true });
 		getSpendLedgerMock.mockReturnValue(ledger);
 		reserveMock.mockResolvedValue({
 			ok: true,
@@ -361,6 +368,46 @@ describe('POST /api/chat', () => {
 		expect(text).toContain('transmitter');
 		expect(text).not.toContain('"type":"error"');
 		expect(streamCompletionMock).not.toHaveBeenCalled();
+	});
+
+	it('rejects with 401 and spends nothing when the Turnstile gate fails', async () => {
+		evaluateChatGateMock.mockResolvedValueOnce({ ok: false });
+
+		await expect(POST(makeEvent(makeBody('Asia/Kathmandu')))).rejects.toMatchObject({
+			status: 401
+		});
+
+		expect(reserveMock).not.toHaveBeenCalled();
+		expect(streamCompletionMock).not.toHaveBeenCalled();
+		expect(recordMessageMock).not.toHaveBeenCalled();
+	});
+
+	it('returns a freshly minted session token in the X-Chat-Session header', async () => {
+		evaluateChatGateMock.mockResolvedValueOnce({ ok: true, issuedSessionToken: 'sess-123' });
+
+		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
+		await response.text();
+
+		expect(response.headers.get('X-Chat-Session')).toBe('sess-123');
+	});
+
+	it('forwards the body tokens to the gate and omits the header on a returning session', async () => {
+		const event = makeEvent(makeBody('Asia/Kathmandu'));
+		event.request = new Request('http://localhost/api/chat', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ ...makeBody('Asia/Kathmandu'), sessionToken: 'existing-session' })
+		});
+
+		const response = await POST(event);
+		await response.text();
+
+		expect(evaluateChatGateMock.mock.calls[0][1]).toMatchObject({
+			sessionToken: 'existing-session',
+			remoteIp: '127.0.0.1'
+		});
+		// A valid returning session mints no new token, so no header is set.
+		expect(response.headers.get('X-Chat-Session')).toBeNull();
 	});
 
 	it('rejects an invalid timezone before spend or LLM calls', async () => {

--- a/src/routes/api/chat/server.test.ts
+++ b/src/routes/api/chat/server.test.ts
@@ -238,8 +238,7 @@ describe('POST /api/chat', () => {
 			{
 				provider: 'openai',
 				apiKey: 'test-openai-key',
-				model: 'gpt-4o-mini',
-				monthlyBudget: 25
+				model: 'gpt-4o-mini'
 			}
 		]);
 

--- a/src/routes/api/chat/server.test.ts
+++ b/src/routes/api/chat/server.test.ts
@@ -319,8 +319,8 @@ describe('POST /api/chat', () => {
 	it('returns a graceful in-voice message and spends nothing when a ceiling is hit', async () => {
 		reserveMock.mockResolvedValueOnce({
 			ok: false,
-			ceiling: 'daily-spend',
-			reason: 'Daily spend cap reached ($3/day).'
+			reason: 'daily-spend',
+			detail: 'Daily spend cap reached ($3/day).'
 		});
 
 		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));

--- a/src/routes/api/chat/server.test.ts
+++ b/src/routes/api/chat/server.test.ts
@@ -1,19 +1,27 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { POST } from './+server';
 import { streamCompletion } from '$lib/server/llm';
-import { canRespond, recordMessage, recordTokens } from '$lib/server/spend';
+import { canRespond, recordMessage } from '$lib/server/spend';
+import { getSpendLedger, actualCostUsd } from '$lib/server/spend-ledger';
 import { loadContentCatalog } from '$lib/server/content-catalog';
 import type { Bot, Channel, Show, TextChunk } from '$lib/types';
 import type { ContentCatalog } from '$lib/server/content-catalog';
+import type { SpendLedger } from '$lib/server/spend-ledger';
 
 vi.mock('$lib/server/llm', () => ({
-	streamCompletion: vi.fn()
+	streamCompletion: vi.fn(),
+	defaultModelFor: (provider: 'claude' | 'openai') =>
+		provider === 'openai' ? 'gpt-4o-mini' : 'claude-haiku-4-5-20251001'
 }));
 
 vi.mock('$lib/server/spend', () => ({
 	canRespond: vi.fn(),
-	recordMessage: vi.fn(),
-	recordTokens: vi.fn()
+	recordMessage: vi.fn()
+}));
+
+vi.mock('$lib/server/spend-ledger', () => ({
+	getSpendLedger: vi.fn(),
+	actualCostUsd: vi.fn()
 }));
 
 vi.mock('$lib/server/content-catalog', () => ({
@@ -23,8 +31,20 @@ vi.mock('$lib/server/content-catalog', () => ({
 const streamCompletionMock = vi.mocked(streamCompletion);
 const canRespondMock = vi.mocked(canRespond);
 const recordMessageMock = vi.mocked(recordMessage);
-const recordTokensMock = vi.mocked(recordTokens);
+const getSpendLedgerMock = vi.mocked(getSpendLedger);
+const actualCostUsdMock = vi.mocked(actualCostUsd);
 const loadContentCatalogMock = vi.mocked(loadContentCatalog);
+
+const reserveMock = vi.fn<SpendLedger['reserve']>();
+const reconcileMock = vi.fn<SpendLedger['reconcile']>();
+const releaseMock = vi.fn<SpendLedger['release']>();
+const statusMock = vi.fn<SpendLedger['status']>();
+const ledger: SpendLedger = {
+	reserve: reserveMock,
+	reconcile: reconcileMock,
+	release: releaseMock,
+	status: statusMock
+};
 
 const sessionId = '00000000-0000-4000-8000-000000000000';
 
@@ -149,7 +169,18 @@ describe('POST /api/chat', () => {
 		);
 		canRespondMock.mockResolvedValue({ allowed: true });
 		recordMessageMock.mockResolvedValue();
-		recordTokensMock.mockResolvedValue(0);
+		getSpendLedgerMock.mockReturnValue(ledger);
+		reserveMock.mockResolvedValue({
+			ok: true,
+			reservationId: 'res-1',
+			provider: 'openai',
+			model: 'gpt-4o-mini',
+			reservedUsd: 0.05,
+			expiresAt: Date.now() + 60_000
+		});
+		reconcileMock.mockResolvedValue();
+		releaseMock.mockResolvedValue();
+		actualCostUsdMock.mockReturnValue(0.01);
 		streamCompletionMock.mockResolvedValue(
 			makeTokenStream([
 				{ type: 'text', text: 'Well, ' },
@@ -179,22 +210,29 @@ describe('POST /api/chat', () => {
 		});
 
 		expect(canRespondMock).not.toHaveBeenCalled();
+		expect(reserveMock).not.toHaveBeenCalled();
 		expect(streamCompletionMock).not.toHaveBeenCalled();
 		expect(recordMessageMock).not.toHaveBeenCalled();
-		expect(recordTokensMock).not.toHaveBeenCalled();
 	});
 
-	it('accepts the same bot when its show is airing and sends requested-timezone episode context to the LLM', async () => {
+	it('reserves against the ledger, streams the admitted provider, and reconciles actual cost', async () => {
 		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
 		await response.text();
 
 		expect(response.status).toBe(200);
+
+		// Ledger admits the provider by budget before any spend.
+		expect(reserveMock).toHaveBeenCalledTimes(1);
+		expect(reserveMock.mock.calls[0][0]).toMatchObject({
+			candidates: [{ provider: 'openai', model: 'gpt-4o-mini' }],
+			maxOutputTokens: 300
+		});
+		expect(reserveMock.mock.calls[0][0].maxInputTokens).toBeGreaterThan(0);
+
+		// The route streams from the single admitted provider/model.
 		expect(streamCompletionMock).toHaveBeenCalledTimes(1);
 		expect(streamCompletionMock.mock.calls[0][0].systemPrompt).toContain(
 			'[SCENE CONTEXT: Currently airing S5E14 "The Marine Biologist"'
-		);
-		expect(streamCompletionMock.mock.calls[0][0].systemPrompt).toContain(
-			'George claims to be a marine biologist.'
 		);
 		expect(streamCompletionMock.mock.calls[0][0].providers).toEqual([
 			{
@@ -204,20 +242,17 @@ describe('POST /api/chat', () => {
 				monthlyBudget: 25
 			}
 		]);
-		expect(recordMessageMock).toHaveBeenCalledTimes(1);
+
 		expect(recordMessageMock).toHaveBeenCalledWith({}, '127.0.0.1');
-		expect(recordTokensMock).toHaveBeenCalledWith(
-			{},
-			{
-				provider: 'openai',
-				model: 'gpt-4o-mini',
-				inputTokens: 5,
-				outputTokens: 2
-			}
-		);
+
+		// Reservation settles once to the summed actual cost; never released.
+		expect(reconcileMock).toHaveBeenCalledTimes(1);
+		expect(reconcileMock.mock.calls[0][0]).toBe('res-1');
+		expect(reconcileMock.mock.calls[0][1]).toEqual({ provider: 'openai', usd: 0.01 });
+		expect(releaseMock).not.toHaveBeenCalled();
 	});
 
-	it('records provider usage chunks without forwarding them to the browser stream', async () => {
+	it('sums actual cost across usage chunks and reconciles once, hiding usage chunks from the browser', async () => {
 		streamCompletionMock.mockResolvedValueOnce(
 			makeTokenStream([
 				{ type: 'text', text: 'Partial answer.' },
@@ -245,6 +280,7 @@ describe('POST /api/chat', () => {
 				}
 			])
 		);
+		actualCostUsdMock.mockReturnValueOnce(0.02).mockReturnValueOnce(0.03);
 
 		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
 		const text = await response.text();
@@ -252,21 +288,26 @@ describe('POST /api/chat', () => {
 		expect(text).toContain('Partial answer.');
 		expect(text).toContain('Fresh answer.');
 		expect(text).not.toContain('"type":"usage"');
-		expect(recordTokensMock).toHaveBeenCalledTimes(2);
-		expect(recordTokensMock.mock.calls[0][1]).toMatchObject({
-			provider: 'openai',
-			model: 'gpt-4o-mini',
-			estimated: true
-		});
-		expect(recordTokensMock.mock.calls[1][1]).toMatchObject({
-			provider: 'openai',
-			model: 'gpt-4o-mini'
-		});
-		expect(recordTokensMock.mock.calls[1][1].estimated).toBeUndefined();
+
+		expect(actualCostUsdMock).toHaveBeenCalledTimes(2);
+		expect(reconcileMock).toHaveBeenCalledTimes(1);
+		expect(reconcileMock.mock.calls[0][1]).toEqual({ provider: 'openai', usd: 0.05 });
 	});
 
-	it('still forwards done chunks when token accounting fails', async () => {
-		recordTokensMock.mockRejectedValueOnce(new Error('KV write failed'));
+	it('releases the reservation when the stream produces no billable usage', async () => {
+		streamCompletionMock.mockResolvedValueOnce(
+			makeTokenStream([{ type: 'text', text: 'silence' }])
+		);
+
+		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
+		await response.text();
+
+		expect(reconcileMock).not.toHaveBeenCalled();
+		expect(releaseMock).toHaveBeenCalledWith('res-1', expect.any(Date));
+	});
+
+	it('still forwards done chunks when reconciliation fails', async () => {
+		reconcileMock.mockRejectedValueOnce(new Error('ledger write failed'));
 
 		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
 		const text = await response.text();
@@ -275,12 +316,34 @@ describe('POST /api/chat', () => {
 		expect(text).not.toContain('"type":"error"');
 	});
 
+	it('returns a graceful in-voice message and spends nothing when a ceiling is hit', async () => {
+		reserveMock.mockResolvedValueOnce({
+			ok: false,
+			ceiling: 'daily-spend',
+			reason: 'Daily spend cap reached ($3/day).'
+		});
+
+		const response = await POST(makeEvent(makeBody('Asia/Kathmandu')));
+		const text = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+		expect(text).toContain('off the air');
+		expect(text).not.toContain('"type":"error"');
+
+		expect(streamCompletionMock).not.toHaveBeenCalled();
+		expect(recordMessageMock).not.toHaveBeenCalled();
+		expect(reconcileMock).not.toHaveBeenCalled();
+		expect(releaseMock).not.toHaveBeenCalled();
+	});
+
 	it('rejects an invalid timezone before spend or LLM calls', async () => {
 		await expect(POST(makeEvent(makeBody('Not/A_Zone')))).rejects.toMatchObject({
 			status: 400
 		});
 
 		expect(canRespondMock).not.toHaveBeenCalled();
+		expect(reserveMock).not.toHaveBeenCalled();
 		expect(streamCompletionMock).not.toHaveBeenCalled();
 	});
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,17 @@ export default defineConfig(({ mode }) => {
 		],
 		resolve: {
 			alias: {
-				$lib: new URL('./src/lib', import.meta.url).pathname
+				$lib: new URL('./src/lib', import.meta.url).pathname,
+				// The `unit` project runs the reminder Worker's handler tests in Node,
+				// where `cloudflare:workers` doesn't exist. Point it at a no-op shim so
+				// the import graph loads; the DO's real behaviour is covered in the
+				// Cloudflare pool project (workers/reminder-agent/test).
+				...(isTest
+					? {
+							'cloudflare:workers': new URL('./vitest-shims/cloudflare-workers.ts', import.meta.url)
+								.pathname
+						}
+					: {})
 			}
 		},
 		define: {

--- a/vitest-shims/cloudflare-workers.ts
+++ b/vitest-shims/cloudflare-workers.ts
@@ -1,0 +1,22 @@
+/**
+ * Node-test shim for the `cloudflare:workers` runtime module.
+ *
+ * The `unit` Vitest project runs the reminder Worker's node-friendly handler
+ * tests (`workers/reminder-agent/src/index.test.ts`) in plain Node, but that
+ * entry transitively imports `SpendLedgerDO`, which extends the real
+ * `DurableObject` base from `cloudflare:workers` — a module that only exists in
+ * workerd. The DO class is never *instantiated* in those tests (they exercise
+ * pure functions), so a no-op base is enough to let the import graph load.
+ *
+ * The Durable Object's real behaviour is covered in the Cloudflare pool project
+ * (`workers/reminder-agent/test/spend-ledger.test.ts`), inside actual workerd.
+ */
+export class DurableObject<Env = unknown> {
+	protected ctx: DurableObjectState;
+	protected env: Env;
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		this.ctx = ctx;
+		this.env = env;
+	}
+}

--- a/workers/reminder-agent/src/index.ts
+++ b/workers/reminder-agent/src/index.ts
@@ -208,7 +208,11 @@ export async function handleLedger(request: Request, env: ReminderWorkerEnv): Pr
 		return json({ error: 'Invalid JSON body' }, { status: 400 });
 	}
 
-	const nowMs = typeof body.nowMs === 'number' ? body.nowMs : Date.now();
+	if (typeof body.nowMs !== 'number' || !Number.isFinite(body.nowMs)) {
+		return json({ error: 'nowMs is required' }, { status: 400 });
+	}
+
+	const nowMs = body.nowMs;
 	const path = new URL(request.url).pathname;
 	const stub = ledgerStub(env);
 

--- a/workers/reminder-agent/src/index.ts
+++ b/workers/reminder-agent/src/index.ts
@@ -1,14 +1,24 @@
 /// <reference types="@cloudflare/workers-types" />
 import { getAgentByName } from 'agents';
 import { ReminderAgent, type ReminderAgentEnv } from '../../../src/lib/server/reminder-agent';
+import {
+	SpendLedgerDO,
+	type SpendLedgerDOEnv
+} from '../../../src/lib/server/spend-ledger/do-ledger';
+import { SPEND_LEDGER_ROUTES } from '../../../src/lib/server/spend-ledger/do-adapter';
+import type { ReconcileInput, ReserveRequest } from '../../../src/lib/server/spend-ledger/types';
 
-export { ReminderAgent };
+export { ReminderAgent, SpendLedgerDO };
 
 const REMINDER_AGENT_INSTANCE = 'global';
+// One global Spend Ledger instance is the whole point — it's the serialization
+// point that makes the dollar ceilings exact (see docs/adr/0005).
+const SPEND_LEDGER_INSTANCE = 'global';
 const MAX_SUBSCRIPTIONS = 50;
 
-export interface ReminderWorkerEnv extends ReminderAgentEnv {
+export interface ReminderWorkerEnv extends ReminderAgentEnv, SpendLedgerDOEnv {
 	REMINDER_AGENT: DurableObjectNamespace<ReminderAgent>;
+	SPEND_LEDGER_DO: DurableObjectNamespace<SpendLedgerDO>;
 }
 
 export interface SubscribePayload {
@@ -169,6 +179,60 @@ export async function handleEmail(
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Spend Ledger RPC — the Pages app reaches the global ledger through these
+// endpoints over its SPEND_LEDGER service binding. Each request is forwarded to
+// the single global SpendLedgerDO instance, where the exact accounting lives.
+// ---------------------------------------------------------------------------
+
+interface LedgerCallBody {
+	req?: unknown;
+	reservationId?: unknown;
+	actual?: unknown;
+	nowMs?: unknown;
+}
+
+function ledgerStub(env: ReminderWorkerEnv) {
+	return env.SPEND_LEDGER_DO.get(env.SPEND_LEDGER_DO.idFromName(SPEND_LEDGER_INSTANCE));
+}
+
+export async function handleLedger(request: Request, env: ReminderWorkerEnv): Promise<Response> {
+	if (request.method !== 'POST') {
+		return json({ error: 'Method not allowed' }, { status: 405 });
+	}
+
+	let body: LedgerCallBody;
+	try {
+		body = (await request.json()) as LedgerCallBody;
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const nowMs = typeof body.nowMs === 'number' ? body.nowMs : Date.now();
+	const path = new URL(request.url).pathname;
+	const stub = ledgerStub(env);
+
+	try {
+		switch (path) {
+			case SPEND_LEDGER_ROUTES.reserve:
+				return json(await stub.reserve(body.req as ReserveRequest, nowMs));
+			case SPEND_LEDGER_ROUTES.reconcile:
+				await stub.reconcile(String(body.reservationId), body.actual as ReconcileInput, nowMs);
+				return json({ ok: true });
+			case SPEND_LEDGER_ROUTES.release:
+				await stub.release(String(body.reservationId), nowMs);
+				return json({ ok: true });
+			case SPEND_LEDGER_ROUTES.status:
+				return json(await stub.status(nowMs));
+			default:
+				return json({ error: 'Not found' }, { status: 404 });
+		}
+	} catch (err) {
+		console.error('[reminder-worker] spend ledger call failed', err);
+		return json({ error: 'Spend ledger failed' }, { status: 500 });
+	}
+}
+
 export default {
 	async fetch(request, env) {
 		const url = new URL(request.url);
@@ -183,6 +247,10 @@ export default {
 
 		if (url.pathname === '/confirm') {
 			return handleConfirm(request, env);
+		}
+
+		if (url.pathname.startsWith('/ledger/')) {
+			return handleLedger(request, env);
 		}
 
 		return json({ error: 'Not found' }, { status: 404 });

--- a/workers/reminder-agent/test/env.d.ts
+++ b/workers/reminder-agent/test/env.d.ts
@@ -1,12 +1,17 @@
-import type { ReminderAgent } from '../src/index';
+import type { ReminderAgent, SpendLedgerDO } from '../src/index';
 
 // Types for the bindings exposed to tests via `cloudflare:test`'s `env`.
 // Augments the pool's base ProvidedEnv with this worker's bindings.
 declare module 'cloudflare:test' {
 	interface ProvidedEnv {
 		REMINDER_AGENT: DurableObjectNamespace<ReminderAgent>;
+		SPEND_LEDGER_DO: DurableObjectNamespace<SpendLedgerDO>;
 		EMAIL_SECRET: string;
 		REMINDER_CONTENT_URL: string;
 		REMINDER_LEAD_MINUTES: string;
+		DAILY_SPEND_CAP_USD: string;
+		DAILY_REQUEST_CAP: string;
+		ANTHROPIC_MONTHLY_SPEND_CAP: string;
+		OPENAI_MONTHLY_SPEND_CAP: string;
 	}
 }

--- a/workers/reminder-agent/test/spend-ledger.test.ts
+++ b/workers/reminder-agent/test/spend-ledger.test.ts
@@ -1,0 +1,75 @@
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import type { LedgerState } from '../../../src/lib/server/spend-ledger/ledger-core';
+
+// Exercises the SpendLedgerDO inside the real Workers runtime, so its storage
+// persistence and RPC surface behave as they will in production. Each test gets
+// its own named instance; isolatedStorage in vitest.config keeps them independent.
+type Stub = ReturnType<typeof env.SPEND_LEDGER_DO.getByName>;
+
+function ledger(instance: string): Stub {
+	return env.SPEND_LEDGER_DO.getByName(instance);
+}
+
+const NOW = new Date('2026-01-04T10:00:00Z').getTime();
+const CANDIDATE = { provider: 'openai' as const, model: 'gpt-4o-mini' };
+const SMALL_REQUEST = { candidates: [CANDIDATE], maxInputTokens: 100, maxOutputTokens: 300 };
+
+describe('SpendLedgerDO', () => {
+	it('admits a request and persists the count + reservation to storage', async () => {
+		const stub = ledger('admit');
+		const result = await stub.reserve(SMALL_REQUEST, NOW);
+		expect(result.ok).toBe(true);
+
+		const status = await stub.status(NOW);
+		expect(status.daily.requests).toBe(1);
+		expect(status.daily.reservedUsd).toBeGreaterThan(0);
+		expect(status.activeReservations).toBe(1);
+
+		// Prove it's persisted, not just held in the live instance's memory.
+		const stored = await runInDurableObject(stub, (_instance, state) =>
+			state.storage.get<LedgerState>('ledger')
+		);
+		expect(Object.keys(stored!.reservations)).toHaveLength(1);
+		expect(stored!.committedDaily[status.day].requests).toBe(1);
+	});
+
+	it('reconciles a reservation to actual spend and clears the hold', async () => {
+		const stub = ledger('reconcile');
+		const result = await stub.reserve(SMALL_REQUEST, NOW);
+		if (!result.ok) throw new Error('expected reserve to succeed');
+
+		await stub.reconcile(result.reservationId, { provider: 'openai', usd: 0.01 }, NOW);
+
+		const status = await stub.status(NOW);
+		expect(status.activeReservations).toBe(0);
+		expect(status.daily.reservedUsd).toBe(0);
+		expect(status.daily.spentUsd).toBeCloseTo(0.01);
+		expect(status.monthly.openai.spentUsd).toBeCloseTo(0.01);
+	});
+
+	it('releases a reservation without committing spend', async () => {
+		const stub = ledger('release');
+		const result = await stub.reserve(SMALL_REQUEST, NOW);
+		if (!result.ok) throw new Error('expected reserve to succeed');
+
+		await stub.release(result.reservationId, NOW);
+
+		const status = await stub.status(NOW);
+		expect(status.activeReservations).toBe(0);
+		expect(status.daily.reservedUsd).toBe(0);
+		expect(status.daily.spentUsd).toBe(0);
+		// The request itself still counted — only the dollar hold was refunded.
+		expect(status.daily.requests).toBe(1);
+	});
+
+	it('refuses when a single request would blow the daily spend cap', async () => {
+		const stub = ledger('deny');
+		const result = await stub.reserve(
+			{ candidates: [CANDIDATE], maxInputTokens: 1_000_000_000, maxOutputTokens: 300 },
+			NOW
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.ceiling).toBe('daily-spend');
+	});
+});

--- a/workers/reminder-agent/test/spend-ledger.test.ts
+++ b/workers/reminder-agent/test/spend-ledger.test.ts
@@ -70,6 +70,6 @@ describe('SpendLedgerDO', () => {
 			NOW
 		);
 		expect(result.ok).toBe(false);
-		if (!result.ok) expect(result.ceiling).toBe('daily-spend');
+		if (!result.ok) expect(result.reason).toBe('daily-spend');
 	});
 });

--- a/workers/reminder-agent/wrangler.jsonc
+++ b/workers/reminder-agent/wrangler.jsonc
@@ -6,9 +6,17 @@
 	"compatibility_date": "2026-06-01",
 	"compatibility_flags": ["nodejs_compat"],
 	"durable_objects": {
-		"bindings": [{ "name": "REMINDER_AGENT", "class_name": "ReminderAgent" }]
+		"bindings": [
+			{ "name": "REMINDER_AGENT", "class_name": "ReminderAgent" },
+			// The single global Spend Ledger. One instance ("global") serializes
+			// every chat request so the dollar ceilings are exact (docs/adr/0005).
+			{ "name": "SPEND_LEDGER_DO", "class_name": "SpendLedgerDO" }
+		]
 	},
-	"migrations": [{ "tag": "v1", "new_sqlite_classes": ["ReminderAgent"] }],
+	"migrations": [
+		{ "tag": "v1", "new_sqlite_classes": ["ReminderAgent"] },
+		{ "tag": "v2", "new_sqlite_classes": ["SpendLedgerDO"] }
+	],
 	"send_email": [{ "name": "SEND_EMAIL" }],
 	"observability": { "enabled": true },
 	// EMAIL_SECRET is a secret, not a var — set it with:
@@ -18,6 +26,13 @@
 		"REMINDER_CONTENT_URL": "https://bli.net/api/data",
 		"REMINDER_FROM_EMAIL": "reminders@bli.net",
 		"REMINDER_FROM_NAME": "Terminal Bli Net",
-		"REMINDER_LEAD_MINUTES": "30"
+		"REMINDER_LEAD_MINUTES": "30",
+		// Spend Ledger ceilings (docs/prd/cost-abuse-hardening.md). Keep the
+		// monthly caps in step with the Pages app's own vars — both halves of the
+		// ledger read their dollar limits from these.
+		"DAILY_SPEND_CAP_USD": "3",
+		"DAILY_REQUEST_CAP": "5000",
+		"ANTHROPIC_MONTHLY_SPEND_CAP": "25",
+		"OPENAI_MONTHLY_SPEND_CAP": "25"
 	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,7 +33,7 @@
 	// Activate both together — a live site key without the server secret would
 	// re-challenge every message. Until then the gate fails open (no challenge).
 	"vars": {
-		// "PUBLIC_TURNSTILE_SITE_KEY": "0x4AAAAAADjFy1qjbUZS5DgP",
+		"PUBLIC_TURNSTILE_SITE_KEY": "0x4AAAAAADjFy1qjbUZS5DgP",
 		"LLM_PROVIDER_ORDER": "openai,claude",
 		"OPENAI_MODEL": "gpt-4o-mini",
 		"ANTHROPIC_MODEL": "claude-haiku-4-5-20251001",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,7 +26,13 @@
 	// once its monthly spend reaches its provider-specific cap.
 	// Claude options:  claude-haiku-4-5-20251001 (default), claude-sonnet-4-6
 	// OpenAI options:  gpt-4o-mini (default), gpt-4o, gpt-4.1-mini, gpt-4.1
+	// Turnstile Gate (proof-of-human in front of chat spend). To ACTIVATE:
+	//   1. uncomment PUBLIC_TURNSTILE_SITE_KEY below (the public widget key), and
+	//   2. set the secret:  wrangler secret put TURNSTILE_SECRET
+	// Activate both together — a live site key without the server secret would
+	// re-challenge every message. Until then the gate fails open (no challenge).
 	"vars": {
+		// "PUBLIC_TURNSTILE_SITE_KEY": "0x4AAAAAADjFy1qjbUZS5DgP",
 		"LLM_PROVIDER_ORDER": "openai,claude",
 		"OPENAI_MODEL": "gpt-4o-mini",
 		"ANTHROPIC_MODEL": "claude-haiku-4-5-20251001",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,16 @@
 	// "kv_namespaces": [{ "binding": "KV", "id": "YOUR_KV_NAMESPACE_ID" }],
 	// ReminderAgent runs as a separate Worker because Cloudflare Pages cannot
 	// export Durable Object classes from the Pages adapter output.
-	"services": [{ "binding": "REMINDER_SERVICE", "service": "terminal-reminder-agent" }],
+	// REMINDER_SERVICE → the reminder Worker's subscribe/confirm endpoints.
+	// SPEND_LEDGER → the same Worker's /ledger/* endpoints, which front the single
+	// global SpendLedgerDO that enforces every dollar ceiling exactly (docs/adr/0005).
+	"services": [
+		{ "binding": "REMINDER_SERVICE", "service": "terminal-reminder-agent" },
+		{ "binding": "SPEND_LEDGER", "service": "terminal-reminder-agent" }
+	],
+	// Spend Ledger ceilings — keep ANTHROPIC/OPENAI monthly caps in step with the
+	// reminder Worker's vars (the DO reads its limits from the Worker's env, not these).
+	// DAILY_SPEND_CAP_USD / DAILY_REQUEST_CAP default to $3 / 5000 when unset.
 	// Secrets (set via `wrangler secret put`):
 	// ANTHROPIC_API_KEY and/or OPENAI_API_KEY.
 	//

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,7 +28,8 @@
 	// OpenAI options:  gpt-4o-mini (default), gpt-4o, gpt-4.1-mini, gpt-4.1
 	// Turnstile Gate (proof-of-human in front of chat spend). To ACTIVATE:
 	//   1. uncomment PUBLIC_TURNSTILE_SITE_KEY below (the public widget key), and
-	//   2. set the secret:  wrangler secret put TURNSTILE_SECRET
+	//   2. set the secret (this is a Pages project, not a Worker):
+	//        wrangler pages secret put TURNSTILE_SECRET
 	// Activate both together — a live site key without the server secret would
 	// re-challenge every message. Until then the gate fails open (no challenge).
 	"vars": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,6 +34,7 @@
 	// re-challenge every message. Until then the gate fails open (no challenge).
 	"vars": {
 		"PUBLIC_TURNSTILE_SITE_KEY": "0x4AAAAAADjFy1qjbUZS5DgP",
+		"SPEND_LEDGER_REQUIRED": "true",
 		"LLM_PROVIDER_ORDER": "openai,claude",
 		"OPENAI_MODEL": "gpt-4o-mini",
 		"ANTHROPIC_MODEL": "claude-haiku-4-5-20251001",


### PR DESCRIPTION
Closes #69.

## What
Exact LLM-spend enforcement for the public chat endpoint, behind a Cloudflare Turnstile proof-of-human gate.

The deployed endpoint previously tracked spend with non-atomic KV counters, recorded *after* streaming and failing **open** when KV was missing — scriptable for cost abuse well past the $25/provider caps. This makes every configured dollar ceiling **exact** and unbypassable, and puts a human check in front of the spend path.

## How
- **Spend Ledger (port + adapters).** Reserve worst-case cost before streaming, reconcile to actual cost after — concurrent requests can never overshoot a ceiling. (`docs/adr/0005`, `docs/prd/cost-abuse-hardening.md`.)
- **Exact via one global Durable Object** in the reminder Worker, reached over a `SPEND_LEDGER` service binding. In-memory adapter for dev/tests.
- **Fail closed in production** — an unreachable spend authority denies, never permits. Dev fails open (in-memory).
- **Turnstile gate** — verify a token on the first message of a session, then issue a 30-min signed session token so later messages aren't re-challenged. Config-activated; fails open when unconfigured.
- **Graceful in-voice "off the air" messages** on a ceiling refusal (never a raw error); structured observability events for every ledger decision.
- **Retired** the superseded KV monthly-spend logic — the per-IP rate throttle and model pricing table are unchanged.

## Tests
882 unit tests green: the no-overshoot concurrency invariant, DO persistence in real workerd, fail-closed denial, Turnstile gate + session-token logic, and route wiring. `pnpm check` and eslint clean.

## Activation (already applied on Pages)
- `TURNSTILE_SECRET` set on the Pages project (production).
- `PUBLIC_TURNSTILE_SITE_KEY` enabled in `wrangler.jsonc`.
- The gate goes live on the next production deploy. To exercise it on a preview deploy, also set the preview secret (`wrangler pages secret put TURNSTILE_SECRET --environment preview`).
