### PR TITLE
Move deploy from Cloudflare Pages to Workers

### DIFF
--- a/.changeset/workers-migration.md
+++ b/.changeset/workers-migration.md
@@ -1,0 +1,14 @@
+---
+type: patch
+category: Upgrade Notes
+---
+
+Move the deploy from Cloudflare Pages to Cloudflare Workers
+
+- The site now ships as a Worker with static assets (`main` + `assets` in `wrangler.jsonc`) instead of a Pages project. This is the ADR 0008 prerequisite: a Workers deploy can export Durable Object classes and run cron triggers, which upcoming apps need.
+- Self-hosters redeploying from this version:
+  - Deploy with `wrangler deploy` (or `pnpm deploy-cloudflare`); `wrangler pages deploy` no longer applies.
+  - Bind KV in `wrangler.jsonc` — dashboard-only bindings are dropped by `wrangler deploy`. Create one with `wrangler kv namespace create KV` and put its id in `kv_namespaces`.
+  - Re-set secrets on the Worker with `wrangler secret put` (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `TURNSTILE_SECRET` as applicable); Pages-scoped secrets do not carry over.
+  - Move any custom domain from the Pages project to the Worker, then delete the Pages project.
+  - Branch previews now come from Workers preview URLs (`preview_urls` is enabled) rather than `*.pages.dev` branch aliases.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A retro desktop you visit in a browser. It looks like what the inside of a compu
 
 Open TV Guide to see what's on. Channels run shows on a schedule like mid-80s cable. If a show is airing, you can chat with the characters — they know what episode they're in.
 
-Built with SvelteKit, deployed on Cloudflare Pages.
+Built with SvelteKit, deployed on Cloudflare Workers.
 
 ## Visit it
 
@@ -113,7 +113,7 @@ Terminal HD stores its filesystem manifest and preferences in localStorage, with
 
 ## Deploy
 
-Deployed to Cloudflare Pages. Secrets (`ANTHROPIC_API_KEY`, optionally `OPENAI_API_KEY`) are set via the Pages dashboard or `wrangler secret put`.
+Deployed to Cloudflare Workers (`pnpm deploy-cloudflare`, or Workers Builds on push). Secrets (`ANTHROPIC_API_KEY`, optionally `OPENAI_API_KEY`, `TURNSTILE_SECRET`) are set via `wrangler secret put`. The KV namespace is bound in `wrangler.jsonc` — self-hosters swap in their own id from `wrangler kv namespace create KV`.
 
 ## Release notes
 

--- a/docs/changeset-architecture.html
+++ b/docs/changeset-architecture.html
@@ -1354,7 +1354,7 @@ git push origin main --follow-tags</code></pre>
 
 					<h3>Deployment alignment</h3>
 					<p>
-						If Cloudflare Pages deploys automatically from <code>main</code>, the release tag points
+						If Cloudflare Workers Builds deploys automatically from <code>main</code>, the release tag points
 						at the release commit only after the production deployment is verified. If production
 						deploys move into GitHub Actions, release creation waits for the build, tests, and
 						deploy job.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"changeset:version": "node scripts/changesets.js version",
 		"format": "prettier --write .",
 		"prepare": "husky",
-		"deploy-cloudflare": "pnpm build && wrangler pages deploy .svelte-kit/cloudflare",
+		"deploy-cloudflare": "pnpm build && wrangler deploy",
 		"deploy-cloudflare:dry": "pnpm build"
 	},
 	"dependencies": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,23 +5,10 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
 	preprocess: vitePreprocess(),
 	kit: {
-		adapter: adapter({
-			routes: {
-				include: ['/*'],
-				exclude: [
-					'<build>',
-					'<prerendered>',
-					'/bots/*',
-					'/themes/*',
-					'/favicon.*',
-					'/*.png',
-					'/*.ico',
-					'/*.xml',
-					'/*.svg',
-					'/site.webmanifest'
-				]
-			}
-		})
+		// No `routes` option: that only shapes the Pages-era _routes.json. On a
+		// Workers deploy, static assets are served before the Worker runs, so the
+		// old exclude list (/bots/*, /themes/*, favicons) is covered by default.
+		adapter: adapter()
 	}
 };
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,14 +1,23 @@
 {
 	"name": "terminal-bli-net",
+	"main": ".svelte-kit/cloudflare/_worker.js",
 	"compatibility_date": "2026-05-24",
 	"compatibility_flags": ["nodejs_compat"],
-	"pages_build_output_dir": ".svelte-kit/cloudflare",
-	// KV binding "KV" must be configured in the Cloudflare Pages dashboard,
-	// or uncomment below with your own namespace ID from `wrangler kv namespace create KV`.
-	// Local dev (miniflare) creates an in-memory KV automatically.
-	// "kv_namespaces": [{ "binding": "KV", "id": "YOUR_KV_NAMESPACE_ID" }],
-	// ReminderAgent runs as a separate Worker because Cloudflare Pages cannot
-	// export Durable Object classes from the Pages adapter output.
+	"assets": {
+		"binding": "ASSETS",
+		"directory": ".svelte-kit/cloudflare"
+	},
+	// Preview URLs for non-production versions (the Workers stand-in for Pages
+	// branch previews). Enable non-production branch builds in Workers Builds too.
+	"preview_urls": true,
+	// On a Workers deploy this file is the source of truth for bindings —
+	// `wrangler deploy` drops anything configured only in the dashboard, so the
+	// KV binding must live here. Self-hosters: replace the id with your own from
+	// `wrangler kv namespace create KV`. Local dev (miniflare) creates an
+	// in-memory KV automatically.
+	"kv_namespaces": [{ "binding": "KV", "id": "f80e014c3a4f47d9895294d3aefdf516" }],
+	// ReminderAgent stays a separate Worker for now (docs/adr/0008 keeps the
+	// fold-in out of scope).
 	// REMINDER_SERVICE → the reminder Worker's subscribe/confirm endpoints.
 	// SPEND_LEDGER → the same Worker's /ledger/* endpoints, which front the single
 	// global SpendLedgerDO that enforces every dollar ceiling exactly (docs/adr/0005).
@@ -28,8 +37,7 @@
 	// OpenAI options:  gpt-4o-mini (default), gpt-4o, gpt-4.1-mini, gpt-4.1
 	// Turnstile Gate (proof-of-human in front of chat spend). To ACTIVATE:
 	//   1. uncomment PUBLIC_TURNSTILE_SITE_KEY below (the public widget key), and
-	//   2. set the secret (this is a Pages project, not a Worker):
-	//        wrangler pages secret put TURNSTILE_SECRET
+	//   2. set the secret: wrangler secret put TURNSTILE_SECRET
 	// Activate both together — a live site key without the server secret would
 	// re-challenge every message. Until then the gate fails open (no challenge).
 	"vars": {


### PR DESCRIPTION
The ADR 0008 prerequisite: ship the site as a Worker with static assets so future apps can export Durable Object classes and run cron triggers from the main deploy.

## What changed

- `wrangler.jsonc`: `main` + `assets` replace `pages_build_output_dir`; KV namespace bound in-file (Workers drops dashboard-only bindings on deploy); `preview_urls` enabled
- `svelte.config.js`: removed the Pages-only `routes` option — Workers serves static assets before invoking the Worker by default
- `package.json`: `deploy-cloudflare` now runs `wrangler deploy`
- README + changeset-architecture doc updated for the Workers deploy
- Upgrade Notes changeset with redeploy steps for self-hosters

## Verified locally

- `pnpm build` clean
- `wrangler deploy --dry-run` resolves all bindings (KV, REMINDER_SERVICE, SPEND_LEDGER, ASSETS, vars)
- `wrangler dev` serves the site; `_headers` immutable cache rules apply under Workers

## Cutover plan (at merge)

1. Create the Worker via Workers Builds (this repo, `pnpm build`, `wrangler deploy`), enable non-prod branch builds
2. `wrangler secret put` on the Worker: `TURNSTILE_SECRET` + API keys
3. Verify on workers.dev: `/api/chat`, `/api/data`, `/api/subscribe`, `/api/dev`, Turnstile gate, KV, reminder bindings
4. Move `terminal.bli.net` to the Worker
5. Disable Pages auto-deploy; delete the Pages project once stable

Note: the open-PR window will show a red Pages preview build (Pages can't parse the Workers config) — expected, production untouched.